### PR TITLE
fix(Profiles): Use translated version of osk/quick2 instead.

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml
@@ -24,6 +24,10 @@ matches:
 source_devices:
   - group: gamepad
     evdev:
+      name: Nintendo Co., Ltd. Pro Controller
+      phys_path: usb-0000:e4:00.3-4/input0
+  - group: gamepad
+    evdev:
       name: Microsoft X-Box 360 pad
       phys_path: usb-0000:e4:00.3-4/input0
   - group: keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
@@ -24,6 +24,10 @@ matches:
 source_devices:
   - group: gamepad
     evdev:
+      name: Nintendo Co., Ltd. Pro Controller
+      phys_path: usb-0000:c4:00.3-4/input0
+  - group: gamepad
+    evdev:
       name: Microsoft X-Box 360 pad
       phys_path: usb-0000:c4:00.3-4/input0
   - group: keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml
@@ -24,6 +24,10 @@ matches:
 source_devices:
   - group: gamepad
     evdev:
+      name: Nintendo Co., Ltd. Pro Controller
+      phys_path: usb-0000:c4:00.3-4/input0
+  - group: gamepad
+    evdev:
       name: Microsoft X-Box 360 pad
       phys_path: usb-0000:c4:00.3-4/input0
   - group: keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus.yaml
@@ -30,6 +30,10 @@ matches:
 source_devices:
   - group: gamepad
     evdev:
+      name: Nintendo Co., Ltd. Pro Controller
+      phys_path: usb-0000:64:00.3-3/input0
+  - group: gamepad
+    evdev:
       name: Microsoft X-Box 360 pad
       phys_path: usb-0000:64:00.3-3/input0
   - group: gamepad

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml
@@ -24,6 +24,10 @@ matches:
 source_devices:
   - group: gamepad
     evdev:
+      name: Nintendo Co., Ltd. Pro Controller
+      phys_path: usb-0000:c4:00.3-4/input0
+  - group: gamepad
+    evdev:
       name: Microsoft X-Box 360 pad
       phys_path: usb-0000:c4:00.3-4/input0
   - group: keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_kun.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_kun.yaml
@@ -21,6 +21,10 @@ matches:
 source_devices:
   - group: gamepad
     evdev:
+      name: Nintendo Co., Ltd. Pro Controller
+      phys_path: usb-0000:c4:00.3-4.1/input0
+  - group: gamepad
+    evdev:
       name: Microsoft X-Box 360 pad
       phys_path: usb-0000:c4:00.3-4.1/input0
   - group: keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_slide.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_slide.yaml
@@ -21,6 +21,10 @@ matches:
 source_devices:
   - group: gamepad
     evdev:
+      name: Nintendo Co., Ltd. Pro Controller
+      phys_path: usb-0000:c4:00.3-3/input0
+  - group: gamepad
+    evdev:
       name: Microsoft X-Box 360 pad
       phys_path: usb-0000:c4:00.3-3/input0
   - group: keyboard

--- a/rootfs/usr/share/inputplumber/profiles/default.yaml
+++ b/rootfs/usr/share/inputplumber/profiles/default.yaml
@@ -31,14 +31,18 @@ mapping:
         button: LeftTop
     target_events:
       - gamepad:
-          button: Keyboard
+          button: Guide
+      - gamepad:
+          button: North
   - name: RightTop
     source_event:
       gamepad:
         button: RightTop
     target_events:
       - gamepad:
-          button: QuickAccess2
+          button: Guide
+      - gamepad:
+          button: East
   - name: Keyboard
     source_event:
       gamepad:


### PR DESCRIPTION
- While at it, fix some ayaneo controllers intitially reporting as a Nintendo Co., Ltd. Pro Controller.