### PR TITLE
fix(DualSense): Use random mac_addr for dualsense.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ log = { version = "0.4.20", features = [
 nix = { version = "0.28.0", features = ["fs"] }
 packed_struct = "0.10.1"
 procfs = "0.16.0"
+rand = "0.8.5"
 serde = { version = "1.0.192", features = ["derive"] }
 serde_yaml = "0.9.27"
 thiserror = "1.0.56"

--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -1696,20 +1696,12 @@ impl CompositeDevice {
 
         // Stop all old target devices
         let targets_to_stop = self.target_devices.clone();
-        let targets_to_stop_len = targets_to_stop.len();
         for (path, target) in targets_to_stop.into_iter() {
             log::debug!("Stopping old target device: {path}");
             self.target_devices.remove(&path);
             if let Err(e) = target.send(TargetCommand::Stop).await {
                 log::error!("Failed to stop old target device: {e:?}");
             }
-        }
-
-        // TODO: This is a cheap hack to let the target devices stop before starting more.
-        // The dualsense controller will close the HIDRAW as the "unique" ID is the same
-        // if the new and old target devices are both dualsense.
-        if targets_to_stop_len > 0 {
-            tokio::time::sleep(Duration::from_millis(80)).await;
         }
 
         let Some(composite_path) = self.dbus_path.clone() else {

--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -12,10 +12,10 @@ use std::{
 };
 
 use packed_struct::prelude::*;
+use rand::{self, Rng};
 use tokio::sync::mpsc::{self, error::TryRecvError};
 use uhid_virt::{Bus, CreateParams, OutputEvent, StreamError, UHIDDevice};
-use zbus::{fdo, Connection};
-use zbus_macros::dbus_interface;
+use zbus::Connection;
 
 use crate::{
     dbus::interface::target::gamepad::TargetGamepadInterface,
@@ -78,7 +78,21 @@ pub struct DualSenseHardware {
 impl DualSenseHardware {
     pub fn new(model: ModelType, bus_type: BusType) -> Self {
         // "e8:47:3a:d6:e7:74"
-        let mac_addr = [0x74, 0xe7, 0xd6, 0x3a, 0x47, 0xe8];
+        //let mac_addr = [0x74, 0xe7, 0xd6, 0x3a, 0x47, 0xe8];
+        let mut rng = rand::thread_rng();
+        let mac_addr: [u8; 6] = [
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+        ];
+        log::debug!(
+            "Creating new DualSense Edge device using MAC Address: {:?}",
+            mac_addr
+        );
+
         Self {
             model,
             bus_type,
@@ -89,10 +103,19 @@ impl DualSenseHardware {
 
 impl Default for DualSenseHardware {
     fn default() -> Self {
+        let mut rng = rand::thread_rng();
+        let mac_addr: [u8; 6] = [
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+            rng.gen(),
+        ];
         Self {
             model: ModelType::Normal,
             bus_type: BusType::Usb,
-            mac_addr: [0x74, 0xe7, 0xd6, 0x3a, 0x47, 0xe8],
+            mac_addr,
         }
     }
 }


### PR DESCRIPTION
- Avoids collisions when one device is starting up and another is shutting down.
replaces #127 