### PR TITLE
fix(DBus): seperate DBus interfaces into their own module

### DIFF
--- a/src/dbus/interface/composite_device.rs
+++ b/src/dbus/interface/composite_device.rs
@@ -1,0 +1,399 @@
+use std::{collections::HashSet, str::FromStr};
+
+use tokio::sync::mpsc;
+use zbus::{
+    fdo,
+    zvariant::{self, Value},
+};
+use zbus_macros::interface;
+
+use crate::input::{
+    capability::{Capability, Gamepad, Mouse},
+    composite_device::{Command, InterceptMode},
+    event::{native::NativeEvent, value::InputValue},
+};
+
+/// The [CompositeDeviceInterface] provides a DBus interface that can be exposed for managing
+/// a [CompositeDevice]. It works by sending command messages to a channel that the
+/// [CompositeDevice] is listening on.
+pub struct CompositeDeviceInterface {
+    tx: mpsc::Sender<Command>,
+}
+
+impl CompositeDeviceInterface {
+    pub fn new(tx: mpsc::Sender<Command>) -> CompositeDeviceInterface {
+        CompositeDeviceInterface { tx }
+    }
+}
+
+#[interface(name = "org.shadowblip.Input.CompositeDevice")]
+impl CompositeDeviceInterface {
+    /// Name of the composite device
+    #[zbus(property)]
+    async fn name(&self) -> fdo::Result<String> {
+        let (sender, mut receiver) = mpsc::channel::<String>(1);
+        self.tx
+            .send(Command::GetName(sender))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        let Some(name) = receiver.recv().await else {
+            return Ok("".to_string());
+        };
+
+        Ok(name)
+    }
+
+    /// Name of the currently loaded profile
+    #[zbus(property)]
+    async fn profile_name(&self) -> fdo::Result<String> {
+        let (sender, mut receiver) = mpsc::channel::<String>(1);
+        self.tx
+            .send(Command::GetProfileName(sender))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        let Some(profile_name) = receiver.recv().await else {
+            return Ok("".to_string());
+        };
+
+        Ok(profile_name)
+    }
+
+    /// Stop the composite device and all target devices
+    async fn stop(&self) -> fdo::Result<()> {
+        self.tx
+            .send(Command::Stop)
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        Ok(())
+    }
+
+    /// Load the device profile from the given path
+    async fn load_profile_path(&self, path: String) -> fdo::Result<()> {
+        let (sender, mut receiver) = mpsc::channel::<Result<(), String>>(1);
+        self.tx
+            .send(Command::LoadProfilePath(path, sender))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+
+        let Some(result) = receiver.recv().await else {
+            return Err(fdo::Error::Failed(
+                "No response from CompositeDevice".to_string(),
+            ));
+        };
+
+        if let Err(e) = result {
+            return Err(fdo::Error::Failed(format!(
+                "Failed to load profile: {:?}",
+                e
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Set the target input device types the composite device should emulate,
+    /// such as ["gamepad", "mouse", "keyboard"]. This method will stop all
+    /// current virtual devices for the composite device and create and attach
+    /// new target devices.
+    async fn set_target_devices(&self, target_device_types: Vec<String>) -> fdo::Result<()> {
+        self.tx
+            .send(Command::SetTargetDevices(target_device_types))
+            .await
+            .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+        Ok(())
+    }
+
+    /// Directly write to the composite device's target devices with the given event
+    fn send_event(&self, event: String, value: zvariant::Value) -> fdo::Result<()> {
+        let cap = Capability::from_str(event.as_str()).map_err(|_| {
+            fdo::Error::Failed(format!(
+                "Failed to parse event string {event} into capability."
+            ))
+        })?;
+
+        let val = match value {
+            zvariant::Value::Bool(v) => InputValue::Bool(v),
+            zvariant::Value::F64(v) => InputValue::Float(v),
+            zvariant::Value::Array(v) => match v.len() {
+                2 => {
+                    let x_val = v.first().unwrap();
+                    let y_val: &Value = v.get(1).unwrap().unwrap();
+                    let x = f64::try_from(x_val).map_err(|_| {
+                        fdo::Error::Failed("Failed to parse x value into float.".to_string())
+                    })?;
+                    let y = f64::try_from(y_val).map_err(|_| {
+                        fdo::Error::Failed("Failed to parse y value into float.".to_string())
+                    })?;
+                    InputValue::Vector2 {
+                        x: Some(x),
+                        y: Some(y),
+                    }
+                }
+                3 => {
+                    let x_val = v.first().unwrap();
+                    let y_val: &Value = v.get(1).unwrap().unwrap();
+                    let z_val: &Value = v.get(2).unwrap().unwrap();
+                    let x = f64::try_from(x_val).map_err(|_| {
+                        fdo::Error::Failed("Failed to parse x value into float.".to_string())
+                    })?;
+                    let y = f64::try_from(y_val).map_err(|_| {
+                        fdo::Error::Failed("Failed to parse y value into float.".to_string())
+                    })?;
+                    let z = f64::try_from(z_val).map_err(|_| {
+                        fdo::Error::Failed("Failed to parse z value into float.".to_string())
+                    })?;
+                    InputValue::Vector3 {
+                        x: Some(x),
+                        y: Some(y),
+                        z: Some(z),
+                    }
+                }
+                _ => InputValue::None,
+            },
+            _ => InputValue::None,
+        };
+
+        let event = NativeEvent::new(cap, val);
+
+        self.tx
+            .blocking_send(Command::WriteSendEvent(event))
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Directly write to the composite device's target devices with the given button event list
+    async fn send_button_chord(&self, mut events: Vec<String>) -> fdo::Result<()> {
+        // Store built native events to send in a command to the CompositeDevice
+        let mut chord: Vec<NativeEvent> = Vec::new();
+
+        // Iterate in the given order for press events
+        for event_str in events.clone() {
+            // Validate the event is valid and create a NativeEvent
+            if event_str.contains("Button") || event_str.starts_with("Keyboard") {
+                let cap = Capability::from_str(event_str.as_str()).map_err(|_| {
+                    fdo::Error::Failed(format!(
+                        "Failed to parse event string {event_str} into capability."
+                    ))
+                })?;
+                let val = InputValue::Bool(true);
+                let event = NativeEvent::new(cap, val);
+                chord.push(event);
+            } else {
+                return Err(fdo::Error::Failed(format!(
+                    "The event '{event_str}' is not a Button capability."
+                )));
+            };
+        }
+        // Reverse the order for up events
+        events = events.into_iter().rev().collect();
+        for event_str in events {
+            // Create a NativeEvent
+            let cap = Capability::from_str(event_str.as_str()).map_err(|_| {
+                fdo::Error::Failed(format!(
+                    "Failed to parse event string {event_str} into capability."
+                ))
+            })?;
+            let val = InputValue::Bool(false);
+            let event = NativeEvent::new(cap, val);
+            chord.push(event);
+        }
+
+        self.tx
+            .send(Command::WriteChordEvent(chord))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn set_intercept_activation(
+        &self,
+        activation_events: Vec<String>,
+        target_event: String,
+    ) -> fdo::Result<()> {
+        let mut activation_caps: Vec<Capability> = Vec::new();
+
+        // Iterate in the given order for press events
+        for event_str in activation_events {
+            // Validate the event is valid and create a NativeEvent
+            if event_str.contains("Button") || event_str.starts_with("Keyboard") {
+                let cap = Capability::from_str(event_str.as_str()).map_err(|_| {
+                    fdo::Error::Failed(format!(
+                        "Failed to parse event string {event_str} into capability."
+                    ))
+                })?;
+                activation_caps.push(cap);
+            } else {
+                return Err(fdo::Error::Failed(format!(
+                    "The event '{event_str}' is not a Button capability."
+                )));
+            };
+        }
+        let mut target_cap: Capability = Capability::None;
+        if target_event.contains("Button") || target_event.starts_with("Keyboard") {
+            let cap = Capability::from_str(target_event.as_str()).map_err(|_| {
+                fdo::Error::Failed(format!(
+                    "Failed to parse event string {target_event} into capability."
+                ))
+            })?;
+            target_cap = cap
+        }
+
+        self.tx
+            .send(Command::SetInterceptActivation(activation_caps, target_cap))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// List of capabilities that all source devices implement
+    #[zbus(property)]
+    async fn capabilities(&self) -> fdo::Result<Vec<String>> {
+        let (sender, mut receiver) = mpsc::channel::<HashSet<Capability>>(1);
+        self.tx
+            .send(Command::GetCapabilities(sender))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        let Some(capabilities) = receiver.recv().await else {
+            return Ok(Vec::new());
+        };
+
+        let mut capability_strings = Vec::new();
+        for cap in capabilities {
+            let str = match cap {
+                Capability::Gamepad(gamepad) => match gamepad {
+                    Gamepad::Button(button) => format!("Gamepad:Button:{}", button),
+                    Gamepad::Axis(axis) => format!("Gamepad:Axis:{}", axis),
+                    Gamepad::Trigger(trigger) => format!("Gamepad:Trigger:{}", trigger),
+                    Gamepad::Accelerometer => "Gamepad:Accelerometer".to_string(),
+                    Gamepad::Gyro => "Gamepad:Gyro".to_string(),
+                },
+                Capability::Mouse(mouse) => match mouse {
+                    Mouse::Motion => "Mouse:Motion".to_string(),
+                    Mouse::Button(button) => format!("Mouse:Button:{}", button),
+                },
+                Capability::Keyboard(key) => format!("Keyboard:{}", key),
+                _ => cap.to_string(),
+            };
+            capability_strings.push(str);
+        }
+
+        Ok(capability_strings)
+    }
+
+    /// List of capabilities that all target devices implement
+    #[zbus(property)]
+    async fn target_capabilities(&self) -> fdo::Result<Vec<String>> {
+        let (sender, mut receiver) = mpsc::channel::<HashSet<Capability>>(1);
+        self.tx
+            .send(Command::GetTargetCapabilities(sender))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        let Some(capabilities) = receiver.recv().await else {
+            return Ok(Vec::new());
+        };
+
+        let mut capability_strings = Vec::new();
+        for cap in capabilities {
+            let str = match cap {
+                Capability::Gamepad(gamepad) => match gamepad {
+                    Gamepad::Button(button) => format!("Gamepad:Button:{}", button),
+                    Gamepad::Axis(axis) => format!("Gamepad:Axis:{}", axis),
+                    Gamepad::Trigger(trigger) => format!("Gamepad:Trigger:{}", trigger),
+                    Gamepad::Accelerometer => "Gamepad:Accelerometer".to_string(),
+                    Gamepad::Gyro => "Gamepad:Gyro".to_string(),
+                },
+                Capability::Mouse(mouse) => match mouse {
+                    Mouse::Motion => "Mouse:Motion".to_string(),
+                    Mouse::Button(button) => format!("Mouse:Button:{}", button),
+                },
+                Capability::Keyboard(key) => format!("Keyboard:{}", key),
+                _ => cap.to_string(),
+            };
+            capability_strings.push(str);
+        }
+
+        Ok(capability_strings)
+    }
+
+    /// List of source devices that this composite device is processing inputs for
+    #[zbus(property)]
+    async fn source_device_paths(&self) -> fdo::Result<Vec<String>> {
+        let (sender, mut receiver) = mpsc::channel::<Vec<String>>(1);
+        self.tx
+            .send(Command::GetSourceDevicePaths(sender))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        let Some(paths) = receiver.recv().await else {
+            return Ok(Vec::new());
+        };
+
+        Ok(paths)
+    }
+
+    /// The intercept mode of the composite device.
+    #[zbus(property)]
+    async fn intercept_mode(&self) -> fdo::Result<u32> {
+        let (sender, mut receiver) = mpsc::channel::<InterceptMode>(1);
+        self.tx
+            .send(Command::GetInterceptMode(sender))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        let Some(mode) = receiver.recv().await else {
+            return Ok(0);
+        };
+
+        match mode {
+            InterceptMode::None => Ok(0),
+            InterceptMode::Pass => Ok(1),
+            InterceptMode::Always => Ok(2),
+        }
+    }
+
+    #[zbus(property)]
+    async fn set_intercept_mode(&self, mode: u32) -> zbus::Result<()> {
+        let mode = match mode {
+            0 => InterceptMode::None,
+            1 => InterceptMode::Pass,
+            2 => InterceptMode::Always,
+            _ => InterceptMode::None,
+        };
+        self.tx
+            .send(Command::SetInterceptMode(mode))
+            .await
+            .map_err(|err| zbus::Error::Failure(err.to_string()))?;
+        Ok(())
+    }
+
+    /// Target devices that this [CompositeDevice] is managing
+    #[zbus(property)]
+    async fn target_devices(&self) -> fdo::Result<Vec<String>> {
+        let (sender, mut receiver) = mpsc::channel::<Vec<String>>(1);
+        self.tx
+            .send(Command::GetTargetDevicePaths(sender))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        let Some(paths) = receiver.recv().await else {
+            return Ok(Vec::new());
+        };
+
+        Ok(paths)
+    }
+
+    /// Target dbus devices that this [CompositeDevice] is managing
+    #[zbus(property)]
+    async fn dbus_devices(&self) -> fdo::Result<Vec<String>> {
+        let (sender, mut receiver) = mpsc::channel::<Vec<String>>(1);
+        self.tx
+            .send(Command::GetDBusDevicePaths(sender))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        let Some(paths) = receiver.recv().await else {
+            return Ok(Vec::new());
+        };
+
+        Ok(paths)
+    }
+}

--- a/src/dbus/interface/manager.rs
+++ b/src/dbus/interface/manager.rs
@@ -1,0 +1,95 @@
+use tokio::sync::{broadcast, mpsc};
+use zbus::fdo;
+use zbus_macros::interface;
+
+use crate::{config::CompositeDeviceConfig, input::manager::ManagerCommand};
+
+/// The [ManagerInterface] provides a DBus interface that can be exposed for managing
+/// a [Manager]. It works by sending command messages to a channel that the
+/// [Manager] is listening on.
+pub struct ManagerInterface {
+    tx: broadcast::Sender<ManagerCommand>,
+}
+
+impl ManagerInterface {
+    pub fn new(tx: broadcast::Sender<ManagerCommand>) -> ManagerInterface {
+        ManagerInterface { tx }
+    }
+}
+
+#[interface(name = "org.shadowblip.InputManager")]
+impl ManagerInterface {
+    #[zbus(property)]
+    async fn intercept_mode(&self) -> fdo::Result<String> {
+        Ok("InputPlumber".to_string())
+    }
+
+    /// Create a composite device using the give composite device config. The
+    /// path should be the absolute path to a composite device configuration file.
+    async fn create_composite_device(&self, config_path: String) -> fdo::Result<String> {
+        let device = CompositeDeviceConfig::from_yaml_file(config_path)
+            .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+        self.tx
+            .send(ManagerCommand::CreateCompositeDevice { config: device })
+            .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+        Ok("".to_string())
+    }
+
+    /// Create a target device of the given type. Returns the DBus path to
+    /// the created target device.
+    async fn create_target_device(&self, kind: String) -> fdo::Result<String> {
+        let (sender, mut receiver) = mpsc::channel(1);
+        self.tx
+            .send(ManagerCommand::CreateTargetDevice { kind, sender })
+            .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+
+        // Read the response from the manager
+        let Some(response) = receiver.recv().await else {
+            return Err(fdo::Error::Failed("No response from manager".to_string()));
+        };
+        let device_path = match response {
+            Ok(path) => path,
+            Err(e) => {
+                let err = format!("Failed to create target device: {e:?}");
+                return Err(fdo::Error::Failed(err));
+            }
+        };
+
+        Ok(device_path)
+    }
+
+    /// Stop the given target device
+    async fn stop_target_device(&self, path: String) -> fdo::Result<()> {
+        self.tx
+            .send(ManagerCommand::StopTargetDevice { path })
+            .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+        Ok(())
+    }
+
+    /// Attach the given target device to the given composite device
+    async fn attach_target_device(
+        &self,
+        target_path: String,
+        composite_path: String,
+    ) -> fdo::Result<()> {
+        let (sender, mut receiver) = mpsc::channel(1);
+        self.tx
+            .send(ManagerCommand::AttachTargetDevice {
+                target_path: target_path.clone(),
+                composite_path: composite_path.clone(),
+                sender,
+            })
+            .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+
+        // Read the response from the manager
+        let Some(response) = receiver.recv().await else {
+            return Err(fdo::Error::Failed("No response from manager".to_string()));
+        };
+        if let Err(e) = response {
+            let err = format!("Failed to attach target device {target_path} to composite device {composite_path}: {e:?}");
+            return Err(fdo::Error::Failed(err));
+        }
+
+        Ok(())
+    }
+}

--- a/src/dbus/interface/mod.rs
+++ b/src/dbus/interface/mod.rs
@@ -1,0 +1,4 @@
+pub mod composite_device;
+pub mod manager;
+pub mod source;
+pub mod target;

--- a/src/dbus/interface/source/evdev.rs
+++ b/src/dbus/interface/source/evdev.rs
@@ -1,0 +1,73 @@
+use std::error::Error;
+
+use zbus::{fdo, Connection};
+use zbus_macros::interface;
+
+use crate::{input::source::evdev::get_dbus_path, procfs};
+
+/// The [SourceEventDeviceInterface] provides a DBus interface that can be exposed for managing
+/// a [Manager]. It works by sending command messages to a channel that the
+/// [Manager] is listening on.
+pub struct SourceEventDeviceInterface {
+    info: procfs::device::Device,
+}
+
+impl SourceEventDeviceInterface {
+    pub fn new(_handler: String, info: procfs::device::Device) -> SourceEventDeviceInterface {
+        SourceEventDeviceInterface { info }
+    }
+
+    /// Creates a new instance of the source evdev interface on DBus. Returns
+    /// a structure with information about the source device.
+    pub async fn listen_on_dbus(
+        conn: Connection,
+        handler: String,
+        info: procfs::device::Device,
+    ) -> Result<(), Box<dyn Error>> {
+        let path = get_dbus_path(handler.clone());
+        let iface = SourceEventDeviceInterface::new(handler.clone(), info);
+        conn.object_server().at(path, iface).await?;
+        Ok(())
+    }
+}
+
+#[interface(name = "org.shadowblip.Input.Source.EventDevice")]
+impl SourceEventDeviceInterface {
+    #[zbus(property)]
+    async fn name(&self) -> fdo::Result<String> {
+        Ok(self.info.name.clone())
+    }
+
+    #[zbus(property)]
+    async fn handlers(&self) -> fdo::Result<Vec<String>> {
+        Ok(self.info.handlers.clone())
+    }
+
+    #[zbus(property)]
+    async fn phys_path(&self) -> fdo::Result<String> {
+        Ok(self.info.phys_path.clone())
+    }
+
+    #[zbus(property)]
+    async fn sysfs_path(&self) -> fdo::Result<String> {
+        Ok(self.info.sysfs_path.clone())
+    }
+
+    #[zbus(property)]
+    async fn unique_id(&self) -> fdo::Result<String> {
+        Ok(self.info.unique_id.clone())
+    }
+
+    /// Returns the full path to the device handler (e.g. /dev/input/event3)
+    #[zbus(property)]
+    pub fn device_path(&self) -> fdo::Result<String> {
+        let handlers = &self.info.handlers;
+        for handler in handlers {
+            if !handler.starts_with("event") {
+                continue;
+            }
+            return Ok(format!("/dev/input/{}", handler.clone()));
+        }
+        Ok("".into())
+    }
+}

--- a/src/dbus/interface/source/hidraw.rs
+++ b/src/dbus/interface/source/hidraw.rs
@@ -1,0 +1,74 @@
+use std::error::Error;
+
+use hidapi::DeviceInfo;
+use zbus::{fdo, Connection};
+use zbus_macros::interface;
+
+use crate::input::source::hidraw::get_dbus_path;
+
+/// DBusInterface exposing information about a HIDRaw device
+pub struct SourceHIDRawInterface {
+    info: DeviceInfo,
+}
+
+impl SourceHIDRawInterface {
+    pub fn new(info: DeviceInfo) -> SourceHIDRawInterface {
+        SourceHIDRawInterface { info }
+    }
+
+    /// Creates a new instance of the source hidraw interface on DBus. Returns
+    /// a structure with information about the source device.
+    pub async fn listen_on_dbus(conn: Connection, info: DeviceInfo) -> Result<(), Box<dyn Error>> {
+        let path = get_dbus_path(info.path().to_string_lossy().to_string());
+        let iface = SourceHIDRawInterface::new(info);
+        conn.object_server().at(path, iface).await?;
+        Ok(())
+    }
+}
+
+#[interface(name = "org.shadowblip.Input.Source.HIDRawDevice")]
+impl SourceHIDRawInterface {
+    #[zbus(property)]
+    async fn path(&self) -> fdo::Result<String> {
+        Ok(self.info.path().to_string_lossy().to_string())
+    }
+
+    #[zbus(property)]
+    async fn vendor_id(&self) -> fdo::Result<String> {
+        Ok(format!("{:04x}", self.info.vendor_id()))
+    }
+
+    #[zbus(property)]
+    async fn product_id(&self) -> fdo::Result<String> {
+        Ok(format!("{:04x}", self.info.product_id()))
+    }
+
+    #[zbus(property)]
+    async fn serial_number(&self) -> fdo::Result<String> {
+        Ok(self.info.serial_number().unwrap_or_default().to_string())
+    }
+
+    #[zbus(property)]
+    async fn release_number(&self) -> fdo::Result<String> {
+        Ok(format!("{:04x}", self.info.release_number()))
+    }
+
+    #[zbus(property)]
+    async fn manufacturer(&self) -> fdo::Result<String> {
+        Ok(self
+            .info
+            .manufacturer_string()
+            .unwrap_or_default()
+            .to_string())
+    }
+
+    #[zbus(property)]
+    async fn product(&self) -> fdo::Result<String> {
+        Ok(self.info.product_string().unwrap_or_default().to_string())
+    }
+
+    #[zbus(property)]
+    async fn interface_number(&self) -> fdo::Result<i32> {
+        Ok(self.info.interface_number())
+    }
+}

--- a/src/dbus/interface/source/mod.rs
+++ b/src/dbus/interface/source/mod.rs
@@ -1,0 +1,2 @@
+pub mod evdev;
+pub mod hidraw;

--- a/src/dbus/interface/target/gamepad.rs
+++ b/src/dbus/interface/target/gamepad.rs
@@ -1,0 +1,29 @@
+use zbus::fdo;
+use zbus_macros::interface;
+
+/// The [TargetGamepadInterface] provides a DBus interface that can be exposed for managing
+/// a [GenericGamepad].
+pub struct TargetGamepadInterface {
+    dev_name: String,
+}
+
+impl TargetGamepadInterface {
+    pub fn new(dev_name: String) -> TargetGamepadInterface {
+        TargetGamepadInterface { dev_name }
+    }
+}
+
+impl Default for TargetGamepadInterface {
+    fn default() -> Self {
+        Self::new("Gamepad".to_string())
+    }
+}
+
+#[interface(name = "org.shadowblip.Input.Gamepad")]
+impl TargetGamepadInterface {
+    /// Name of the DBus device
+    #[zbus(property)]
+    async fn name(&self) -> fdo::Result<String> {
+        Ok(self.dev_name.clone())
+    }
+}

--- a/src/dbus/interface/target/keyboard.rs
+++ b/src/dbus/interface/target/keyboard.rs
@@ -1,0 +1,218 @@
+use tokio::sync::mpsc;
+use zbus::fdo;
+use zbus_macros::interface;
+
+use crate::input::{
+    capability::{Capability, Keyboard},
+    event::{native::NativeEvent, value::InputValue},
+    target::TargetCommand,
+};
+
+/// The [DBusInterface] provides a DBus interface that can be exposed for managing
+/// a [KeyboardDevice]. It works by sending command messages to a channel that the
+/// [KeyboardDevice] is listening on.
+pub struct TargetKeyboardInterface {
+    command_tx: mpsc::Sender<TargetCommand>,
+}
+
+impl TargetKeyboardInterface {
+    pub fn new(command_tx: mpsc::Sender<TargetCommand>) -> TargetKeyboardInterface {
+        TargetKeyboardInterface { command_tx }
+    }
+}
+
+#[interface(name = "org.shadowblip.Input.Keyboard")]
+impl TargetKeyboardInterface {
+    /// Name of the composite device
+    #[zbus(property)]
+    async fn name(&self) -> fdo::Result<String> {
+        Ok("Keyboard".into())
+    }
+
+    /// Send the given key to the virtual keyboard
+    async fn send_key(&self, key: String, value: bool) -> fdo::Result<()> {
+        // Create a NativeEvent to send to the keyboard
+        let capability = capability_from_key_string(key.as_str());
+        if matches!(capability, Capability::NotImplemented) {
+            return Err(fdo::Error::NotSupported("Invalid key code".into()));
+        }
+        let value = InputValue::Bool(value);
+        let event = NativeEvent::new(capability, value);
+
+        // Write the event to the virtual device
+        self.command_tx
+            .send(TargetCommand::WriteEvent(event))
+            .await
+            .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+
+        Ok(())
+    }
+}
+
+/// Returns an input device capability from the given key string.
+fn capability_from_key_string(key: &str) -> Capability {
+    match key {
+        "KEY_ESC" => Capability::Keyboard(Keyboard::KeyEsc),
+        "KEY_1" => Capability::Keyboard(Keyboard::Key1),
+        "KEY_2" => Capability::Keyboard(Keyboard::Key2),
+        "KEY_3" => Capability::Keyboard(Keyboard::Key3),
+        "KEY_4" => Capability::Keyboard(Keyboard::Key4),
+        "KEY_5" => Capability::Keyboard(Keyboard::Key5),
+        "KEY_6" => Capability::Keyboard(Keyboard::Key6),
+        "KEY_7" => Capability::Keyboard(Keyboard::Key7),
+        "KEY_8" => Capability::Keyboard(Keyboard::Key8),
+        "KEY_9" => Capability::Keyboard(Keyboard::Key9),
+        "KEY_0" => Capability::Keyboard(Keyboard::Key0),
+        "KEY_MINUS" => Capability::Keyboard(Keyboard::KeyMinus),
+        "KEY_EQUAL" => Capability::Keyboard(Keyboard::KeyEqual),
+        "KEY_BACKSPACE" => Capability::Keyboard(Keyboard::KeyBackspace),
+        "KEY_TAB" => Capability::Keyboard(Keyboard::KeyTab),
+        "KEY_Q" => Capability::Keyboard(Keyboard::KeyQ),
+        "KEY_W" => Capability::Keyboard(Keyboard::KeyW),
+        "KEY_E" => Capability::Keyboard(Keyboard::KeyE),
+        "KEY_R" => Capability::Keyboard(Keyboard::KeyR),
+        "KEY_T" => Capability::Keyboard(Keyboard::KeyT),
+        "KEY_Y" => Capability::Keyboard(Keyboard::KeyY),
+        "KEY_U" => Capability::Keyboard(Keyboard::KeyU),
+        "KEY_I" => Capability::Keyboard(Keyboard::KeyI),
+        "KEY_O" => Capability::Keyboard(Keyboard::KeyO),
+        "KEY_P" => Capability::Keyboard(Keyboard::KeyP),
+        "KEY_LEFTBRACE" => Capability::Keyboard(Keyboard::KeyLeftBrace),
+        "KEY_RIGHTBRACE" => Capability::Keyboard(Keyboard::KeyRightBrace),
+        "KEY_ENTER" => Capability::Keyboard(Keyboard::KeyEnter),
+        "KEY_LEFTCTRL" => Capability::Keyboard(Keyboard::KeyLeftCtrl),
+        "KEY_A" => Capability::Keyboard(Keyboard::KeyA),
+        "KEY_S" => Capability::Keyboard(Keyboard::KeyS),
+        "KEY_D" => Capability::Keyboard(Keyboard::KeyD),
+        "KEY_F" => Capability::Keyboard(Keyboard::KeyF),
+        "KEY_G" => Capability::Keyboard(Keyboard::KeyG),
+        "KEY_H" => Capability::Keyboard(Keyboard::KeyH),
+        "KEY_J" => Capability::Keyboard(Keyboard::KeyJ),
+        "KEY_K" => Capability::Keyboard(Keyboard::KeyK),
+        "KEY_L" => Capability::Keyboard(Keyboard::KeyL),
+        "KEY_SEMICOLON" => Capability::Keyboard(Keyboard::KeySemicolon),
+        "KEY_APOSTROPHE" => Capability::Keyboard(Keyboard::KeyApostrophe),
+        "KEY_GRAVE" => Capability::Keyboard(Keyboard::KeyGrave),
+        "KEY_LEFTSHIFT" => Capability::Keyboard(Keyboard::KeyLeftShift),
+        "KEY_BACKSLASH" => Capability::Keyboard(Keyboard::KeyBackslash),
+        "KEY_Z" => Capability::Keyboard(Keyboard::KeyZ),
+        "KEY_X" => Capability::Keyboard(Keyboard::KeyX),
+        "KEY_C" => Capability::Keyboard(Keyboard::KeyC),
+        "KEY_V" => Capability::Keyboard(Keyboard::KeyV),
+        "KEY_B" => Capability::Keyboard(Keyboard::KeyB),
+        "KEY_N" => Capability::Keyboard(Keyboard::KeyN),
+        "KEY_M" => Capability::Keyboard(Keyboard::KeyM),
+        "KEY_COMMA" => Capability::Keyboard(Keyboard::KeyComma),
+        "KEY_DOT" => Capability::Keyboard(Keyboard::KeyDot),
+        "KEY_SLASH" => Capability::Keyboard(Keyboard::KeySlash),
+        "KEY_RIGHTSHIFT" => Capability::Keyboard(Keyboard::KeyRightShift),
+        "KEY_KPASTERISK" => Capability::Keyboard(Keyboard::KeyKpAsterisk),
+        "KEY_LEFTALT" => Capability::Keyboard(Keyboard::KeyLeftAlt),
+        "KEY_SPACE" => Capability::Keyboard(Keyboard::KeySpace),
+        "KEY_CAPSLOCK" => Capability::Keyboard(Keyboard::KeyCapslock),
+        "KEY_F1" => Capability::Keyboard(Keyboard::KeyF1),
+        "KEY_F2" => Capability::Keyboard(Keyboard::KeyF2),
+        "KEY_F3" => Capability::Keyboard(Keyboard::KeyF3),
+        "KEY_F4" => Capability::Keyboard(Keyboard::KeyF4),
+        "KEY_F5" => Capability::Keyboard(Keyboard::KeyF5),
+        "KEY_F6" => Capability::Keyboard(Keyboard::KeyF6),
+        "KEY_F7" => Capability::Keyboard(Keyboard::KeyF7),
+        "KEY_F8" => Capability::Keyboard(Keyboard::KeyF8),
+        "KEY_F9" => Capability::Keyboard(Keyboard::KeyF9),
+        "KEY_F10" => Capability::Keyboard(Keyboard::KeyF10),
+        "KEY_NUMLOCK" => Capability::Keyboard(Keyboard::KeyNumlock),
+        "KEY_SCROLLLOCK" => Capability::Keyboard(Keyboard::KeyScrollLock),
+        "KEY_KP7" => Capability::Keyboard(Keyboard::KeyKp7),
+        "KEY_KP8" => Capability::Keyboard(Keyboard::KeyKp8),
+        "KEY_KP9" => Capability::Keyboard(Keyboard::KeyKp9),
+        "KEY_KPMINUS" => Capability::Keyboard(Keyboard::KeyKpMinus),
+        "KEY_KP4" => Capability::Keyboard(Keyboard::KeyKp4),
+        "KEY_KP5" => Capability::Keyboard(Keyboard::KeyKp5),
+        "KEY_KP6" => Capability::Keyboard(Keyboard::KeyKp6),
+        "KEY_KPPLUS" => Capability::Keyboard(Keyboard::KeyKpPlus),
+        "KEY_KP1" => Capability::Keyboard(Keyboard::KeyKp1),
+        "KEY_KP2" => Capability::Keyboard(Keyboard::KeyKp2),
+        "KEY_KP3" => Capability::Keyboard(Keyboard::KeyKp3),
+        "KEY_KP0" => Capability::Keyboard(Keyboard::KeyKp0),
+        "KEY_KPDOT" => Capability::Keyboard(Keyboard::KeyKpDot),
+        "KEY_ZENKAKUHANKAKU" => Capability::Keyboard(Keyboard::KeyZenkakuhankaku),
+        "KEY_102ND" => Capability::Keyboard(Keyboard::Key102nd),
+        "KEY_F11" => Capability::Keyboard(Keyboard::KeyF11),
+        "KEY_F12" => Capability::Keyboard(Keyboard::KeyF12),
+        "KEY_RO" => Capability::Keyboard(Keyboard::KeyRo),
+        "KEY_KATAKANA" => Capability::Keyboard(Keyboard::KeyKatakana),
+        "KEY_HIRAGANA" => Capability::Keyboard(Keyboard::KeyHiragana),
+        "KEY_HENKAN" => Capability::Keyboard(Keyboard::KeyHenkan),
+        "KEY_KATAKANAHIRAGANA" => Capability::Keyboard(Keyboard::KeyKatakanaHiragana),
+        "KEY_MUHENKAN" => Capability::Keyboard(Keyboard::KeyMuhenkan),
+        "KEY_KPJPCOMMA" => Capability::Keyboard(Keyboard::KeyKpJpComma),
+        "KEY_KPENTER" => Capability::Keyboard(Keyboard::KeyKpEnter),
+        "KEY_RIGHTCTRL" => Capability::Keyboard(Keyboard::KeyRightCtrl),
+        "KEY_KPSLASH" => Capability::Keyboard(Keyboard::KeyKpSlash),
+        "KEY_SYSRQ" => Capability::Keyboard(Keyboard::KeySysrq),
+        "KEY_RIGHTALT" => Capability::Keyboard(Keyboard::KeyRightAlt),
+        "KEY_HOME" => Capability::Keyboard(Keyboard::KeyHome),
+        "KEY_UP" => Capability::Keyboard(Keyboard::KeyUp),
+        "KEY_PAGEUP" => Capability::Keyboard(Keyboard::KeyPageUp),
+        "KEY_LEFT" => Capability::Keyboard(Keyboard::KeyLeft),
+        "KEY_RIGHT" => Capability::Keyboard(Keyboard::KeyRight),
+        "KEY_END" => Capability::Keyboard(Keyboard::KeyEnd),
+        "KEY_DOWN" => Capability::Keyboard(Keyboard::KeyDown),
+        "KEY_PAGEDOWN" => Capability::Keyboard(Keyboard::KeyPageDown),
+        "KEY_INSERT" => Capability::Keyboard(Keyboard::KeyInsert),
+        "KEY_DELETE" => Capability::Keyboard(Keyboard::KeyDelete),
+        "KEY_MUTE" => Capability::Keyboard(Keyboard::KeyMute),
+        "KEY_VOLUMEDOWN" => Capability::Keyboard(Keyboard::KeyVolumeDown),
+        "KEY_VOLUMEUP" => Capability::Keyboard(Keyboard::KeyVolumeUp),
+        "KEY_POWER" => Capability::Keyboard(Keyboard::KeyPower),
+        "KEY_KPEQUAL" => Capability::Keyboard(Keyboard::KeyKpEqual),
+        "KEY_PAUSE" => Capability::Keyboard(Keyboard::KeyPause),
+        "KEY_KPCOMMA" => Capability::Keyboard(Keyboard::KeyKpComma),
+        "KEY_HANJA" => Capability::Keyboard(Keyboard::KeyHanja),
+        "KEY_YEN" => Capability::Keyboard(Keyboard::KeyYen),
+        "KEY_LEFTMETA" => Capability::Keyboard(Keyboard::KeyLeftMeta),
+        "KEY_RIGHTMETA" => Capability::Keyboard(Keyboard::KeyRightMeta),
+        "KEY_COMPOSE" => Capability::Keyboard(Keyboard::KeyCompose),
+        "KEY_STOP" => Capability::Keyboard(Keyboard::KeyStop),
+        "KEY_AGAIN" => Capability::Keyboard(Keyboard::KeyAgain),
+        "KEY_PROPS" => Capability::Keyboard(Keyboard::KeyProps),
+        "KEY_UNDO" => Capability::Keyboard(Keyboard::KeyUndo),
+        "KEY_FRONT" => Capability::Keyboard(Keyboard::KeyFront),
+        "KEY_COPY" => Capability::Keyboard(Keyboard::KeyCopy),
+        "KEY_OPEN" => Capability::Keyboard(Keyboard::KeyOpen),
+        "KEY_PASTE" => Capability::Keyboard(Keyboard::KeyPaste),
+        "KEY_FIND" => Capability::Keyboard(Keyboard::KeyFind),
+        "KEY_CUT" => Capability::Keyboard(Keyboard::KeyCut),
+        "KEY_HELP" => Capability::Keyboard(Keyboard::KeyHelp),
+        "KEY_CALC" => Capability::Keyboard(Keyboard::KeyCalc),
+        "KEY_SLEEP" => Capability::Keyboard(Keyboard::KeySleep),
+        "KEY_WWW" => Capability::Keyboard(Keyboard::KeyWww),
+        "KEY_BACK" => Capability::Keyboard(Keyboard::KeyBack),
+        "KEY_FORWARD" => Capability::Keyboard(Keyboard::KeyForward),
+        "KEY_EJECTCD" => Capability::Keyboard(Keyboard::KeyEjectCD),
+        "KEY_NEXTSONG" => Capability::Keyboard(Keyboard::KeyNextSong),
+        "KEY_PLAYPAUSE" => Capability::Keyboard(Keyboard::KeyPlayPause),
+        "KEY_PREVIOUSSONG" => Capability::Keyboard(Keyboard::KeyPreviousSong),
+        "KEY_STOPCD" => Capability::Keyboard(Keyboard::KeyStopCD),
+        "KEY_REFRESH" => Capability::Keyboard(Keyboard::KeyRefresh),
+        "KEY_EDIT" => Capability::Keyboard(Keyboard::KeyEdit),
+        "KEY_SCROLLUP" => Capability::Keyboard(Keyboard::KeyScrollUp),
+        "KEY_SCROLLDOWN" => Capability::Keyboard(Keyboard::KeyScrollDown),
+        "KEY_KPLEFTPAREN" => Capability::Keyboard(Keyboard::KeyKpLeftParen),
+        "KEY_KPRIGHTPAREN" => Capability::Keyboard(Keyboard::KeyKpRightParen),
+        "KEY_F13" => Capability::Keyboard(Keyboard::KeyF13),
+        "KEY_F14" => Capability::Keyboard(Keyboard::KeyF14),
+        "KEY_F15" => Capability::Keyboard(Keyboard::KeyF15),
+        "KEY_F16" => Capability::Keyboard(Keyboard::KeyF16),
+        "KEY_F17" => Capability::Keyboard(Keyboard::KeyF17),
+        "KEY_F18" => Capability::Keyboard(Keyboard::KeyF18),
+        "KEY_F19" => Capability::Keyboard(Keyboard::KeyF19),
+        "KEY_F20" => Capability::Keyboard(Keyboard::KeyF20),
+        "KEY_F21" => Capability::Keyboard(Keyboard::KeyF21),
+        "KEY_F22" => Capability::Keyboard(Keyboard::KeyF22),
+        "KEY_F23" => Capability::Keyboard(Keyboard::KeyF23),
+        "KEY_F24" => Capability::Keyboard(Keyboard::KeyF24),
+        "KEY_PROG1" => Capability::Keyboard(Keyboard::KeyProg1),
+        _ => Capability::NotImplemented,
+    }
+}

--- a/src/dbus/interface/target/mod.rs
+++ b/src/dbus/interface/target/mod.rs
@@ -1,0 +1,33 @@
+pub mod gamepad;
+pub mod keyboard;
+pub mod mouse;
+
+use zbus::fdo;
+use zbus_macros::interface;
+
+/// The [TargetInterface] provides a DBus interface that can be exposed for managing
+/// a target input device.
+pub struct TargetInterface {
+    dev_name: String,
+}
+
+impl TargetInterface {
+    pub fn new(dev_name: String) -> TargetInterface {
+        TargetInterface { dev_name }
+    }
+}
+
+impl Default for TargetInterface {
+    fn default() -> Self {
+        Self::new("Gamepad".to_string())
+    }
+}
+
+#[interface(name = "org.shadowblip.Input.Target")]
+impl TargetInterface {
+    /// Name of the DBus device
+    #[zbus(property)]
+    async fn name(&self) -> fdo::Result<String> {
+        Ok(self.dev_name.clone())
+    }
+}

--- a/src/dbus/interface/target/mouse.rs
+++ b/src/dbus/interface/target/mouse.rs
@@ -1,0 +1,28 @@
+use zbus::fdo;
+use zbus_macros::interface;
+
+/// The [TargetMouseInterface] provides a DBus interface that can be exposed for managing
+/// a [MouseDevice]. It works by sending command messages to a channel that the
+/// [MouseDevice] is listening on.
+pub struct TargetMouseInterface {}
+
+impl TargetMouseInterface {
+    pub fn new() -> TargetMouseInterface {
+        TargetMouseInterface {}
+    }
+}
+
+impl Default for TargetMouseInterface {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[interface(name = "org.shadowblip.Input.Mouse")]
+impl TargetMouseInterface {
+    /// Name of the composite device
+    #[zbus(property)]
+    async fn name(&self) -> fdo::Result<String> {
+        Ok("Mouse".into())
+    }
+}

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -1,0 +1,1 @@
+pub mod interface;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod constants;
+pub mod dbus;
 pub mod dmi;
 pub mod drivers;
 pub mod iio;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use crate::udev::unhide_all;
 
 mod config;
 mod constants;
+mod dbus;
 mod dmi;
 mod drivers;
 mod iio;


### PR DESCRIPTION
This change moves all of the DBus interface code into their own separate files (and updates it to zbus 4.x format). This can let us re-use various DBus interfaces multiple times. Such as using a single interface for `org.shadowblip.Input.Gamepad` across all target devices.