### PR TITLE
refactor(CompositeDevice): add CompositeDeviceClient

### DIFF
--- a/src/dbus/interface/composite_device.rs
+++ b/src/dbus/interface/composite_device.rs
@@ -9,7 +9,7 @@ use zbus_macros::interface;
 
 use crate::input::{
     capability::{Capability, Gamepad, Mouse},
-    composite_device::{Command, InterceptMode},
+    composite_device::{command::Command, InterceptMode},
     event::{native::NativeEvent, value::InputValue},
 };
 

--- a/src/input/composite_device/client.rs
+++ b/src/input/composite_device/client.rs
@@ -8,21 +8,21 @@ use crate::input::{
     target::TargetCommand,
 };
 
-use super::{Command, InterceptMode};
+use super::{CompositeCommand, InterceptMode};
 
 /// Possible errors for a composite device client
 #[derive(Error, Debug)]
 pub enum ClientError {
     #[error("failed to send command to device")]
-    SendError(SendError<Command>),
+    SendError(SendError<CompositeCommand>),
     #[error("service encountered an error processing the request")]
     ServiceError(Box<dyn std::error::Error>),
     #[error("device no longer exists")]
     ChannelClosed,
 }
 
-impl From<SendError<Command>> for ClientError {
-    fn from(err: SendError<Command>) -> Self {
+impl From<SendError<CompositeCommand>> for ClientError {
+    fn from(err: SendError<CompositeCommand>) -> Self {
         Self::SendError(err)
     }
 }
@@ -30,24 +30,24 @@ impl From<SendError<Command>> for ClientError {
 /// A client for a composite device
 #[derive(Debug, Clone)]
 pub struct CompositeDeviceClient {
-    tx: Sender<Command>,
+    tx: Sender<CompositeCommand>,
 }
 
-impl From<Sender<Command>> for CompositeDeviceClient {
-    fn from(tx: Sender<Command>) -> Self {
+impl From<Sender<CompositeCommand>> for CompositeDeviceClient {
+    fn from(tx: Sender<CompositeCommand>) -> Self {
         Self { tx }
     }
 }
 
 impl CompositeDeviceClient {
-    pub fn new(tx: Sender<Command>) -> Self {
+    pub fn new(tx: Sender<CompositeCommand>) -> Self {
         Self { tx }
     }
 
     /// Get the name of the composite device
     pub async fn get_name(&self) -> Result<String, ClientError> {
         let (tx, mut rx) = channel(1);
-        self.tx.send(Command::GetName(tx)).await?;
+        self.tx.send(CompositeCommand::GetName(tx)).await?;
         if let Some(name) = rx.recv().await {
             return Ok(name);
         }
@@ -57,21 +57,41 @@ impl CompositeDeviceClient {
     /// Process the given event from the given device
     pub async fn process_event(&self, device_id: String, event: Event) -> Result<(), ClientError> {
         self.tx
-            .send(Command::ProcessEvent(device_id, event))
+            .send(CompositeCommand::ProcessEvent(device_id, event))
             .await?;
+        Ok(())
+    }
+
+    /// Process the given event from the given device (blocking)
+    pub fn blocking_process_event(
+        &self,
+        device_id: String,
+        event: Event,
+    ) -> Result<(), ClientError> {
+        self.tx
+            .blocking_send(CompositeCommand::ProcessEvent(device_id, event))?;
         Ok(())
     }
 
     /// Process the given output event
     pub async fn process_output_event(&self, event: OutputEvent) -> Result<(), ClientError> {
-        self.tx.send(Command::ProcessOutputEvent(event)).await?;
+        self.tx
+            .send(CompositeCommand::ProcessOutputEvent(event))
+            .await?;
+        Ok(())
+    }
+
+    /// Process the given output event (blocking)
+    pub fn blocking_process_output_event(&self, event: OutputEvent) -> Result<(), ClientError> {
+        self.tx
+            .blocking_send(CompositeCommand::ProcessOutputEvent(event))?;
         Ok(())
     }
 
     /// Get capabilities from all source devices
     pub async fn get_capabilities(&self) -> Result<HashSet<Capability>, ClientError> {
         let (tx, mut rx) = channel(1);
-        self.tx.send(Command::GetCapabilities(tx)).await?;
+        self.tx.send(CompositeCommand::GetCapabilities(tx)).await?;
         if let Some(capabilities) = rx.recv().await {
             return Ok(capabilities);
         }
@@ -81,7 +101,9 @@ impl CompositeDeviceClient {
     /// Get capabilities from all target devices
     pub async fn get_target_capabilities(&self) -> Result<HashSet<Capability>, ClientError> {
         let (tx, mut rx) = channel(1);
-        self.tx.send(Command::GetTargetCapabilities(tx)).await?;
+        self.tx
+            .send(CompositeCommand::GetTargetCapabilities(tx))
+            .await?;
         if let Some(capabilities) = rx.recv().await {
             return Ok(capabilities);
         }
@@ -90,14 +112,16 @@ impl CompositeDeviceClient {
 
     /// Set the intercept mode of the composite device
     pub async fn set_intercept_mode(&self, mode: InterceptMode) -> Result<(), ClientError> {
-        self.tx.send(Command::SetInterceptMode(mode)).await?;
+        self.tx
+            .send(CompositeCommand::SetInterceptMode(mode))
+            .await?;
         Ok(())
     }
 
     /// Get the intercept mode of the composite device
     pub async fn get_intercept_mode(&self) -> Result<InterceptMode, ClientError> {
         let (tx, mut rx) = channel(1);
-        self.tx.send(Command::GetInterceptMode(tx)).await?;
+        self.tx.send(CompositeCommand::GetInterceptMode(tx)).await?;
         if let Some(mode) = rx.recv().await {
             return Ok(mode);
         }
@@ -107,7 +131,9 @@ impl CompositeDeviceClient {
     /// Get the source device paths of the composite device
     pub async fn get_source_device_paths(&self) -> Result<Vec<String>, ClientError> {
         let (tx, mut rx) = channel(1);
-        self.tx.send(Command::GetSourceDevicePaths(tx)).await?;
+        self.tx
+            .send(CompositeCommand::GetSourceDevicePaths(tx))
+            .await?;
         if let Some(paths) = rx.recv().await {
             return Ok(paths);
         }
@@ -117,7 +143,9 @@ impl CompositeDeviceClient {
     /// Get the target device paths of the composite device
     pub async fn get_target_device_paths(&self) -> Result<Vec<String>, ClientError> {
         let (tx, mut rx) = channel(1);
-        self.tx.send(Command::GetTargetDevicePaths(tx)).await?;
+        self.tx
+            .send(CompositeCommand::GetTargetDevicePaths(tx))
+            .await?;
         if let Some(paths) = rx.recv().await {
             return Ok(paths);
         }
@@ -127,7 +155,9 @@ impl CompositeDeviceClient {
     /// Get the DBus device paths of the composite device
     pub async fn get_dbus_device_paths(&self) -> Result<Vec<String>, ClientError> {
         let (tx, mut rx) = channel(1);
-        self.tx.send(Command::GetDBusDevicePaths(tx)).await?;
+        self.tx
+            .send(CompositeCommand::GetDBusDevicePaths(tx))
+            .await?;
         if let Some(paths) = rx.recv().await {
             return Ok(paths);
         }
@@ -136,13 +166,17 @@ impl CompositeDeviceClient {
 
     /// Add the given source device to the composite device
     pub async fn add_source_device(&self, info: SourceDeviceInfo) -> Result<(), ClientError> {
-        self.tx.send(Command::SourceDeviceAdded(info)).await?;
+        self.tx
+            .send(CompositeCommand::SourceDeviceAdded(info))
+            .await?;
         Ok(())
     }
 
     /// Remove the given source device from the composite device
     pub async fn remove_source_device(&self, path: String) -> Result<(), ClientError> {
-        self.tx.send(Command::SourceDeviceRemoved(path)).await?;
+        self.tx
+            .send(CompositeCommand::SourceDeviceRemoved(path))
+            .await?;
         Ok(())
     }
 
@@ -150,7 +184,9 @@ impl CompositeDeviceClient {
     /// new target devices, attach them to this device, and stop/remove any
     /// existing devices.
     pub async fn set_target_devices(&self, devices: Vec<String>) -> Result<(), ClientError> {
-        self.tx.send(Command::SetTargetDevices(devices)).await?;
+        self.tx
+            .send(CompositeCommand::SetTargetDevices(devices))
+            .await?;
         Ok(())
     }
 
@@ -159,14 +195,16 @@ impl CompositeDeviceClient {
         &self,
         devices: HashMap<String, Sender<TargetCommand>>,
     ) -> Result<(), ClientError> {
-        self.tx.send(Command::AttachTargetDevices(devices)).await?;
+        self.tx
+            .send(CompositeCommand::AttachTargetDevices(devices))
+            .await?;
         Ok(())
     }
 
     /// Get the name of the currently loaded profile
     pub async fn get_profile_name(&self) -> Result<String, ClientError> {
         let (tx, mut rx) = channel(1);
-        self.tx.send(Command::GetProfileName(tx)).await?;
+        self.tx.send(CompositeCommand::GetProfileName(tx)).await?;
         if let Some(name) = rx.recv().await {
             return Ok(name);
         }
@@ -176,7 +214,9 @@ impl CompositeDeviceClient {
     /// Load the device profile from the given path
     pub async fn load_profile_path(&self, path: String) -> Result<(), ClientError> {
         let (tx, mut rx) = channel(1);
-        self.tx.send(Command::LoadProfilePath(path, tx)).await?;
+        self.tx
+            .send(CompositeCommand::LoadProfilePath(path, tx))
+            .await?;
         if let Some(result) = rx.recv().await {
             return match result {
                 Ok(_) => Ok(()),
@@ -188,32 +228,46 @@ impl CompositeDeviceClient {
 
     /// Write the given event to the appropriate target device.
     pub async fn write_event(&self, event: NativeEvent) -> Result<(), ClientError> {
-        self.tx.send(Command::WriteEvent(event)).await?;
+        self.tx.send(CompositeCommand::WriteEvent(event)).await?;
         Ok(())
     }
 
     /// Write the given set of events as a button chord
     pub async fn write_chord(&self, events: Vec<NativeEvent>) -> Result<(), ClientError> {
-        self.tx.send(Command::WriteChordEvent(events)).await?;
+        self.tx
+            .send(CompositeCommand::WriteChordEvent(events))
+            .await?;
         Ok(())
     }
 
     /// Write the given event to the appropriate target device, bypassing intercept
     /// logic.
     pub async fn write_send_event(&self, event: NativeEvent) -> Result<(), ClientError> {
-        self.tx.send(Command::WriteSendEvent(event)).await?;
+        self.tx
+            .send(CompositeCommand::WriteSendEvent(event))
+            .await?;
+        Ok(())
+    }
+
+    /// Write the given event to the appropriate target device, bypassing intercept
+    /// logic. (blocking)
+    pub fn blocking_write_send_event(&self, event: NativeEvent) -> Result<(), ClientError> {
+        self.tx
+            .blocking_send(CompositeCommand::WriteSendEvent(event))?;
         Ok(())
     }
 
     /// Translate and write the given event to the appropriate target devices
     pub async fn handle_event(&self, event: NativeEvent) -> Result<(), ClientError> {
-        self.tx.send(Command::HandleEvent(event)).await?;
+        self.tx.send(CompositeCommand::HandleEvent(event)).await?;
         Ok(())
     }
 
     /// Remove the given event type from list of recently translated events
     pub async fn remove_recent_event(&self, capability: Capability) -> Result<(), ClientError> {
-        self.tx.send(Command::RemoveRecentEvent(capability)).await?;
+        self.tx
+            .send(CompositeCommand::RemoveRecentEvent(capability))
+            .await?;
         Ok(())
     }
 
@@ -225,14 +279,17 @@ impl CompositeDeviceClient {
         target_cap: Capability,
     ) -> Result<(), ClientError> {
         self.tx
-            .send(Command::SetInterceptActivation(activation_caps, target_cap))
+            .send(CompositeCommand::SetInterceptActivation(
+                activation_caps,
+                target_cap,
+            ))
             .await?;
         Ok(())
     }
 
     /// Stop the composite device
     pub async fn stop(&self) -> Result<(), ClientError> {
-        self.tx.send(Command::Stop).await?;
+        self.tx.send(CompositeCommand::Stop).await?;
         Ok(())
     }
 }

--- a/src/input/composite_device/client.rs
+++ b/src/input/composite_device/client.rs
@@ -1,0 +1,238 @@
+use std::collections::{HashMap, HashSet};
+use thiserror::Error;
+use tokio::sync::mpsc::{channel, error::SendError, Sender};
+
+use crate::input::event::native::NativeEvent;
+use crate::input::{
+    capability::Capability, event::Event, manager::SourceDeviceInfo, output_event::OutputEvent,
+    target::TargetCommand,
+};
+
+use super::{Command, InterceptMode};
+
+/// Possible errors for a composite device client
+#[derive(Error, Debug)]
+pub enum ClientError {
+    #[error("failed to send command to device")]
+    SendError(SendError<Command>),
+    #[error("service encountered an error processing the request")]
+    ServiceError(Box<dyn std::error::Error>),
+    #[error("device no longer exists")]
+    ChannelClosed,
+}
+
+impl From<SendError<Command>> for ClientError {
+    fn from(err: SendError<Command>) -> Self {
+        Self::SendError(err)
+    }
+}
+
+/// A client for a composite device
+#[derive(Debug, Clone)]
+pub struct CompositeDeviceClient {
+    tx: Sender<Command>,
+}
+
+impl From<Sender<Command>> for CompositeDeviceClient {
+    fn from(tx: Sender<Command>) -> Self {
+        Self { tx }
+    }
+}
+
+impl CompositeDeviceClient {
+    pub fn new(tx: Sender<Command>) -> Self {
+        Self { tx }
+    }
+
+    /// Get the name of the composite device
+    pub async fn get_name(&self) -> Result<String, ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(Command::GetName(tx)).await?;
+        if let Some(name) = rx.recv().await {
+            return Ok(name);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Process the given event from the given device
+    pub async fn process_event(&self, device_id: String, event: Event) -> Result<(), ClientError> {
+        self.tx
+            .send(Command::ProcessEvent(device_id, event))
+            .await?;
+        Ok(())
+    }
+
+    /// Process the given output event
+    pub async fn process_output_event(&self, event: OutputEvent) -> Result<(), ClientError> {
+        self.tx.send(Command::ProcessOutputEvent(event)).await?;
+        Ok(())
+    }
+
+    /// Get capabilities from all source devices
+    pub async fn get_capabilities(&self) -> Result<HashSet<Capability>, ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(Command::GetCapabilities(tx)).await?;
+        if let Some(capabilities) = rx.recv().await {
+            return Ok(capabilities);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Get capabilities from all target devices
+    pub async fn get_target_capabilities(&self) -> Result<HashSet<Capability>, ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(Command::GetTargetCapabilities(tx)).await?;
+        if let Some(capabilities) = rx.recv().await {
+            return Ok(capabilities);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Set the intercept mode of the composite device
+    pub async fn set_intercept_mode(&self, mode: InterceptMode) -> Result<(), ClientError> {
+        self.tx.send(Command::SetInterceptMode(mode)).await?;
+        Ok(())
+    }
+
+    /// Get the intercept mode of the composite device
+    pub async fn get_intercept_mode(&self) -> Result<InterceptMode, ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(Command::GetInterceptMode(tx)).await?;
+        if let Some(mode) = rx.recv().await {
+            return Ok(mode);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Get the source device paths of the composite device
+    pub async fn get_source_device_paths(&self) -> Result<Vec<String>, ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(Command::GetSourceDevicePaths(tx)).await?;
+        if let Some(paths) = rx.recv().await {
+            return Ok(paths);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Get the target device paths of the composite device
+    pub async fn get_target_device_paths(&self) -> Result<Vec<String>, ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(Command::GetTargetDevicePaths(tx)).await?;
+        if let Some(paths) = rx.recv().await {
+            return Ok(paths);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Get the DBus device paths of the composite device
+    pub async fn get_dbus_device_paths(&self) -> Result<Vec<String>, ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(Command::GetDBusDevicePaths(tx)).await?;
+        if let Some(paths) = rx.recv().await {
+            return Ok(paths);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Add the given source device to the composite device
+    pub async fn add_source_device(&self, info: SourceDeviceInfo) -> Result<(), ClientError> {
+        self.tx.send(Command::SourceDeviceAdded(info)).await?;
+        Ok(())
+    }
+
+    /// Remove the given source device from the composite device
+    pub async fn remove_source_device(&self, path: String) -> Result<(), ClientError> {
+        self.tx.send(Command::SourceDeviceRemoved(path)).await?;
+        Ok(())
+    }
+
+    /// Set the given target devices on the composite device. This will create
+    /// new target devices, attach them to this device, and stop/remove any
+    /// existing devices.
+    pub async fn set_target_devices(&self, devices: Vec<String>) -> Result<(), ClientError> {
+        self.tx.send(Command::SetTargetDevices(devices)).await?;
+        Ok(())
+    }
+
+    /// Attach the given target devices to the composite device
+    pub async fn attach_target_devices(
+        &self,
+        devices: HashMap<String, Sender<TargetCommand>>,
+    ) -> Result<(), ClientError> {
+        self.tx.send(Command::AttachTargetDevices(devices)).await?;
+        Ok(())
+    }
+
+    /// Get the name of the currently loaded profile
+    pub async fn get_profile_name(&self) -> Result<String, ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(Command::GetProfileName(tx)).await?;
+        if let Some(name) = rx.recv().await {
+            return Ok(name);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Load the device profile from the given path
+    pub async fn load_profile_path(&self, path: String) -> Result<(), ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(Command::LoadProfilePath(path, tx)).await?;
+        if let Some(result) = rx.recv().await {
+            return match result {
+                Ok(_) => Ok(()),
+                Err(e) => Err(ClientError::ServiceError(e.into())),
+            };
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Write the given event to the appropriate target device.
+    pub async fn write_event(&self, event: NativeEvent) -> Result<(), ClientError> {
+        self.tx.send(Command::WriteEvent(event)).await?;
+        Ok(())
+    }
+
+    /// Write the given set of events as a button chord
+    pub async fn write_chord(&self, events: Vec<NativeEvent>) -> Result<(), ClientError> {
+        self.tx.send(Command::WriteChordEvent(events)).await?;
+        Ok(())
+    }
+
+    /// Write the given event to the appropriate target device, bypassing intercept
+    /// logic.
+    pub async fn write_send_event(&self, event: NativeEvent) -> Result<(), ClientError> {
+        self.tx.send(Command::WriteSendEvent(event)).await?;
+        Ok(())
+    }
+
+    /// Translate and write the given event to the appropriate target devices
+    pub async fn handle_event(&self, event: NativeEvent) -> Result<(), ClientError> {
+        self.tx.send(Command::HandleEvent(event)).await?;
+        Ok(())
+    }
+
+    /// Remove the given event type from list of recently translated events
+    pub async fn remove_recent_event(&self, capability: Capability) -> Result<(), ClientError> {
+        self.tx.send(Command::RemoveRecentEvent(capability)).await?;
+        Ok(())
+    }
+
+    /// Set the events to look for to activate input interception while in
+    /// "PASS" mode.
+    pub async fn set_intercept_activation(
+        &self,
+        activation_caps: Vec<Capability>,
+        target_cap: Capability,
+    ) -> Result<(), ClientError> {
+        self.tx
+            .send(Command::SetInterceptActivation(activation_caps, target_cap))
+            .await?;
+        Ok(())
+    }
+
+    /// Stop the composite device
+    pub async fn stop(&self) -> Result<(), ClientError> {
+        self.tx.send(Command::Stop).await?;
+        Ok(())
+    }
+}

--- a/src/input/composite_device/command.rs
+++ b/src/input/composite_device/command.rs
@@ -1,0 +1,44 @@
+use std::collections::{HashMap, HashSet};
+
+use tokio::sync::mpsc;
+
+use crate::input::{
+    capability::Capability,
+    event::{native::NativeEvent, Event},
+    manager::SourceDeviceInfo,
+    output_event::OutputEvent,
+    target::TargetCommand,
+};
+
+use super::InterceptMode;
+
+/// CompositeDevice commands define all the different ways to interact with [CompositeDevice]
+/// over a channel. These commands are processed in an asyncronous thread and
+/// dispatched as they come in.
+#[derive(Debug, Clone)]
+pub enum Command {
+    GetName(mpsc::Sender<String>),
+    ProcessEvent(String, Event),
+    ProcessOutputEvent(OutputEvent),
+    GetCapabilities(mpsc::Sender<HashSet<Capability>>),
+    GetTargetCapabilities(mpsc::Sender<HashSet<Capability>>),
+    SetInterceptMode(InterceptMode),
+    GetInterceptMode(mpsc::Sender<InterceptMode>),
+    GetSourceDevicePaths(mpsc::Sender<Vec<String>>),
+    GetTargetDevicePaths(mpsc::Sender<Vec<String>>),
+    GetDBusDevicePaths(mpsc::Sender<Vec<String>>),
+    SourceDeviceAdded(SourceDeviceInfo),
+    SourceDeviceStopped(String),
+    SourceDeviceRemoved(String),
+    SetTargetDevices(Vec<String>),
+    AttachTargetDevices(HashMap<String, mpsc::Sender<TargetCommand>>),
+    GetProfileName(mpsc::Sender<String>),
+    LoadProfilePath(String, mpsc::Sender<Result<(), String>>),
+    WriteEvent(NativeEvent),
+    WriteChordEvent(Vec<NativeEvent>),
+    WriteSendEvent(NativeEvent),
+    HandleEvent(NativeEvent),
+    RemoveRecentEvent(Capability),
+    SetInterceptActivation(Vec<Capability>, Capability),
+    Stop,
+}

--- a/src/input/composite_device/command.rs
+++ b/src/input/composite_device/command.rs
@@ -16,7 +16,7 @@ use super::InterceptMode;
 /// over a channel. These commands are processed in an asyncronous thread and
 /// dispatched as they come in.
 #[derive(Debug, Clone)]
-pub enum Command {
+pub enum CompositeCommand {
     GetName(mpsc::Sender<String>),
     ProcessEvent(String, Event),
     ProcessOutputEvent(OutputEvent),

--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -1,3 +1,6 @@
+pub mod client;
+pub mod command;
+
 use std::{
     borrow::Borrow,
     collections::{BTreeSet, HashMap, HashSet},
@@ -34,6 +37,8 @@ use crate::{
     udev::{hide_device, unhide_device},
 };
 
+use self::command::Command;
+
 use super::{manager::ManagerCommand, output_event::OutputEvent, source::SourceCommand};
 
 /// Size of the command channel buffer for processing input events and commands.
@@ -50,37 +55,6 @@ pub enum InterceptMode {
     Pass,
     /// Intercept all input and send nothing to the target devices
     Always,
-}
-
-/// CompositeDevice commands define all the different ways to interact with [CompositeDevice]
-/// over a channel. These commands are processed in an asyncronous thread and
-/// dispatched as they come in.
-#[derive(Debug, Clone)]
-pub enum Command {
-    GetName(mpsc::Sender<String>),
-    ProcessEvent(String, Event),
-    ProcessOutputEvent(OutputEvent),
-    GetCapabilities(mpsc::Sender<HashSet<Capability>>),
-    GetTargetCapabilities(mpsc::Sender<HashSet<Capability>>),
-    SetInterceptMode(InterceptMode),
-    GetInterceptMode(mpsc::Sender<InterceptMode>),
-    GetSourceDevicePaths(mpsc::Sender<Vec<String>>),
-    GetTargetDevicePaths(mpsc::Sender<Vec<String>>),
-    GetDBusDevicePaths(mpsc::Sender<Vec<String>>),
-    SourceDeviceAdded(SourceDeviceInfo),
-    SourceDeviceStopped(String),
-    SourceDeviceRemoved(String),
-    SetTargetDevices(Vec<String>),
-    AttachTargetDevices(HashMap<String, mpsc::Sender<TargetCommand>>),
-    GetProfileName(mpsc::Sender<String>),
-    LoadProfilePath(String, mpsc::Sender<Result<(), String>>),
-    WriteEvent(NativeEvent),
-    WriteChordEvent(Vec<NativeEvent>),
-    WriteSendEvent(NativeEvent),
-    HandleEvent(NativeEvent),
-    RemoveRecentEvent(Capability),
-    SetInterceptActivation(Vec<Capability>, Capability),
-    Stop,
 }
 
 /// A [CompositeDevice] represents any number source input devices that

--- a/src/input/source/evdev.rs
+++ b/src/input/source/evdev.rs
@@ -12,7 +12,7 @@ use crate::{
     drivers::dualsense::hid_report::SetStatePackedOutputData,
     input::{
         capability::Capability,
-        composite_device::Command,
+        composite_device::command::Command,
         event::{evdev::EvdevEvent, Event},
         output_event::OutputEvent,
     },

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -11,7 +11,7 @@ use tokio::sync::mpsc;
 use crate::{
     constants::BUS_PREFIX,
     drivers::{self},
-    input::{capability::Capability, composite_device::Command},
+    input::{capability::Capability, composite_device::command::Command},
 };
 
 use super::SourceCommand;

--- a/src/input/source/hidraw/fts3528.rs
+++ b/src/input/source/hidraw/fts3528.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     input::{
         capability::{Capability, Touch},
-        composite_device::Command,
+        composite_device::command::Command,
         event::{native::NativeEvent, value::InputValue, Event},
         source::SourceCommand,
     },

--- a/src/input/source/hidraw/lego.rs
+++ b/src/input/source/hidraw/lego.rs
@@ -13,7 +13,7 @@ use crate::{
             Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger, Mouse, MouseButton,
             Touch, Touchpad,
         },
-        composite_device::Command,
+        composite_device::command::Command,
         event::{native::NativeEvent, value::InputValue, Event},
     },
 };

--- a/src/input/source/hidraw/opineo.rs
+++ b/src/input/source/hidraw/opineo.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     input::{
         capability::{Capability, Touch, Touchpad},
-        composite_device::Command,
+        composite_device::command::Command,
         event::{native::NativeEvent, value::InputValue, Event},
     },
     udev::get_device,

--- a/src/input/source/hidraw/steam_deck.rs
+++ b/src/input/source/hidraw/steam_deck.rs
@@ -25,7 +25,7 @@ use crate::{
             Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger, Touch, TouchButton,
             Touchpad,
         },
-        composite_device::Command,
+        composite_device::command::Command,
         event::{native::NativeEvent, value::InputValue, Event},
         output_event::OutputEvent,
         source::SourceCommand,

--- a/src/input/source/iio.rs
+++ b/src/input/source/iio.rs
@@ -12,7 +12,7 @@ use crate::{
     config,
     constants::BUS_PREFIX,
     iio::device::Device,
-    input::{capability::Capability, composite_device::Command},
+    input::{capability::Capability, composite_device::command::Command},
 };
 
 use super::SourceCommand;

--- a/src/input/source/iio/accel_gyro_3d.rs
+++ b/src/input/source/iio/accel_gyro_3d.rs
@@ -8,7 +8,7 @@ use crate::{
     iio::device::Device,
     input::{
         capability::{Capability, Gamepad},
-        composite_device::Command,
+        composite_device::command::Command,
         event::{native::NativeEvent, value::InputValue, Event},
         source::SourceCommand,
     },

--- a/src/input/source/iio/bmi_imu.rs
+++ b/src/input/source/iio/bmi_imu.rs
@@ -8,7 +8,7 @@ use crate::{
     iio::device::Device,
     input::{
         capability::{Capability, Gamepad},
-        composite_device::Command,
+        composite_device::command::Command,
         event::{native::NativeEvent, value::InputValue, Event},
         source::SourceCommand,
     },

--- a/src/input/target/dbus.rs
+++ b/src/input/target/dbus.rs
@@ -42,7 +42,7 @@ pub struct DBusDevice {
     dbus_path: Option<String>,
     tx: mpsc::Sender<TargetCommand>,
     rx: mpsc::Receiver<TargetCommand>,
-    composite_tx: Option<mpsc::Sender<composite_device::Command>>,
+    composite_tx: Option<mpsc::Sender<composite_device::command::Command>>,
 }
 
 impl DBusDevice {
@@ -72,7 +72,7 @@ impl DBusDevice {
 
     /// Configures the device to send output events to the given composite device
     /// channel.
-    pub fn set_composite_device(&mut self, tx: mpsc::Sender<composite_device::Command>) {
+    pub fn set_composite_device(&mut self, tx: mpsc::Sender<composite_device::command::Command>) {
         self.composite_tx = Some(tx);
     }
 

--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -41,7 +41,7 @@ use crate::{
             Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger, Touch, TouchButton,
             Touchpad,
         },
-        composite_device::Command,
+        composite_device::command::Command,
         event::{native::NativeEvent, value::InputValue},
         output_event,
     },

--- a/src/input/target/gamepad.rs
+++ b/src/input/target/gamepad.rs
@@ -22,7 +22,7 @@ use crate::{
     dbus::interface::target::gamepad::TargetGamepadInterface,
     input::{
         capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger},
-        composite_device::Command,
+        composite_device::command::Command,
         event::{evdev::EvdevEvent, native::NativeEvent},
         output_event::{OutputEvent, UinputOutputEvent},
     },

--- a/src/input/target/keyboard.rs
+++ b/src/input/target/keyboard.rs
@@ -27,7 +27,7 @@ pub struct KeyboardDevice {
     dbus_path: Option<String>,
     tx: mpsc::Sender<TargetCommand>,
     rx: mpsc::Receiver<TargetCommand>,
-    composite_tx: Option<mpsc::Sender<composite_device::Command>>,
+    composite_tx: Option<mpsc::Sender<composite_device::command::Command>>,
 }
 
 impl KeyboardDevice {
@@ -54,7 +54,7 @@ impl KeyboardDevice {
 
     /// Configures the device to send output events to the given composite device
     /// channel.
-    pub fn set_composite_device(&mut self, tx: mpsc::Sender<composite_device::Command>) {
+    pub fn set_composite_device(&mut self, tx: mpsc::Sender<composite_device::command::Command>) {
         self.composite_tx = Some(tx);
     }
 

--- a/src/input/target/keyboard.rs
+++ b/src/input/target/keyboard.rs
@@ -12,7 +12,7 @@ use crate::{
     dbus::interface::target::keyboard::TargetKeyboardInterface,
     input::{
         capability::{Capability, Keyboard},
-        composite_device,
+        composite_device::client::CompositeDeviceClient,
         event::{evdev::EvdevEvent, native::NativeEvent},
     },
 };
@@ -27,7 +27,7 @@ pub struct KeyboardDevice {
     dbus_path: Option<String>,
     tx: mpsc::Sender<TargetCommand>,
     rx: mpsc::Receiver<TargetCommand>,
-    composite_tx: Option<mpsc::Sender<composite_device::command::Command>>,
+    composite_device: Option<CompositeDeviceClient>,
 }
 
 impl KeyboardDevice {
@@ -36,7 +36,7 @@ impl KeyboardDevice {
         Self {
             conn,
             dbus_path: None,
-            composite_tx: None,
+            composite_device: None,
             tx,
             rx,
         }
@@ -54,8 +54,8 @@ impl KeyboardDevice {
 
     /// Configures the device to send output events to the given composite device
     /// channel.
-    pub fn set_composite_device(&mut self, tx: mpsc::Sender<composite_device::command::Command>) {
-        self.composite_tx = Some(tx);
+    pub fn set_composite_device(&mut self, composite_device: CompositeDeviceClient) {
+        self.composite_device = Some(composite_device);
     }
 
     /// Creates a new instance of the device interface on DBus.
@@ -86,8 +86,8 @@ impl KeyboardDevice {
         log::debug!("Started listening for events to send");
         while let Some(command) = self.rx.recv().await {
             match command {
-                TargetCommand::SetCompositeDevice(tx) => {
-                    self.set_composite_device(tx);
+                TargetCommand::SetCompositeDevice(composite_device) => {
+                    self.set_composite_device(composite_device);
                 }
                 TargetCommand::WriteEvent(event) => {
                     //log::debug!("Got event to emit: {:?}", event);

--- a/src/input/target/mod.rs
+++ b/src/input/target/mod.rs
@@ -1,6 +1,8 @@
 use tokio::sync::mpsc::Sender;
 
-use super::{capability::Capability, composite_device::Command, event::native::NativeEvent};
+use super::{
+    capability::Capability, composite_device::command::Command, event::native::NativeEvent,
+};
 
 pub mod dbus;
 pub mod dualsense;

--- a/src/input/target/mod.rs
+++ b/src/input/target/mod.rs
@@ -1,7 +1,8 @@
 use tokio::sync::mpsc::Sender;
 
 use super::{
-    capability::Capability, composite_device::command::Command, event::native::NativeEvent,
+    capability::Capability, composite_device::client::CompositeDeviceClient,
+    event::native::NativeEvent,
 };
 
 pub mod dbus;
@@ -32,7 +33,7 @@ pub enum TargetDeviceType {
 #[derive(Debug, Clone)]
 pub enum TargetCommand {
     WriteEvent(NativeEvent),
-    SetCompositeDevice(Sender<Command>),
+    SetCompositeDevice(CompositeDeviceClient),
     GetCapabilities(Sender<Vec<Capability>>),
     Stop,
 }

--- a/src/input/target/mouse.rs
+++ b/src/input/target/mouse.rs
@@ -35,7 +35,7 @@ pub struct MouseDevice {
     dbus_path: Option<String>,
     tx: mpsc::Sender<TargetCommand>,
     rx: mpsc::Receiver<TargetCommand>,
-    composite_tx: Option<mpsc::Sender<composite_device::Command>>,
+    composite_tx: Option<mpsc::Sender<composite_device::command::Command>>,
 }
 
 impl MouseDevice {
@@ -62,7 +62,7 @@ impl MouseDevice {
 
     /// Configures the device to send output events to the given composite device
     /// channel.
-    pub fn set_composite_device(&mut self, tx: mpsc::Sender<composite_device::Command>) {
+    pub fn set_composite_device(&mut self, tx: mpsc::Sender<composite_device::command::Command>) {
         self.composite_tx = Some(tx);
     }
 

--- a/src/input/target/steam_deck.rs
+++ b/src/input/target/steam_deck.rs
@@ -57,7 +57,7 @@ pub struct SteamDeckDevice {
     tx: mpsc::Sender<TargetCommand>,
     rx: mpsc::Receiver<TargetCommand>,
     state: PackedInputDataReport,
-    composite_tx: Option<mpsc::Sender<composite_device::Command>>,
+    composite_tx: Option<mpsc::Sender<composite_device::command::Command>>,
 }
 
 impl SteamDeckDevice {
@@ -80,7 +80,7 @@ impl SteamDeckDevice {
 
     /// Configures the device to send output events to the given composite device
     /// channel.
-    pub fn set_composite_device(&mut self, tx: mpsc::Sender<composite_device::Command>) {
+    pub fn set_composite_device(&mut self, tx: mpsc::Sender<composite_device::command::Command>) {
         self.composite_tx = Some(tx);
     }
 

--- a/src/input/target/touchscreen_fts3528.rs
+++ b/src/input/target/touchscreen_fts3528.rs
@@ -40,7 +40,7 @@ pub struct Fts3528TouchscreenDevice {
     tx: mpsc::Sender<TargetCommand>,
     rx: mpsc::Receiver<TargetCommand>,
     state: PackedInputDataReport,
-    composite_tx: Option<mpsc::Sender<composite_device::Command>>,
+    composite_tx: Option<mpsc::Sender<composite_device::command::Command>>,
 }
 
 impl Fts3528TouchscreenDevice {
@@ -63,7 +63,7 @@ impl Fts3528TouchscreenDevice {
 
     /// Configures the device to send output events to the given composite device
     /// channel.
-    pub fn set_composite_device(&mut self, tx: mpsc::Sender<composite_device::Command>) {
+    pub fn set_composite_device(&mut self, tx: mpsc::Sender<composite_device::command::Command>) {
         self.composite_tx = Some(tx);
     }
 

--- a/src/input/target/xb360.rs
+++ b/src/input/target/xb360.rs
@@ -4,13 +4,12 @@ use evdev::{
     uinput::VirtualDeviceBuilder, AbsInfo, AbsoluteAxisCode, AttributeSet, FFEffectCode, KeyCode,
     UinputAbsSetup,
 };
-use tokio::sync::broadcast;
 
-use crate::input::composite_device;
+use crate::input::composite_device::client::CompositeDeviceClient;
 
 #[derive(Debug)]
 pub struct XBox360Controller {
-    _composite_tx: Option<broadcast::Sender<composite_device::command::Command>>,
+    _composite_tx: Option<CompositeDeviceClient>,
 }
 
 impl XBox360Controller {

--- a/src/input/target/xb360.rs
+++ b/src/input/target/xb360.rs
@@ -10,7 +10,7 @@ use crate::input::composite_device;
 
 #[derive(Debug)]
 pub struct XBox360Controller {
-    _composite_tx: Option<broadcast::Sender<composite_device::Command>>,
+    _composite_tx: Option<broadcast::Sender<composite_device::command::Command>>,
 }
 
 impl XBox360Controller {


### PR DESCRIPTION
This change adds a new `CompositeDeviceClient` to simplify communicating with a `CompositeDevice`. It provides helper methods for sending and receiving data over a channel.

For example, instead of doing:

```rust
tx.send(Command::ProcessEvent(device_id, event).await?;
```

we can now do:

```rust
composite_device.process_event(device_id, event).await?;
```

This is especially helpful when getting data back from a composite device.