### PR TITLE
fix(OrangePi): Add correct IMU chip

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
@@ -33,7 +33,7 @@ source_devices:
       phys_path: usb-0000:c3:00.3-5/input1
   - group: imu
     iio:
-      name: i2c-BMI0160:00
+      name: i2c-BMI0260:00
 
 # The target input device(s) that the virtual device profile can use
 target_devices:


### PR DESCRIPTION
The OrangePi Neo uses the BMI260 motion sensor
https://www.bosch-sensortec.com/products/motion-sensors/imus/bmi260/