### PR TITLE
fix(Startup): Increase delay in starting new target devices.

### DIFF
--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -1709,7 +1709,7 @@ impl CompositeDevice {
         // The dualsense controller will close the HIDRAW as the "unique" ID is the same
         // if the new and old target devices are both dualsense.
         if targets_to_stop_len > 0 {
-            tokio::time::sleep(Duration::from_millis(80)).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
         }
 
         let Some(composite_path) = self.dbus_path.clone() else {


### PR DESCRIPTION
The current delay still permits the occasional collision where the stopping target device kills the new one if the targets are the same.