### PR TITLE
fix(Controller): add device profile for Switch Pro controller

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-switch_pro.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-switch_pro.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=../schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Nintendo Co., Ltd. Pro Controller
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: gamepad
+    evdev:
+      name: Nintendo Co., Ltd. Pro Controller
+  #- group: imu
+  #  evdev:
+  #    name: Nintendo Co., Ltd. Pro Controller (IMU)
+
+# The target input device(s) that the virtual device profile can use
+target_devices:
+  - gamepad
+  - mouse
+  - keyboard


### PR DESCRIPTION
The Switch Pro controller does not create a `js*` handler, so the normal Gamepad catch-all profile does not pick up the controller. This adds a basic profile to allow managing a Switch Pro controller. In the future, we'll need to figure out a way to support the IMU half of the device.