### PR TITLE
fix(Capability): Block Sync events

### DIFF
--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -605,7 +605,10 @@ impl CompositeDevice {
 
         // Only send valid events to the target device(s)
         if cap == Capability::NotImplemented {
-            log::trace!("Refusing to send 'NotImplemented' event to target devices");
+            log::trace!(
+                "Refusing to send '{}' event to target devices.",
+                cap.to_string()
+            );
             return Ok(());
         }
 

--- a/src/input/source/evdev.rs
+++ b/src/input/source/evdev.rs
@@ -135,6 +135,13 @@ impl EventDevice {
     ) -> Result<(), Box<dyn Error>> {
         for event in events {
             log::trace!("Received event: {:?}", event);
+
+            // Block Sync events, we create these at the target anyway and they waste processing.
+            if event.event_type() == EventType::SYNCHRONIZATION {
+                log::trace!("Holding Sync event from propagating through the processing stack.");
+                continue;
+            }
+
             // If this is an ABS event, get the min/max info for this type of
             // event so we can normalize the value.
             let abs_info = if event.event_type() == EventType::ABSOLUTE {


### PR DESCRIPTION
Sync events do not need to be processed. All target devices submit a sync event with every emitted event and processing them adds overhead to emitting an superflous event. Block them instead.