### PR TITLE
fix(LegionGo): Fix input when a single controller is detached.

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
@@ -20,54 +20,108 @@ matches:
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.
 source_devices:
-  - group: mouse # Touch Device
+  # Touchpad
+  - group: mouse # Gamepad Mode
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x6182
       interface_num: 1
-  - group: gamepad
+  - group: mouse # DInput Mode
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6184
+      interface_num: 1
+  - group: mouse # Gampead Mode
+    blocked: true
+    evdev:
+      vendor_id: "17ef"
+      product_id: "6182"
+      name: "  Legion Controller for Windows  Touchpad"
+  - group: mouse # DInput mode
+    blocked: true
+    evdev:
+      vendor_id: "17ef"
+      product_id: "6184"
+      name: "Legion-Controller 1-D6 Touchpad"
+
+  # Mouse
+  - group: mouse # DInput Mode
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6185
+      interface_num: 1
+  - group: mouse # Gamepad Mode
+    blocked: true
+    evdev:
+      vendor_id: "17ef"
+      product_id: "6182"
+      name: "  Legion Controller for Windows  Mouse"
+  - group: mouse # FPS/Dinput Mode
+    blocked: true
+    evdev:
+      vendor_id: "17ef"
+      product_id: "618[4-5]"
+      name: "Legion-Controller 1-D6 Mouse"
+  - group: mouse # FPS/Dinput Mode
+    blocked: true
+    unique: false
+    evdev:
+      vendor_id: "17ef"
+      product_id: "618[4-5]"
+      name: "Legion-Controller 1-D6"
+
+  # Keyboard
+  - group: mouse # DInput Mode
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6185
+      interface_num: 0
+  - group: keyboard # Gamepad Mode
+    blocked: true
+    evdev:
+      vendor_id: "17ef"
+      product_id: "6182"
+      name: "  Legion Controller for Windows  Keyboard"
+  - group: keyboard # FPS/DInput Mode
+    blocked: true
+    evdev:
+      vendor_id: "17ef"
+      product_id: "618[4-5]"
+      name: "Legion-Controller 1-D6 Keyboard"
+
+  # Gamepad
+  - group: gamepad # Gamepad Mode
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x6182
       interface_num: 2
-  - group: gamepad
+  - group: gamepad # Dinput Mode
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6184
+      interface_num: 0
+  - group: gamepad # Dinput Mode
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x6184
+      interface_num: 2
+  - group: gamepad # FPS Mode
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x6185
       interface_num: 2
-  - group: gamepad
+  - group: gamepad # Newer Kernels
+    evdev:
+      vendor_id: "17ef"
+      product_id: "6182"
+      name: "Lenovo Legion Controller for Windows"
+  - group: gamepad # Older Kernels
     evdev:
       vendor_id: "17ef"
       product_id: "6182"
       name: "Generic X-Box pad"
-  - group: keyboard
-    blocked: true
-    unique: false
-    evdev:
-      vendor_id: "17ef"
-      product_id: "6182"
-      name: "*Legion Controller*"
-  - group: keyboard
-    blocked: false
-    unique: false
-    evdev:
-      vendor_id: "17ef"
-      product_id: "6185"
-      name: "Legion-Controller 1-D6"
-  - group: keyboard
-    blocked: true
-    unique: true
-    evdev:
-      vendor_id: "17ef"
-      product_id: "6185"
-      name: "Legion-Controller 1-D6 Keyboard"
-  - group: keyboard
-    blocked: true
-    unique: true
-    evdev:
-      vendor_id: "17ef"
-      product_id: "6185"
-      name: "Legion-Controller 1-D6 Mouse"
+
+  # IMU
   - group: imu
     iio:
       name: accel_3d

--- a/src/drivers/iio_imu/driver.rs
+++ b/src/drivers/iio_imu/driver.rs
@@ -194,7 +194,10 @@ impl Driver {
     pub fn calculate_sample_delay(&self) -> Result<Duration, Box<dyn Error>> {
         let accel_rate = self.get_sample_rate("accel").unwrap_or(1.0);
         let gyro_rate = self.get_sample_rate("gyro").unwrap_or(1.0);
-        let sample_delay = 1.0 / accel_rate.max(gyro_rate);
+        let mut sample_delay = 1.0 / accel_rate.max(gyro_rate);
+        if sample_delay <= 0.0 {
+            sample_delay = 0.0025;
+        }
         log::debug!("Updated sample delay is: {sample_delay} seconds.");
 
         Ok(Duration::from_secs_f64(sample_delay))

--- a/src/drivers/lego/event.rs
+++ b/src/drivers/lego/event.rs
@@ -3,7 +3,6 @@
 pub enum Event {
     Button(ButtonEvent),
     MouseButton(MouseButtonEvent),
-    Gyro(GyroEvent),
     Axis(AxisEvent),
     Trigger(TriggerEvent),
     Status(StatusEvent),
@@ -148,13 +147,7 @@ pub enum TriggerEvent {
     MouseWheel(MouseWheelInput),
 }
 
-/// AccelerometerEvent has data from the accelerometer
-#[derive(Clone, Debug)]
-pub enum GyroEvent {
-    LeftGyro(GyroInput),
-    RightGyro(GyroInput),
-}
-
+/// StatusEvent has data on if controllers are in FPS mode, connected, and the battery state.
 #[derive(Clone, Debug)]
 pub enum StatusEvent {
     LeftControllerBattery(StatusInput),

--- a/src/drivers/lego/hid_report.rs
+++ b/src/drivers/lego/hid_report.rs
@@ -154,10 +154,6 @@ impl ReportType {
 // # ReportID: 4 / 0xffa00003:   60 ,  116 ,    1 ,    0 ,  100 ,    4 ,  100 ,    4 ,    1 ,    1 ,    1 ,    2 ,    2 , -128 , -128 , -128 , -128 ,    1 ,    0 ,    0 ,    0 ,    0 ,    0 ,    2 , -128 ,    0 ,    0 ,    0 ,    0 , -128 , -128 , -128 , -128 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0
 // E: 000001.919879 64 04 3c 74 01 00 64 04 64 04 01 01 01 02 02 80 80 80 80 01 00 00 00 00 00 02 80 00 00 00 00 80 80 80 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 //
-// Start
-// # ReportID: 4 / 0xffa00003:   60 ,  116 ,    1 ,    0 ,  100 ,    4 ,   99 ,    4 ,    1 ,    1 ,    1 ,    2 ,    2 , -128 , -128 , -128 , -128 ,    0 ,    0 ,    1 ,    0 ,    0 ,    0 ,    2 , -128 ,    0 ,    0 ,    0 ,    0 , -128 , -128 , -128 , -128 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0
-// E: 000003.383926 64 04 3c 74 01 00 64 04 63 04 01 01 01 02 02 80 80 80 80 00 00 01 00 00 00 02 80 00 00 00 00 80 80 80 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
-//
 // A
 // # ReportID: 4 / 0xffa00003:   60 ,  116 ,    1 ,    0 ,  100 ,    4 ,  100 ,    4 ,    1 ,    1 ,    1 ,    2 ,    2 , -128 , -128 , -128 , -128 ,    0 , -128 ,    0 ,    0 ,    0 ,    0 ,    2 , -128 ,    0 ,    0 ,    0 ,    0 , -128 , -128 , -128 , -128 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0
 // E: 000002.471810 64 04 3c 74 01 00 64 04 64 04 01 01 01 02 02 80 80 80 80 00 80 00 00 00 00 02 80 00 00 00 00 80 80 80 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
@@ -213,6 +209,10 @@ impl ReportType {
 // Select
 // # ReportID: 4 / 0xffa00003:   60 ,  116 ,    1 ,    0 ,  100 ,    4 ,   99 ,    4 ,    1 ,    1 ,    1 ,    2 ,    2 , -128 , -128 , -128 , -128 ,    0 ,    0 ,    2 ,    0 ,    0 ,    0 ,    2 , -128 ,    0 ,    0 ,    0 ,    0 , -128 , -128 , -128 , -128 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0
 // E: 000004.440004 64 04 3c 74 01 00 64 04 63 04 01 01 01 02 z02 80 80 80 80 00 00 02 00 00 00 02 80 00 00 00 00 80 80 80 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
+//
+// Start
+// # ReportID: 4 / 0xffa00003:   60 ,  116 ,    1 ,    0 ,  100 ,    4 ,   99 ,    4 ,    1 ,    1 ,    1 ,    2 ,    2 , -128 , -128 , -128 , -128 ,    0 ,    0 ,    1 ,    0 ,    0 ,    0 ,    2 , -128 ,    0 ,    0 ,    0 ,    0 , -128 , -128 , -128 , -128 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0
+// E: 000003.383926 64 04 3c 74 01 00 64 04 63 04 01 01 01 02 02 80 80 80 80 00 00 01 00 00 00 02 80 00 00 00 00 80 80 80 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 //
 // Mouse Wheel Click
 // # ReportID: 4 / 0xffa00003:   60 ,  116 ,    1 ,    0 ,  100 ,    4 ,  100 ,    4 ,    1 ,    1 ,    1 ,    2 ,    2 , -128 , -128 , -128 , -128 ,    0 ,    0 ,    0 , -128 ,    0 ,    0 ,    2 , -128 ,    0 ,    0 ,    0 ,    0 , -128 , -128 , -128 , -128 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0 ,    0
@@ -489,7 +489,7 @@ pub struct KeyboardDataReport {
 // coming from.
 //
 // DInputDataLeft
-//
+// X and Y report backwards here.
 // No Input
 // # ReportID: 7 / X:  2048 | Y:  2048 | Z:  2048 | Rz:  2048 | Hat switch:   8 | # | Button: 0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0 | Accelerator:    0 | Brake:    0 | #
 // E: 000031.877403 13 08 00 08 80 00 08 80 08 00 00 00 00 00
@@ -545,19 +545,27 @@ pub struct KeyboardDataReport {
 // Start
 // # ReportID: 7 / X:  2048 | Yz  2048 | Z:  2048 | Rz:  2048 | Hat switch:   8 | # | Button: 0  0  0  0  0  0  0  1  0  0  0  0  0  0  0  0 | Accelerator:    0 | Brake:    0 | #
 // E: 000002.754038 13 07 00 08 80 00 08 80 08 80 00 00 00 00
+//
+// # ReportID: 7 / X:  1808 | Y:  3247 | Z:  2048 | Rz:  2048 | Hat switch:   8 | # | Button: 0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0 | Accelerator:    0 | Brake:    0 | #
+// E: 000004.928909 13 07 10 f7 ca 00 08 80 08 00 00 00 00 00 caf = 3247
+// # ReportID: 7 / X:  2480 | Y:  2063 | Z:  2048 | Rz:  2048 | Hat switch:   8 | # | Button: 0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0 | Accelerator:    0 | Brake:    0 | #
+// E: 000012.289568 13 07 b0 f9 80 00 08 80 08 00 00 00 00 00 9b0 = 2480
+
 #[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
 #[packed_struct(bit_numbering = "msb0", size_bytes = "13")]
 pub struct DInputDataLeftReport {
     #[packed_field(bytes = "0")]
     pub report_id: u8,
-    #[packed_field(bytes = "1")]
-    pub report_size: u8,
 
     // Axes
-    #[packed_field(bits = "16..=27", endian = "lsb")]
-    pub l_stick_y: Integer<u16, packed_bits::Bits<12>>,
-    #[packed_field(bits = "28..=39", endian = "lsb")]
-    pub l_stick_x: Integer<u16, packed_bits::Bits<12>>,
+    #[packed_field(bytes = "1", endian = "lsb")]
+    pub l_stick_y_lg: u8,
+    #[packed_field(bits = "16..=19", endian = "lsb")]
+    pub l_stick_x_sm: Integer<u8, packed_bits::Bits<4>>,
+    #[packed_field(bits = "20..=23", endian = "lsb")]
+    pub l_stick_y_sm: Integer<u8, packed_bits::Bits<4>>,
+    #[packed_field(bytes = "3", endian = "lsb")]
+    pub l_stick_x_lg: u8,
 
     // Buttons
     #[packed_field(bits = "72")]
@@ -573,9 +581,9 @@ pub struct DInputDataLeftReport {
     #[packed_field(bits = "77")]
     pub y2: bool,
     #[packed_field(bits = "78")]
-    pub select: bool,
+    pub view: bool,
     #[packed_field(bits = "79")]
-    pub start: bool,
+    pub menu: bool,
 }
 
 // DInputDataRight
@@ -641,14 +649,16 @@ pub struct DInputDataLeftReport {
 pub struct DInputDataRightReport {
     #[packed_field(bytes = "0")]
     pub report_id: u8,
-    #[packed_field(bytes = "1")]
-    pub report_size: u8,
 
     // Axes
-    #[packed_field(bits = "16..=27", endian = "lsb")]
-    pub r_stick_y: Integer<u16, packed_bits::Bits<12>>,
-    #[packed_field(bits = "28..=39", endian = "lsb")]
-    pub r_stick_x: Integer<u16, packed_bits::Bits<12>>,
+    #[packed_field(bytes = "1", endian = "lsb")]
+    pub r_stick_y_lg: u8,
+    #[packed_field(bits = "16..=19", endian = "lsb")]
+    pub r_stick_x_sm: Integer<u8, packed_bits::Bits<4>>,
+    #[packed_field(bits = "20..=23", endian = "lsb")]
+    pub r_stick_y_sm: Integer<u8, packed_bits::Bits<4>>,
+    #[packed_field(bytes = "3", endian = "lsb")]
+    pub r_stick_x_lg: u8,
 
     // Buttons
     #[packed_field(bits = "72")]
@@ -754,7 +764,7 @@ pub struct MouseDataReport {
     pub m1: bool,
 
     // Axes
-    #[packed_field(bits = "16..=27", endian = "msb")]
+    #[packed_field(bits = "16..=27", endian = "lsb")]
     pub mouse_x: Integer<i16, packed_bits::Bits<12>>,
     #[packed_field(bits = "28..=39", endian = "msb")]
     pub mouse_y: Integer<i16, packed_bits::Bits<12>>,

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -130,7 +130,8 @@ impl HIDRawDevice {
         // Legion Go
         if self.info.vendor_id() == drivers::lego::driver::VID
             && (self.info.product_id() == drivers::lego::driver::PID
-                || self.info.product_id() == drivers::lego::driver::PID2)
+                || self.info.product_id() == drivers::lego::driver::PID2
+                || self.info.product_id() == drivers::lego::driver::PID3)
         {
             log::info!("Detected Legion Go");
             return DriverType::LegionGo;

--- a/src/input/source/iio/iio_imu.rs
+++ b/src/input/source/iio/iio_imu.rs
@@ -80,7 +80,7 @@ impl IMU {
                     let events = driver.poll()?;
                     let native_events = translate_events(events);
                     for event in native_events {
-                        log::trace!("Sending event to CompositeDevice: {:?}", event);
+                        log::trace!("Sending IMU event to CompositeDevice: {:?}", event);
                         // Don't send un-implemented events
                         if matches!(event.as_capability(), Capability::NotImplemented) {
                             continue;


### PR DESCRIPTION
- Uses the DInput report when one of the two controllers is disconnected as the device driven by the xpad driver is not present in that mode. 
- Fix the Dinput report PackedStruct
- Convert DInput axes into xinput axes ( we could reverse this math to add more fidelity in Dinput mode vice less)
- Capture more devices on the Legion go.
- Remove some types and code we are never going to use, like accel data from the controller HID report.
- Add safe default for IMU polling in the event the sample rate is 0.