### PR TITLE
fix(CompositeDevice): use async task to set target devices on profile load to prevent crash

### DIFF
--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -1851,12 +1851,12 @@ impl CompositeDevice {
 
         // Set the target devices to use if it is defined in the profile
         if let Some(target_devices) = profile.target_devices {
-            if let Err(e) = self
-                .tx
-                .blocking_send(Command::SetTargetDevices(target_devices))
-            {
-                log::error!("Failed to send set target devices: {e:?}");
-            }
+            let tx = self.tx.clone();
+            tokio::task::spawn(async move {
+                if let Err(e) = tx.send(Command::SetTargetDevices(target_devices)).await {
+                    log::error!("Failed to send set target devices: {e:?}");
+                }
+            });
         }
 
         log::debug!("Successfully loaded device profile: {}", profile.name);


### PR DESCRIPTION
This fixes a crash when dynamically loading an input profile at runtime. We previously used `send_blocking`, which will crash if called from an async context (which is what we do when we receive a `LoadProfile` from DBus):

![image](https://github.com/ShadowBlip/InputPlumber/assets/376460/36b117f9-fb3f-4320-acb8-e26d180efb1b)

To resolve this, we now spawn an async task to send the `SetTargetDevices` command to the Composite Device.