### PR TITLE
Update ally_type1.yaml

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/ally_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ally_type1.yaml
@@ -26,7 +26,7 @@ mapping:
       - keyboard: KeyDelete
     target_event:
       gamepad:
-        button: Keyboard
+        button: LeftPaddle2
   - name: Armory Crate (Short)
     source_events:
       - keyboard: KeyProg1
@@ -38,7 +38,7 @@ mapping:
       - keyboard: KeyF17
     target_event:
       gamepad:
-        button: QuickAccess2
+        button: RightPaddle2
   - name: Left Paddle
     source_events:
       - keyboard: KeyF14


### PR DESCRIPTION
This change allows you to change the response when you press and hold the AC/CC button to BR/BL. It is now possible to assign keyboard, mouse, and action actions for each game from the controller settings without rewriting files.