### PR TITLE
Update ally_type1.yaml

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/ally_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ally_type1.yaml
@@ -26,7 +26,7 @@ mapping:
       - keyboard: KeyDelete
     target_event:
       gamepad:
-        button: Keyboard
+        button: LeftPaddle2
   - name: Armory Crate (Short)
     source_events:
       - keyboard: KeyProg1
@@ -38,7 +38,7 @@ mapping:
       - keyboard: KeyF17
     target_event:
       gamepad:
-        button: QuickAccess2
+        button: RightPaddle2
   - name: Left Paddle
     source_events:
       - keyboard: KeyF14


### PR DESCRIPTION
By setting long press of AC/CC button as back button 2, you can assign it to each game. It will be recognized as R4/L4.