### PR TITLE
Fix Onexplayer AMD being recognized as intel model

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-onexplayer_amd.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-onexplayer_amd.yaml
@@ -28,6 +28,10 @@ matches:
       product_name: ONEXPLAYER
       sys_vendor: ONE-NETBOOK
       cpu_vendor: AuthenticAMD Advanced Micro Devices, Inc.
+  - dmi_data:
+      product_name: ONE XPLAYER
+      sys_vendor: ONE-NETBOOK TECHNOLOGY CO., LTD.
+      cpu_vendor: AuthenticAMD
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.


### PR DESCRIPTION
My personal Onexplayer AMD was being matched as an intel model and had incorrect mappings. This fixes it.