### PR TITLE
fix(devices): Ignore devices that aren't specified.

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/60-ps4_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-ps4_gamepad.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Sony Interactive Entertainment Wireless Controller
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+source_devices:
+  # Read events from the evdev device
+  - group: gamepad
+    evdev:
+      name: Sony Interactive Entertainment Wireless Controller
+      vendor_id: 054c
+      product_id: 09cc
+
+  # Block the hidraw device to prevent SDL usage of the device
+  - group: gamepad
+    blocked: true
+    unique: false
+    hidraw:
+      vendor_id: 0x054c
+      product_id: 0x09cc
+      interface_num: 3
+
+# The target input device(s) that the virtual device profile can use
+target_devices:
+  - ds5-edge
+  - mouse
+  - keyboard

--- a/rootfs/usr/share/inputplumber/devices/60-xbox_360_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-xbox_360_gamepad.yaml
@@ -1,0 +1,182 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Xbox 360 Gamepad
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: gamepad
+    evdev:
+      name: "Generic X-Box pad"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0079"
+      product_id: "18d4"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "03eb"
+      product_id: "{ff01,ff02}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "044f"
+      product_id: "b326"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "045e"
+      product_id: "{028e,028f}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "046d"
+      product_id: "{c21d,c21e,c21f,c242}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "056e"
+      product_id: "2004"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "05ac"
+      product_id: "055b"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "06a3"
+      product_id: "f51a"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0738"
+      product_id: "{4716,4718,4726,4728,4736,4738,4740,4758,9871,b726,b738,beef,cb02,cb03,cb29,f738}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "07ff"
+      product_id: "ffff"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0e6f"
+      product_id: "{0105,0113,011f,0131,0133,0201,0213,021f,0301,0401,0413,0501,f900}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0f0d"
+      product_id: "{000a,000c,000d,0016,001b,00dc}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "1038"
+      product_id: "{1430,1431}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "11c9"
+      product_id: "55f0"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "1209"
+      product_id: "2882"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "12ab"
+      product_id: "{0004,0301,0303}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "1430"
+      product_id: "{4748,f801}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "146b"
+      product_id: "{0601,0604}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "1532"
+      product_id: "0037"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "15e4"
+      product_id: "{3f00,3f0a,3f10}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "162e"
+      product_id: "beef"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "1689"
+      product_id: "{fd00,fd01,fe00}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "1949"
+      product_id: "041a"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "1bad"
+      product_id: "{0002,0003,0130,f016,f018,f019,f021,f023,f025,f027,f028,f02e,f036,f038,f039,f03a,f03d,f03e,f03f,f042,f080,f501,f502,f503,f504,f505,f506,f900,f901,f903,f904,f906,fa01,fd00,fd01}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "20d6"
+      product_id: "281f"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "24c6"
+      product_id: "{5000,5300,5303,530a,531a,5397,5500,5501,5502,5503,5506,5510,550d,550e,5b02,5d04,fafe}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "2563"
+      product_id: "058d"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "2dc8"
+      product_id: "{3106,3109}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "31e3"
+      product_id: "{1100,1200,1210,1220,1230,1300,1310}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "3285"
+      product_id: "0607"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "413d"
+      product_id: "2104"
+
+# The target input device(s) that the virtual device profile can use
+target_devices:
+  - gamepad
+  - mouse
+  - keyboard

--- a/rootfs/usr/share/inputplumber/devices/60-xbox_360_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-xbox_360_gamepad.yaml
@@ -38,7 +38,7 @@ source_devices:
   - group: gamepad
     evdev:
       vendor_id: "045e"
-      product_id: "{028e,028f}"
+      product_id: "{028e,028f,02a1}"
 
   - group: gamepad
     evdev:

--- a/rootfs/usr/share/inputplumber/devices/60-xbox_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-xbox_gamepad.yaml
@@ -1,0 +1,109 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Xbox Gamepad
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty,then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: gamepad
+    evdev:
+      vendor_id: "044f"
+      product_id: "0f07"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "045e"
+      product_id: "{0202,0285,0287,0288,0289}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "046d"
+      product_id: "{ca84,ca88}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "1007"
+      product_id: "107a"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "05fe"
+      product_id: "{3030,3031}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "062a"
+      product_id: "0020"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0738"
+      product_id: "{4506,4516,4520,4522,4526,4536,4540,4556,4586,4588,45ff,4743,6040}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0c12"
+      product_id: "{0005,8801,8802,8809,880a,8810,9902}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0d2f"
+      product_id: "0002"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0e4c"
+      product_id: "{1097,1103,2390,3510}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0e6f"
+      product_id: "{0003,0005,0006,0008}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0e8f"
+      product_id: "{020,3008}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0f30"
+      product_id: "{010b,0202,8888}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "102c"
+      product_id: "ff0c"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "12ab"
+      product_id: "8809"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "1430"
+      product_id: "8888"
+
+  - group: gamepad
+    evdev:
+      name: "Chinese-made Xbox Controller"
+      vendor_id: "ffff"
+      product_id: "ffff"
+
+# The target input device(s) that the virtual device profile can use
+target_devices:
+  - gamepad
+  - mouse
+  - keyboard

--- a/rootfs/usr/share/inputplumber/devices/60-xbox_one_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-xbox_one_gamepad.yaml
@@ -1,0 +1,92 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Xbox One Gamepad
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty,then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: gamepad
+    evdev:
+      name: "Microsoft X-Box One pad"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "045e"
+      product_id: "{02d1,02dd,02e3,0b00,02ea,0b12}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0738"
+      product_id: "4a01"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0e6f"
+      product_id: "{0139,013a,0146,0147,015c,0161,0162,0163,0164,0165,0246,02a0,02a1,02a2,02a4,02a6,02a7,02a8,02ab,02ad,02b3,02b8,0346}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "0f0d"
+      product_id: "{0063,0067,0078,00c5}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "10f5"
+      product_id: "7005"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "1430"
+      product_id: "079B"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "1532"
+      product_id: "{0a00,0a03,0a29}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "20d6"
+      product_id: "{2001,2009}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "2e24"
+      product_id: "0652"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "24c6"
+      product_id: "{541a,542a,543a,551a,561a,581a}"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "2dc"
+      product_id: "2000"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "2e9"
+      product_id: "0504"
+
+  - group: gamepad
+    evdev:
+      vendor_id: "328"
+      product_id: "0614"
+
+# The target input device(s) that the virtual device profile can use
+target_devices:
+  - gamepad
+  - mouse
+  - keyboard

--- a/rootfs/usr/share/inputplumber/devices/69-ignore_generic.yaml
+++ b/rootfs/usr/share/inputplumber/devices/69-ignore_generic.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Ignore Gamepads
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: gamepad
+    ignore: true
+    evdev:
+      handler: js*


### PR DESCRIPTION
- We should ignore anything we don't have a specific configuration for until we have more implementations for unusual devices. This will prevent loads of bug reports of controllers not working.