### PR TITLE
fix(Suspend): Add restart service for InputPlumber after resume.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ assets = [
   { source = "target/release/inputplumber", dest = "/usr/bin/inputplumber", mode = "755" },
   { source = "rootfs/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf", dest = "/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf", mode = "644" },
   { source = "rootfs/usr/lib/systemd/system/inputplumber.service", dest = "/usr/lib/systemd/system/inputplumber.service", mode = "644" },
+  { source = "rootfs/usr/lib/systemd/system/inputplumber-resume.service", dest = "/usr/lib/systemd/system/inputplumber-resume.service", mode = "644" },
   { source = "rootfs/usr/share/inputplumber/devices/*.yaml", dest = "/usr/share/inputplumber/devices/", mode = "644" },
   { source = "rootfs/usr/share/inputplumber/schema/*.json", dest = "/usr/share/inputplumber/schema/", mode = "644" },
   { source = "rootfs/usr/share/inputplumber/capability_maps/*.yaml", dest = "/usr/share/inputplumber/capability_maps/", mode = "644" },

--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,8 @@ install: build ## Install inputplumber to the given prefix (default: PREFIX=/usr
 		$(PREFIX)/bin/$(NAME)
 	install -D -m 644 rootfs/usr/share/dbus-1/system.d/$(DBUS_NAME).conf \
 		$(PREFIX)/share/dbus-1/system.d/$(DBUS_NAME).conf
-	install -D -m 644 rootfs/usr/lib/systemd/system/$(NAME).service \
-		$(PREFIX)/lib/systemd/system/$(NAME).service
+	install -D -m 644 -t $(PREFIX)/usr/lib/systemd/system/ \
+		rootfs/lib/systemd/system/*
 	install -D -m 644 rootfs/usr/lib/udev/hwdb.d/59-inputplumber.hwdb \
 		$(PREFIX)/lib/udev/hwdb.d/59-inputplumber.hwdb
 	install -D -m 644 -t $(PREFIX)/share/$(NAME)/devices/ \
@@ -67,6 +67,7 @@ uninstall: ## Uninstall inputplumber
 	rm $(PREFIX)/bin/$(NAME)
 	rm $(PREFIX)/share/dbus-1/system.d/$(DBUS_NAME).conf
 	rm $(PREFIX)/lib/systemd/system/$(NAME).service
+	rm $(PREFIX)/lib/systemd/system/$(NAME)-resume.service
 	rm $(PREFIX)/lib/udev/hwdb.d/59-inputplumber.hwdb
 	rm -rf $(PREFIX)/share/$(NAME)/devices/
 	rm -rf $(PREFIX)/share/$(NAME)/schema/

--- a/rootfs/usr/lib/systemd/system/inputplumber-resume.service
+++ b/rootfs/usr/lib/systemd/system/inputplumber-resume.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Restart InputPlumber after resume
+After=suspend.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/systemctl --no-block restart inputplumber.service
+
+[Install]
+WantedBy=suspend.target


### PR DESCRIPTION
Wacky way of working around a suspend issue. Partially solves #77 but should be revisited for a proper solution.