### PR TITLE
fix(CompositeDevice): resolve deadlock issues with switching profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,8 +43,8 @@ serde_yaml = "0.9.27"
 thiserror = "1.0.56"
 tokio = { version = "*", features = ["full"] }
 uhid-virt = "0.0.7"
-zbus = { version = "4.1.2", default-features = false, features = ["tokio"] }
-zbus_macros = "4.1.2"
+zbus = { version = "4.2.2", default-features = false, features = ["tokio"] }
+zbus_macros = "4.2.2"
 
 [profile.release]
 debug = false

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -437,7 +437,7 @@ impl CompositeDeviceConfig {
     ) -> bool {
         //TODO: Check if the evdev has no proterties defined, that would always match.
 
-        if is_virtual(device) {
+        if device.is_virtual() {
             log::debug!("{} is virtual, skipping.", device.name);
             return false;
         }
@@ -574,16 +574,4 @@ impl CompositeDeviceConfig {
 
         Some(matches)
     }
-}
-
-/// Determines if a procfs device is virtual or real.
-fn is_virtual(device: &procfs::device::Device) -> bool {
-    if !device.phys_path.is_empty() {
-        return false;
-    }
-
-    if device.sysfs_path.contains("/devices/virtual") {
-        return true;
-    }
-    false
 }

--- a/src/dbus/interface/composite_device.rs
+++ b/src/dbus/interface/composite_device.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, str::FromStr};
+use std::{collections::HashSet, str::FromStr, time::Duration};
 
 use tokio::sync::mpsc;
 use zbus::{
@@ -33,7 +33,7 @@ impl CompositeDeviceInterface {
     async fn name(&self) -> fdo::Result<String> {
         let (sender, mut receiver) = mpsc::channel::<String>(1);
         self.tx
-            .send(Command::GetName(sender))
+            .send_timeout(Command::GetName(sender), Duration::from_millis(500))
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
         let Some(name) = receiver.recv().await else {
@@ -48,7 +48,7 @@ impl CompositeDeviceInterface {
     async fn profile_name(&self) -> fdo::Result<String> {
         let (sender, mut receiver) = mpsc::channel::<String>(1);
         self.tx
-            .send(Command::GetProfileName(sender))
+            .send_timeout(Command::GetProfileName(sender), Duration::from_millis(500))
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
         let Some(profile_name) = receiver.recv().await else {
@@ -61,7 +61,7 @@ impl CompositeDeviceInterface {
     /// Stop the composite device and all target devices
     async fn stop(&self) -> fdo::Result<()> {
         self.tx
-            .send(Command::Stop)
+            .send_timeout(Command::Stop, Duration::from_millis(500))
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
         Ok(())
@@ -71,7 +71,10 @@ impl CompositeDeviceInterface {
     async fn load_profile_path(&self, path: String) -> fdo::Result<()> {
         let (sender, mut receiver) = mpsc::channel::<Result<(), String>>(1);
         self.tx
-            .send(Command::LoadProfilePath(path, sender))
+            .send_timeout(
+                Command::LoadProfilePath(path, sender),
+                Duration::from_millis(500),
+            )
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
 
@@ -97,7 +100,10 @@ impl CompositeDeviceInterface {
     /// new target devices.
     async fn set_target_devices(&self, target_device_types: Vec<String>) -> fdo::Result<()> {
         self.tx
-            .send(Command::SetTargetDevices(target_device_types))
+            .send_timeout(
+                Command::SetTargetDevices(target_device_types),
+                Duration::from_millis(500),
+            )
             .await
             .map_err(|err| fdo::Error::Failed(err.to_string()))?;
         Ok(())
@@ -200,7 +206,7 @@ impl CompositeDeviceInterface {
         }
 
         self.tx
-            .send(Command::WriteChordEvent(chord))
+            .send_timeout(Command::WriteChordEvent(chord), Duration::from_millis(500))
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
 
@@ -241,7 +247,10 @@ impl CompositeDeviceInterface {
         }
 
         self.tx
-            .send(Command::SetInterceptActivation(activation_caps, target_cap))
+            .send_timeout(
+                Command::SetInterceptActivation(activation_caps, target_cap),
+                Duration::from_millis(500),
+            )
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
 
@@ -253,7 +262,7 @@ impl CompositeDeviceInterface {
     async fn capabilities(&self) -> fdo::Result<Vec<String>> {
         let (sender, mut receiver) = mpsc::channel::<HashSet<Capability>>(1);
         self.tx
-            .send(Command::GetCapabilities(sender))
+            .send_timeout(Command::GetCapabilities(sender), Duration::from_millis(500))
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
         let Some(capabilities) = receiver.recv().await else {
@@ -288,7 +297,10 @@ impl CompositeDeviceInterface {
     async fn target_capabilities(&self) -> fdo::Result<Vec<String>> {
         let (sender, mut receiver) = mpsc::channel::<HashSet<Capability>>(1);
         self.tx
-            .send(Command::GetTargetCapabilities(sender))
+            .send_timeout(
+                Command::GetTargetCapabilities(sender),
+                Duration::from_millis(500),
+            )
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
         let Some(capabilities) = receiver.recv().await else {
@@ -323,7 +335,10 @@ impl CompositeDeviceInterface {
     async fn source_device_paths(&self) -> fdo::Result<Vec<String>> {
         let (sender, mut receiver) = mpsc::channel::<Vec<String>>(1);
         self.tx
-            .send(Command::GetSourceDevicePaths(sender))
+            .send_timeout(
+                Command::GetSourceDevicePaths(sender),
+                Duration::from_millis(500),
+            )
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
         let Some(paths) = receiver.recv().await else {
@@ -338,7 +353,10 @@ impl CompositeDeviceInterface {
     async fn intercept_mode(&self) -> fdo::Result<u32> {
         let (sender, mut receiver) = mpsc::channel::<InterceptMode>(1);
         self.tx
-            .send(Command::GetInterceptMode(sender))
+            .send_timeout(
+                Command::GetInterceptMode(sender),
+                Duration::from_millis(500),
+            )
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
         let Some(mode) = receiver.recv().await else {
@@ -361,7 +379,7 @@ impl CompositeDeviceInterface {
             _ => InterceptMode::None,
         };
         self.tx
-            .send(Command::SetInterceptMode(mode))
+            .send_timeout(Command::SetInterceptMode(mode), Duration::from_millis(500))
             .await
             .map_err(|err| zbus::Error::Failure(err.to_string()))?;
         Ok(())
@@ -372,7 +390,10 @@ impl CompositeDeviceInterface {
     async fn target_devices(&self) -> fdo::Result<Vec<String>> {
         let (sender, mut receiver) = mpsc::channel::<Vec<String>>(1);
         self.tx
-            .send(Command::GetTargetDevicePaths(sender))
+            .send_timeout(
+                Command::GetTargetDevicePaths(sender),
+                Duration::from_millis(500),
+            )
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
         let Some(paths) = receiver.recv().await else {
@@ -387,7 +408,10 @@ impl CompositeDeviceInterface {
     async fn dbus_devices(&self) -> fdo::Result<Vec<String>> {
         let (sender, mut receiver) = mpsc::channel::<Vec<String>>(1);
         self.tx
-            .send(Command::GetDBusDevicePaths(sender))
+            .send_timeout(
+                Command::GetDBusDevicePaths(sender),
+                Duration::from_millis(500),
+            )
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))?;
         let Some(paths) = receiver.recv().await else {

--- a/src/dbus/interface/target/keyboard.rs
+++ b/src/dbus/interface/target/keyboard.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use tokio::sync::mpsc;
 use zbus::fdo;
 use zbus_macros::interface;
@@ -41,7 +43,7 @@ impl TargetKeyboardInterface {
 
         // Write the event to the virtual device
         self.command_tx
-            .send(TargetCommand::WriteEvent(event))
+            .send_timeout(TargetCommand::WriteEvent(event), Duration::from_millis(500))
             .await
             .map_err(|err| fdo::Error::Failed(err.to_string()))?;
 

--- a/src/input/manager.rs
+++ b/src/input/manager.rs
@@ -4,7 +4,6 @@ use std::fs;
 use std::time::Duration;
 
 use thiserror::Error;
-use tokio::sync::broadcast;
 use tokio::sync::mpsc;
 use zbus::zvariant::ObjectPath;
 use zbus::Connection;
@@ -36,6 +35,7 @@ use crate::input::target::steam_deck::SteamDeckDevice;
 use crate::input::target::xb360::XBox360Controller;
 use crate::input::target::TargetDeviceType;
 use crate::procfs;
+use crate::udev;
 use crate::watcher;
 use crate::watcher::WatchEvent;
 
@@ -44,7 +44,7 @@ use super::target::TargetCommand;
 const DEV_PATH: &str = "/dev";
 const INPUT_PATH: &str = "/dev/input";
 const IIO_PATH: &str = "/sys/bus/iio/devices";
-const BUFFER_SIZE: usize = 1024;
+const BUFFER_SIZE: usize = 20480;
 
 #[derive(Error, Debug)]
 pub enum ManagerError {
@@ -59,13 +59,6 @@ pub enum ManagerError {
 /// dispatched as they come in.
 #[derive(Debug, Clone)]
 pub enum ManagerCommand {
-    SourceDeviceAdded {
-        id: String,
-        info: SourceDeviceInfo,
-    },
-    SourceDeviceRemoved {
-        id: String,
-    },
     EventDeviceAdded {
         name: String,
     },
@@ -133,10 +126,10 @@ pub struct Manager {
     /// The transmit side of the [rx] channel used to send [Command] messages.
     /// This can be cloned to allow child objects to communicate up to the
     /// manager.
-    tx: broadcast::Sender<ManagerCommand>,
+    tx: mpsc::Sender<ManagerCommand>,
     /// The receive side of the channel used to listen for [Command] messages
     /// from other objects.
-    rx: broadcast::Receiver<ManagerCommand>,
+    rx: mpsc::Receiver<ManagerCommand>,
     /// Mapping of source devices to their SourceDevice objects.
     /// E.g. {"evdev://event0": <SourceDevice>}
     source_devices: HashMap<String, SourceDevice>,
@@ -167,7 +160,7 @@ pub struct Manager {
 impl Manager {
     /// Returns a new instance of Gamepad Manager
     pub fn new(conn: Connection) -> Manager {
-        let (tx, rx) = broadcast::channel(BUFFER_SIZE);
+        let (tx, rx) = mpsc::channel(BUFFER_SIZE);
 
         log::debug!("Loading DMI data");
         let dmi_data = get_dmi_data();
@@ -199,7 +192,7 @@ impl Manager {
         self.listen_on_dbus().await?;
 
         // Loop and listen for command events
-        while let Ok(cmd) = self.rx.recv().await {
+        while let Some(cmd) = self.rx.recv().await {
             log::debug!("Received command: {:?}", cmd);
             match cmd {
                 ManagerCommand::EventDeviceAdded { name } => {
@@ -237,16 +230,6 @@ impl Manager {
                         log::error!("Error creating composite device: {:?}", e);
                     }
                 }
-                ManagerCommand::SourceDeviceAdded { id, info } => {
-                    if let Err(e) = self.on_source_device_added(id, info).await {
-                        log::error!("Error handling added source device: {:?}", e);
-                    }
-                }
-                ManagerCommand::SourceDeviceRemoved { id } => {
-                    if let Err(e) = self.on_source_device_removed(id).await {
-                        log::error!("Error handling removed source device: {:?}", e);
-                    }
-                }
                 ManagerCommand::CompositeDeviceStopped(path) => {
                     if let Err(e) = self.on_composite_device_stopped(path).await {
                         log::error!("Error handling stopped composite device: {:?}", e);
@@ -254,6 +237,7 @@ impl Manager {
                 }
                 ManagerCommand::CreateTargetDevice { kind, sender } => {
                     // Create the target device
+                    log::debug!("Got request to create target device: {kind}");
                     let device = match self.create_and_start_target_device(kind.as_str()).await {
                         Ok(device) => device,
                         Err(err) => {
@@ -263,6 +247,7 @@ impl Manager {
                             continue;
                         }
                     };
+                    log::debug!("Created target device: {kind}");
 
                     // Get the DBus path to the target device
                     let path = device.keys().next().cloned();
@@ -276,12 +261,14 @@ impl Manager {
                     if let Err(e) = sender.send(response).await {
                         log::error!("Failed to send response: {e:?}");
                     }
+                    log::debug!("Finished creating target device: {kind}");
                 }
                 ManagerCommand::AttachTargetDevice {
                     target_path,
                     composite_path,
                     sender,
                 } => {
+                    log::debug!("Got request to attach target device {target_path} to device: {composite_path}");
                     let Some(target) = self.target_devices.get(&target_path) else {
                         let err = ManagerError::AttachTargetDeviceFailed(
                             "Failed to find target device".into(),
@@ -316,8 +303,10 @@ impl Manager {
                     if let Err(e) = sender.send(Ok(())).await {
                         log::error!("Failed to send response: {e:?}");
                     }
+                    log::debug!("Finished handling attach request for: {target_path}");
                 }
                 ManagerCommand::StopTargetDevice { path } => {
+                    log::debug!("Got request to stop target device: {path}");
                     let Some(target) = self.target_devices.get(&path) else {
                         log::error!("Failed to find target device: {path}");
                         continue;
@@ -325,6 +314,7 @@ impl Manager {
                     if let Err(e) = target.send(TargetCommand::Stop).await {
                         log::error!("Failed to send stop command to target device {path}: {e:?}");
                     }
+                    log::debug!("Finished handling stop target device request for {path}");
                 }
                 ManagerCommand::TargetDeviceStopped { path } => {
                     log::debug!("Target device stopped: {path}");
@@ -532,7 +522,7 @@ impl Manager {
             let target = target.clone();
             tokio::task::spawn(async move {
                 target.closed().await;
-                if let Err(e) = tx.send(ManagerCommand::TargetDeviceStopped { path }) {
+                if let Err(e) = tx.send(ManagerCommand::TargetDeviceStopped { path }).await {
                     log::error!("Failed to target device stopped: {e:?}");
                 }
             });
@@ -643,7 +633,10 @@ impl Manager {
                 log::error!("Error running device: {:?}", e);
             }
             log::debug!("Composite device stopped running: {:?}", dbus_path);
-            if let Err(e) = tx.send(ManagerCommand::CompositeDeviceStopped(dbus_path)) {
+            if let Err(e) = tx
+                .send(ManagerCommand::CompositeDeviceStopped(dbus_path))
+                .await
+            {
                 log::error!("Error sending composite device stopped: {:?}", e);
             }
         });
@@ -667,10 +660,19 @@ impl Manager {
 
         // Remove the DBus interface
         let dbus_path = ObjectPath::from_string_unchecked(path.clone());
-        self.dbus
-            .object_server()
-            .remove::<CompositeDeviceInterface, ObjectPath>(dbus_path)
-            .await?;
+        let conn = self.dbus.clone();
+        tokio::task::spawn(async move {
+            log::debug!("Stopping dbus interface: {dbus_path}");
+            let result = conn
+                .object_server()
+                .remove::<CompositeDeviceInterface, ObjectPath>(dbus_path.clone())
+                .await;
+            if let Err(e) = result {
+                log::error!("Failed to remove dbus interface {dbus_path}: {e:?}");
+            } else {
+                log::debug!("Stopped dbus interface: {dbus_path}");
+            }
+        });
 
         // Find any source devices that were in use by the composite device
         let mut to_remove = Vec::new();
@@ -1044,6 +1046,7 @@ impl Manager {
         log::debug!("Event device added: {}", handler);
 
         // Look up the connected device using procfs
+        log::debug!("Finding device in procfs: {handler}");
         let mut info: Option<procfs::device::Device> = None;
         let devices = procfs::device::get_all()?;
         for device in devices {
@@ -1059,23 +1062,34 @@ impl Manager {
         };
 
         // Create a DBus interface for the event device
-        SourceEventDeviceInterface::listen_on_dbus(
-            self.dbus.clone(),
-            handler.clone(),
-            info.clone(),
-        )
-        .await?;
-
-        // Signal that a source device was added
-        let id = format!("evdev://{}", handler);
-        self.tx.send(ManagerCommand::SourceDeviceAdded {
-            id: id.clone(),
-            info: SourceDeviceInfo::EvdevDeviceInfo(info),
-        })?;
+        log::debug!("Attempting to listen on dbus for {handler}");
+        let conn = self.dbus.clone();
+        let hand = handler.clone();
+        let inf = info.clone();
+        tokio::task::spawn(async move {
+            let result = SourceEventDeviceInterface::listen_on_dbus(conn, hand, inf).await;
+            if let Err(e) = result {
+                log::error!("Error creating source evdev dbus interface: {e:?}");
+            }
+            log::debug!("Finished adding source device on dbus");
+        });
 
         // Add the device as a source device
+        let id = format!("evdev://{}", handler);
         let path = source::evdev::get_dbus_path(handler.clone());
-        self.source_device_dbus_paths.insert(id, path);
+        self.source_device_dbus_paths.insert(id.clone(), path);
+
+        // Check to see if the device is virtual
+        if info.is_virtual() {
+            log::debug!("{} is virtual, skipping consideration.", info.name);
+            return Ok(());
+        }
+
+        // Signal that a source device was added
+        log::debug!("Spawing task to add source device");
+        self.on_source_device_added(id, SourceDeviceInfo::EvdevDeviceInfo(info))
+            .await?;
+        log::debug!("Finished adding event device {handler}");
 
         Ok(())
     }
@@ -1089,13 +1103,23 @@ impl Manager {
         // Remove the DBus interface
         let path = source::evdev::get_dbus_path(handler);
         let path = ObjectPath::from_string_unchecked(path.clone());
-        self.dbus
-            .object_server()
-            .remove::<SourceEventDeviceInterface, ObjectPath>(path.clone())
-            .await?;
+        let conn = self.dbus.clone();
+        tokio::task::spawn(async move {
+            log::debug!("Stopping dbus interface: {path}");
+            let result = conn
+                .object_server()
+                .remove::<SourceEventDeviceInterface, ObjectPath>(path.clone())
+                .await;
+            if let Err(e) = result {
+                log::error!("Failed to remove dbus interface {path}: {e:?}");
+            } else {
+                log::debug!("Stopped dbus interface: {path}");
+            }
+        });
 
         // Signal that a source device was removed
-        self.tx.send(ManagerCommand::SourceDeviceRemoved { id })?;
+        self.source_device_dbus_paths.remove(&id);
+        self.on_source_device_removed(id).await?;
 
         Ok(())
     }
@@ -1103,31 +1127,36 @@ impl Manager {
     /// Called when a hidraw device (e.g. /dev/hidraw0) is added
     async fn on_hidraw_added(&mut self, name: String) -> Result<(), Box<dyn Error>> {
         log::debug!("HIDRaw added: {}", name);
-        let path = format!("/dev/{}", name);
+        let dev_path = format!("/dev/{}", name);
 
         // Look up the connected device using hidapi
         let devices = hidraw::list_devices()?;
         let device = devices
             .iter()
-            .find(|dev| dev.path().to_string_lossy() == path)
+            .find(|dev| dev.path().to_string_lossy() == dev_path)
             .cloned();
         let Some(info) = device else {
-            return Err(format!("Failed to find device information for: {}", path).into());
+            return Err(format!("Failed to find device information for: {}", dev_path).into());
         };
+
+        // Look up the connected device using udev
+        let device_info = udev::get_device(dev_path.clone()).await?;
 
         // Create a DBus interface for the hidraw device
         SourceHIDRawInterface::listen_on_dbus(self.dbus.clone(), info.clone()).await?;
 
-        // Signal that a source device was added
-        let id = format!("hidraw://{}", name);
-        self.tx.send(ManagerCommand::SourceDeviceAdded {
-            id: id.clone(),
-            info: SourceDeviceInfo::HIDRawDeviceInfo(info),
-        })?;
-
         // Add the device as a source device
-        let path = source::hidraw::get_dbus_path(path);
-        self.source_device_dbus_paths.insert(id, path);
+        let id = format!("hidraw://{}", name);
+        let path = source::hidraw::get_dbus_path(dev_path.clone());
+        self.source_device_dbus_paths.insert(id.clone(), path);
+
+        // Check to see if the device is virtual
+        if device_info.is_virtual() {
+            log::debug!("{} is virtual, skipping consideration.", dev_path);
+            return Ok(());
+        }
+        self.on_source_device_added(id, SourceDeviceInfo::HIDRawDeviceInfo(info))
+            .await?;
 
         Ok(())
     }
@@ -1138,8 +1167,8 @@ impl Manager {
         let id = format!("hidraw://{}", name);
 
         // Signal that a source device was removed
-        self.tx
-            .send(ManagerCommand::SourceDeviceRemoved { id: id.clone() })?;
+        self.source_device_dbus_paths.remove(&id);
+        self.on_source_device_removed(id).await?;
 
         Ok(())
     }
@@ -1164,14 +1193,13 @@ impl Manager {
 
         // Signal that a source device was added
         let id = format!("iio://{}", id);
-        self.tx.send(ManagerCommand::SourceDeviceAdded {
-            id: id.clone(),
-            info: SourceDeviceInfo::IIODeviceInfo(info),
-        })?;
+        let identity = id.clone();
+        self.on_source_device_added(id, SourceDeviceInfo::IIODeviceInfo(info))
+            .await?;
 
         // Add the device as a source device
         let path = source::iio::get_dbus_path(path);
-        self.source_device_dbus_paths.insert(id, path);
+        self.source_device_dbus_paths.insert(identity, path);
 
         Ok(())
     }
@@ -1180,10 +1208,8 @@ impl Manager {
     async fn on_iio_removed(&mut self, id: String) -> Result<(), Box<dyn Error>> {
         log::debug!("IIO device removed: {}", id);
         let id = format!("iio://{}", id);
+        self.on_source_device_removed(id).await?;
 
-        // Signal that a source device was removed
-        self.tx
-            .send(ManagerCommand::SourceDeviceRemoved { id: id.clone() })?;
         Ok(())
     }
 
@@ -1196,7 +1222,7 @@ impl Manager {
                 return Err("Devices exceeded maximum of 2048".into());
             }
             let path = format!("{BUS_TARGETS_PREFIX}/{kind}{i}");
-            if self.target_devices.get(&path).is_some() {
+            if self.target_devices.contains_key(&path) {
                 i += 1;
                 continue;
             }
@@ -1213,7 +1239,7 @@ impl Manager {
                 return "Devices exceeded".to_string();
             }
             let path = format!("{}/CompositeDevice{}", BUS_PREFIX, i);
-            if self.composite_devices.get(&path).is_some() {
+            if self.composite_devices.contains_key(&path) {
                 i += 1;
                 continue;
             }
@@ -1242,17 +1268,18 @@ impl Manager {
                     // Create events
                     WatchEvent::Create { name, base_path } => {
                         if base_path == INPUT_PATH && name.starts_with("event") {
-                            let result = cmd_tx.send(ManagerCommand::EventDeviceAdded { name });
+                            let result =
+                                cmd_tx.send(ManagerCommand::EventDeviceAdded { name }).await;
                             if let Err(e) = result {
                                 log::error!("Unable to send command: {:?}", e);
                             }
                         } else if name.starts_with("hidraw") {
-                            let result = cmd_tx.send(ManagerCommand::HIDRawAdded { name });
+                            let result = cmd_tx.send(ManagerCommand::HIDRawAdded { name }).await;
                             if let Err(e) = result {
                                 log::error!("Unable to send command: {:?}", e);
                             }
                         } else if base_path == IIO_PATH {
-                            let result = cmd_tx.send(ManagerCommand::IIODeviceAdded { name });
+                            let result = cmd_tx.send(ManagerCommand::IIODeviceAdded { name }).await;
                             if let Err(e) = result {
                                 log::error!("Unable to send command: {:?}", e);
                             }
@@ -1261,17 +1288,20 @@ impl Manager {
                     // Delete events
                     WatchEvent::Delete { name, base_path } => {
                         if base_path == INPUT_PATH && name.starts_with("event") {
-                            let result = cmd_tx.send(ManagerCommand::EventDeviceRemoved { name });
+                            let result = cmd_tx
+                                .send(ManagerCommand::EventDeviceRemoved { name })
+                                .await;
                             if let Err(e) = result {
                                 log::error!("Unable to send command: {:?}", e);
                             }
                         } else if name.starts_with("hidraw") {
-                            let result = cmd_tx.send(ManagerCommand::HIDRawRemoved { name });
+                            let result = cmd_tx.send(ManagerCommand::HIDRawRemoved { name }).await;
                             if let Err(e) = result {
                                 log::error!("Unable to send command: {:?}", e);
                             }
                         } else if base_path == IIO_PATH {
-                            let result = cmd_tx.send(ManagerCommand::IIODeviceRemoved { name });
+                            let result =
+                                cmd_tx.send(ManagerCommand::IIODeviceRemoved { name }).await;
                             if let Err(e) = result {
                                 log::error!("Unable to send command: {:?}", e);
                             }

--- a/src/input/source/mod.rs
+++ b/src/input/source/mod.rs
@@ -1,8 +1,9 @@
 use std::{error::Error, sync::mpsc::Sender};
 
 use ::evdev::FFEffectData;
+use tokio::sync::mpsc;
 
-use super::output_event::OutputEvent;
+use super::{capability::Capability, output_event::OutputEvent};
 
 pub mod evdev;
 pub mod hidraw;
@@ -14,6 +15,53 @@ pub enum SourceDevice {
     EventDevice(evdev::EventDevice),
     HIDRawDevice(hidraw::HIDRawDevice),
     IIODevice(iio::IIODevice),
+}
+
+impl SourceDevice {
+    /// Returns a unique identifier for the source device.
+    pub fn get_id(&self) -> String {
+        match self {
+            SourceDevice::EventDevice(device) => device.get_id(),
+            SourceDevice::HIDRawDevice(device) => device.get_id(),
+            SourceDevice::IIODevice(device) => device.get_id(),
+        }
+    }
+
+    /// Returns a transmitter channel that can be used to send events to this device
+    pub fn transmitter(&self) -> mpsc::Sender<SourceCommand> {
+        match self {
+            SourceDevice::EventDevice(device) => device.transmitter(),
+            SourceDevice::HIDRawDevice(device) => device.transmitter(),
+            SourceDevice::IIODevice(device) => device.transmitter(),
+        }
+    }
+
+    /// Run the source device
+    pub async fn run(&mut self) -> Result<(), Box<dyn Error>> {
+        match self {
+            SourceDevice::EventDevice(device) => device.run().await,
+            SourceDevice::HIDRawDevice(device) => device.run().await,
+            SourceDevice::IIODevice(device) => device.run().await,
+        }
+    }
+
+    /// Returns the capabilities that this source device can fulfill.
+    pub fn get_capabilities(&self) -> Result<Vec<Capability>, Box<dyn Error>> {
+        match self {
+            SourceDevice::EventDevice(device) => device.get_capabilities(),
+            SourceDevice::HIDRawDevice(device) => device.get_capabilities(),
+            SourceDevice::IIODevice(device) => device.get_capabilities(),
+        }
+    }
+
+    /// Returns the full path to the device handler (e.g. /dev/input/event3, /dev/hidraw0)
+    pub fn get_device_path(&self) -> String {
+        match self {
+            SourceDevice::EventDevice(device) => device.get_device_path(),
+            SourceDevice::HIDRawDevice(device) => device.get_device_path(),
+            SourceDevice::IIODevice(device) => device.get_device_path(),
+        }
+    }
 }
 
 /// A [SourceCommand] is a message that can be sent to a [SourceDevice] over

--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -137,6 +137,7 @@ impl DualSenseDevice {
 
     /// Creates a new instance of the dbus device interface on DBus.
     pub async fn listen_on_dbus(&mut self, path: String) -> Result<(), Box<dyn Error>> {
+        log::debug!("Starting dbus interface on {path}");
         let conn = self.conn.clone();
         self.dbus_path = Some(path.clone());
 
@@ -152,11 +153,15 @@ impl DualSenseDevice {
         };
 
         tokio::spawn(async move {
+            log::debug!("Starting dbus interface: {path}");
             let iface = TargetGamepadInterface::new(name);
-            if let Err(e) = conn.object_server().at(path, iface).await {
-                log::error!("Failed to setup DBus interface for Gamepad device: {:?}", e);
+            if let Err(e) = conn.object_server().at(path.clone(), iface).await {
+                log::debug!("Failed to start dbus interface {path}: {e:?}");
+            } else {
+                log::debug!("Started dbus interface on {path}");
             }
         });
+
         Ok(())
     }
 
@@ -191,18 +196,31 @@ impl DualSenseDevice {
                 break;
             }
         }
-
         log::debug!("Stopped listening for events");
-        device.destroy()?;
 
         // Remove the DBus interface
         if let Some(path) = self.dbus_path.clone() {
-            log::debug!("Removing DBus interface for {path}");
-            self.conn
-                .object_server()
-                .remove::<TargetGamepadInterface, String>(path)
-                .await?;
+            let conn = self.conn.clone();
+            let path = path.clone();
+            tokio::task::spawn(async move {
+                log::debug!("Stopping dbus interface for {path}");
+                let result = conn
+                    .object_server()
+                    .remove::<TargetGamepadInterface, String>(path.clone())
+                    .await;
+                if let Err(e) = result {
+                    log::error!("Failed to stop dbus interface {path}: {e:?}");
+                } else {
+                    log::debug!("Stopped dbus interface for {path}");
+                }
+            });
         }
+
+        log::debug!("Destroying device");
+        if let Err(e) = device.destroy() {
+            log::error!("Error destroying device: {e:?}");
+        }
+        log::debug!("Destroyed device");
 
         Ok(())
     }

--- a/src/input/target/gamepad.rs
+++ b/src/input/target/gamepad.rs
@@ -74,12 +74,16 @@ impl GenericGamepad {
 
     /// Creates a new instance of the dbus device interface on DBus.
     pub async fn listen_on_dbus(&mut self, path: String) -> Result<(), Box<dyn Error>> {
+        log::debug!("Starting dbus interface on {path}");
         let conn = self.conn.clone();
         self.dbus_path = Some(path.clone());
         tokio::spawn(async move {
+            log::debug!("Starting dbus interface: {path}");
             let iface = TargetGamepadInterface::new("Gamepad".into());
-            if let Err(e) = conn.object_server().at(path, iface).await {
-                log::error!("Failed to setup DBus interface for Gamepad device: {:?}", e);
+            if let Err(e) = conn.object_server().at(path.clone(), iface).await {
+                log::debug!("Failed to start dbus interface {path}: {e:?}");
+            } else {
+                log::debug!("Started dbus interface on {path}");
             }
         });
         Ok(())
@@ -135,11 +139,20 @@ impl GenericGamepad {
 
         // Remove the DBus interface
         if let Some(path) = self.dbus_path.clone() {
-            log::debug!("Removing DBus interface for {path}");
-            self.conn
-                .object_server()
-                .remove::<TargetGamepadInterface, String>(path)
-                .await?;
+            let conn = self.conn.clone();
+            let path = path.clone();
+            tokio::task::spawn(async move {
+                log::debug!("Stopping dbus interface for {path}");
+                let result = conn
+                    .object_server()
+                    .remove::<TargetGamepadInterface, String>(path.clone())
+                    .await;
+                if let Err(e) = result {
+                    log::error!("Failed to stop dbus interface {path}: {e:?}");
+                } else {
+                    log::debug!("Stopped dbus interface for {path}");
+                }
+            });
         }
 
         Ok(())

--- a/src/input/target/keyboard.rs
+++ b/src/input/target/keyboard.rs
@@ -60,13 +60,17 @@ impl KeyboardDevice {
 
     /// Creates a new instance of the device interface on DBus.
     pub async fn listen_on_dbus(&mut self, path: String) -> Result<(), Box<dyn Error>> {
+        log::debug!("Starting dbus interface on {path}");
         let conn = self.conn.clone();
         self.dbus_path = Some(path.clone());
         let tx = self.tx.clone();
         tokio::spawn(async move {
+            log::debug!("Starting dbus interface: {path}");
             let iface = TargetKeyboardInterface::new(tx);
-            if let Err(e) = conn.object_server().at(path, iface).await {
-                log::error!("Failed to setup DBus interface for device: {:?}", e);
+            if let Err(e) = conn.object_server().at(path.clone(), iface).await {
+                log::debug!("Failed to start dbus interface {path}: {e:?}");
+            } else {
+                log::debug!("Started dbus interface on {path}");
             }
         });
         Ok(())
@@ -109,11 +113,20 @@ impl KeyboardDevice {
 
         // Remove the DBus interface
         if let Some(path) = self.dbus_path.clone() {
-            log::debug!("Removing DBus interface");
-            self.conn
-                .object_server()
-                .remove::<TargetKeyboardInterface, String>(path)
-                .await?;
+            let conn = self.conn.clone();
+            let path = path.clone();
+            tokio::task::spawn(async move {
+                log::debug!("Stopping dbus interface for {path}");
+                let result = conn
+                    .object_server()
+                    .remove::<TargetKeyboardInterface, String>(path.clone())
+                    .await;
+                if let Err(e) = result {
+                    log::error!("Failed to stop dbus interface {path}: {e:?}");
+                } else {
+                    log::debug!("Stopped dbus interface for {path}");
+                }
+            });
         }
 
         Ok(())

--- a/src/procfs/device.rs
+++ b/src/procfs/device.rs
@@ -48,6 +48,18 @@ impl Device {
             bitmaps: Vec::new(),
         }
     }
+
+    /// Returns true if this procfs device is virtual
+    pub fn is_virtual(&self) -> bool {
+        if !self.phys_path.is_empty() {
+            return false;
+        }
+
+        if self.sysfs_path.contains("/devices/virtual") {
+            return true;
+        }
+        false
+    }
 }
 
 /// Returns a list of sysfs input devices that are currently detected. This

--- a/src/udev/device.rs
+++ b/src/udev/device.rs
@@ -36,6 +36,11 @@ pub struct Device {
 }
 
 impl Device {
+    /// Returns true if the given device is virtual
+    pub fn is_virtual(&self) -> bool {
+        self.path.starts_with("/devices/virtual")
+    }
+
     /// Returns the parent sysfs device path
     pub fn get_parent(&self) -> Option<String> {
         let path = format!("/sys{}/device", self.path.clone());
@@ -94,7 +99,7 @@ impl Device {
     pub fn get_vendor_id(&self) -> Option<String> {
         let path = format!("/sys{}/device/id/vendor", self.path.clone());
         let Some(id) = fs::read_to_string(path).ok() else {
-              return None;
+            return None;
         };
         Some(id.replace('\n', ""))
     }
@@ -104,7 +109,7 @@ impl Device {
     pub fn get_product_id(&self) -> Option<String> {
         let path = format!("/sys{}/device/id/product", self.path.clone());
         let Some(id) = fs::read_to_string(path).ok() else {
-              return None;
+            return None;
         };
         Some(id.replace('\n', ""))
     }


### PR DESCRIPTION
Additional changes:

* Update zbus to v4.2.2
* Better support for detecting virtual devices
* Add methods to `SourceDevice` enum to reduce code duplication
* Increase manager command buffer size
* Prevent target device changes while target devices are still waiting to be attached to a CompositeDevice