### PR TITLE
fix(Performance): Reduce poll rate for most source devices.

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_max.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_max.yaml
@@ -6,18 +6,15 @@ version: 1
 kind: CompositeDevice
 
 # Name of the composite device mapping
-name: AYANEO Air
+name: AYN Loki Max
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty, then the source devices will *always* be checked.
 # /sys/class/dmi/id/product_name
 matches:
   - dmi_data:
-      product_name: AIR
-      sys_vendor: AYANEO
-  - dmi_data:
-      product_name: AIR Pro
-      sys_vendor: AYANEO
+      product_name: Loki Max
+      sys_vendor: ayn
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.
@@ -25,18 +22,18 @@ source_devices:
   - group: gamepad
     evdev:
       name: Microsoft X-Box 360 pad
-      phys_path: usb-0000:04:00.3-4/input0
+      phys_path: usb-0000:74:00.0-1/input0
   - group: keyboard
     evdev:
       name: AT Translated Set 2 keyboard
       phys_path: isa0060/serio0/input0
-  #- group: imu #TODO:reenable after we switch from polling
-  #  iio:
-  #    name: i2c-BMI0160:00
-  #    mount_matrix:
-  #      x: [0, -1, 0]
-  #      y: [0, 0, -1]
-  #      z: [1, 0, 0]
+  - group: imu
+    iio:
+      name: i2c-BMI0160:00
+      mount_matrix:
+        x: [1, 0, 0]
+        y: [0, 0, -1]
+        z: [0, 1, 0]
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
@@ -45,4 +42,4 @@ target_devices:
   - keyboard
 
 # The ID of a device event mapping in the 'event_maps' folder
-capability_map_id: aya3
+capability_map_id: ayn1

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_mini_pro.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_mini_pro.yaml
@@ -6,18 +6,15 @@ version: 1
 kind: CompositeDevice
 
 # Name of the composite device mapping
-name: AYANEO Air
+name: AYN Loki MiniPro
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty, then the source devices will *always* be checked.
 # /sys/class/dmi/id/product_name
 matches:
   - dmi_data:
-      product_name: AIR
-      sys_vendor: AYANEO
-  - dmi_data:
-      product_name: AIR Pro
-      sys_vendor: AYANEO
+      product_name: Loki MiniPro
+      sys_vendor: ayn
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.
@@ -25,18 +22,18 @@ source_devices:
   - group: gamepad
     evdev:
       name: Microsoft X-Box 360 pad
-      phys_path: usb-0000:04:00.3-4/input0
+      phys_path: usb-0000:04:00.4-2/input0
   - group: keyboard
     evdev:
       name: AT Translated Set 2 keyboard
       phys_path: isa0060/serio0/input0
-  #- group: imu #TODO:reenable after we switch from polling
-  #  iio:
-  #    name: i2c-BMI0160:00
-  #    mount_matrix:
-  #      x: [0, -1, 0]
-  #      y: [0, 0, -1]
-  #      z: [1, 0, 0]
+  - group: imu
+    iio:
+      name: i2c-BMI0160:00
+      mount_matrix:
+        x: [1, 0, 0]
+        y: [0, 0, -1]
+        z: [0, 1, 0]
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
@@ -45,4 +42,4 @@ target_devices:
   - keyboard
 
 # The ID of a device event mapping in the 'event_maps' folder
-capability_map_id: aya3
+capability_map_id: ayn1

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_zero.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_zero.yaml
@@ -6,20 +6,14 @@ version: 1
 kind: CompositeDevice
 
 # Name of the composite device mapping
-name: AYN Loki
+name: AYN Loki Zero
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty, then the source devices will *always* be checked.
 # /sys/class/dmi/id/product_name
 matches:
   - dmi_data:
-      product_name: Loki Max
-      sys_vendor: ayn
-  - dmi_data:
       product_name: Loki MiniPro
-      sys_vendor: ayn
-  - dmi_data:
-      product_name: Loki Zero
       sys_vendor: ayn
 
 # One or more source devices to combine into a single virtual device. The events
@@ -28,26 +22,18 @@ source_devices:
   - group: gamepad
     evdev:
       name: Microsoft X-Box 360 pad
-      phys_path: usb-0000:74:00.0-1/input0
-  - group: gamepad
-    evdev:
-      name: Microsoft X-Box 360 pad
       phys_path: usb-0000:04:00.3-4/input0
-  - group: gamepad
-    evdev:
-      name: Microsoft X-Box 360 pad
-      phys_path: usb-0000:04:00.4-2/input0
   - group: keyboard
     evdev:
       name: AT Translated Set 2 keyboard
       phys_path: isa0060/serio0/input0
-  - group: imu
-    iio:
-      name: i2c-BMI0160:00
-      mount_matrix:
-        x: [1, 0, 0]
-        y: [0, 0, -1]
-        z: [0, 1, 0]
+  #- group: imu #TODO:reenable after we switch from polling
+  #  iio:
+  #    name: i2c-BMI0160:00
+  #    mount_matrix:
+  #      x: [1, 0, 0]
+  #      y: [0, 0, -1]
+  #      z: [0, 1, 0]
 
 # The target input device(s) that the virtual device profile can use
 target_devices:

--- a/src/drivers/iio_imu/driver.rs
+++ b/src/drivers/iio_imu/driver.rs
@@ -86,7 +86,7 @@ impl Driver {
             accel_info,
             gyro,
             gyro_info,
-            sample_delay: Duration::from_micros(2500), //400Hz
+            sample_delay: Duration::from_millis(8), //125Hz
         })
     }
 
@@ -192,12 +192,13 @@ impl Driver {
     /// events again. Uses the fastest frequency set between the currently set accelerometer and
     /// gyroscope sample rates. Called automatically when the sample_rate is changed.
     pub fn calculate_sample_delay(&self) -> Result<Duration, Box<dyn Error>> {
-        let accel_rate = self.get_sample_rate("accel").unwrap_or(1.0);
-        let gyro_rate = self.get_sample_rate("gyro").unwrap_or(1.0);
-        let mut sample_delay = 1.0 / accel_rate.max(gyro_rate);
-        if sample_delay <= 0.0 {
-            sample_delay = 0.0025;
-        }
+        //let accel_rate = self.get_sample_rate("accel").unwrap_or(1.0);
+        //let gyro_rate = self.get_sample_rate("gyro").unwrap_or(1.0);
+        //let mut sample_delay = 1.0 / accel_rate.max(gyro_rate);
+        let sample_delay = 0.008;
+        //if sample_delay <= 0.0 {
+        //    sample_delay = 0.0025;
+        //}
         log::debug!("Updated sample delay is: {sample_delay} seconds.");
 
         Ok(Duration::from_secs_f64(sample_delay))

--- a/src/input/source/evdev.rs
+++ b/src/input/source/evdev.rs
@@ -24,7 +24,7 @@ use super::SourceCommand;
 /// Size of the [SourceCommand] buffer for receiving output events
 const BUFFER_SIZE: usize = 2048;
 /// How long to sleep before polling for events.
-const POLL_RATE: Duration = Duration::from_micros(1666);
+const POLL_RATE: Duration = Duration::from_millis(8);
 
 /// [EventDevice] represents an input device using the input subsystem.
 #[derive(Debug)]

--- a/src/input/target/dbus.rs
+++ b/src/input/target/dbus.rs
@@ -118,6 +118,11 @@ impl DBusDevice {
                         log::error!("Failed to send target capabilities: {e:?}");
                     }
                 }
+                TargetCommand::GetType(tx) => {
+                    if let Err(e) = tx.send("dbus".to_string()).await {
+                        log::error!("Failed to send target type: {e:?}");
+                    }
+                }
                 TargetCommand::Stop => break,
             };
         }

--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -320,6 +320,12 @@ impl DualSenseDevice {
                                 log::error!("Failed to send target capabilities: {e:?}");
                             }
                         }
+                        TargetCommand::GetType(tx) => {
+                            if let Err(e) = tx.send("ds5-edge".to_string()).await {
+                                log::error!("Failed to send target type: {e:?}");
+                            }
+                        }
+
                         TargetCommand::Stop => return Err("Device stopped".into()),
                     }
                 }

--- a/src/input/target/keyboard.rs
+++ b/src/input/target/keyboard.rs
@@ -105,6 +105,11 @@ impl KeyboardDevice {
                         log::error!("Failed to send target capabilities: {e:?}");
                     }
                 }
+                TargetCommand::GetType(tx) => {
+                    if let Err(e) = tx.send("keyboard".to_string()).await {
+                        log::error!("Failed to send target type: {e:?}");
+                    }
+                }
                 TargetCommand::Stop => break,
             };
         }

--- a/src/input/target/mod.rs
+++ b/src/input/target/mod.rs
@@ -35,5 +35,6 @@ pub enum TargetCommand {
     WriteEvent(NativeEvent),
     SetCompositeDevice(CompositeDeviceClient),
     GetCapabilities(Sender<Vec<Capability>>),
+    GetType(Sender<String>),
     Stop,
 }

--- a/src/input/target/mouse.rs
+++ b/src/input/target/mouse.rs
@@ -155,6 +155,11 @@ impl MouseDevice {
                         log::error!("Failed to send target capabilities: {e:?}");
                     }
                 }
+                TargetCommand::GetType(tx) => {
+                    if let Err(e) = tx.send("mouse".to_string()).await {
+                        log::error!("Failed to send target type: {e:?}");
+                    }
+                }
                 TargetCommand::Stop => break,
             };
         }

--- a/src/input/target/steam_deck.rs
+++ b/src/input/target/steam_deck.rs
@@ -222,6 +222,11 @@ impl SteamDeckDevice {
                         log::error!("Failed to send target capabilities: {e:?}");
                     }
                 }
+                TargetCommand::GetType(tx) => {
+                    if let Err(e) = tx.send("steam-deck".to_string()).await {
+                        log::error!("Failed to send target type: {e:?}");
+                    }
+                }
                 TargetCommand::Stop => break,
             };
         }

--- a/src/input/target/touchscreen_fts3528.rs
+++ b/src/input/target/touchscreen_fts3528.rs
@@ -215,6 +215,11 @@ impl Fts3528TouchscreenDevice {
                         log::error!("Failed to send target capabilities: {e:?}");
                     }
                 }
+                TargetCommand::GetType(tx) => {
+                    if let Err(e) = tx.send("touchscreen-fts3528".to_string()).await {
+                        log::error!("Failed to send target type: {e:?}");
+                    }
+                }
                 TargetCommand::Stop => break,
             };
         }

--- a/src/input/target/xb360.rs
+++ b/src/input/target/xb360.rs
@@ -32,7 +32,7 @@ use super::TargetCommand;
 /// Size of the [TargetCommand] buffer for receiving input events
 const BUFFER_SIZE: usize = 2048;
 /// How long to sleep before polling for events.
-const POLL_RATE: Duration = Duration::from_micros(1666);
+const POLL_RATE: Duration = Duration::from_millis(8); //125Hz is standard for xbox controllers
 
 #[derive(Debug)]
 pub struct XBox360Controller {
@@ -125,6 +125,11 @@ impl XBox360Controller {
                     let caps = self.get_capabilities();
                     if let Err(e) = tx.send(caps).await {
                         log::error!("Failed to send target capabilities: {e:?}");
+                    }
+                }
+                TargetCommand::GetType(tx) => {
+                    if let Err(e) = tx.send("xb360".to_string()).await {
+                        log::error!("Failed to send target type: {e:?}");
                     }
                 }
                 TargetCommand::Stop => break,

--- a/src/input/target/xbox_elite.rs
+++ b/src/input/target/xbox_elite.rs
@@ -32,7 +32,7 @@ use super::TargetCommand;
 /// Size of the [TargetCommand] buffer for receiving input events
 const BUFFER_SIZE: usize = 2048;
 /// How long to sleep before polling for events.
-const POLL_RATE: Duration = Duration::from_micros(1666);
+const POLL_RATE: Duration = Duration::from_millis(8); //125Hz is standard for xbox controllers
 
 #[derive(Debug)]
 pub struct XboxEliteController {
@@ -125,6 +125,11 @@ impl XboxEliteController {
                     let caps = self.get_capabilities();
                     if let Err(e) = tx.send(caps).await {
                         log::error!("Failed to send target capabilities: {e:?}");
+                    }
+                }
+                TargetCommand::GetType(tx) => {
+                    if let Err(e) = tx.send("xbox-elite".to_string()).await {
+                        log::error!("Failed to send target type: {e:?}");
                     }
                 }
                 TargetCommand::Stop => break,


### PR DESCRIPTION
- Reduces the poll rate for evdev source devices and gyro's to 125Hz. Disables gyro on low power devices (AYANEO AIR, AYN Loki Zero).
- Adds fix for bugs caused by stopping/starting the same target device type. We no longer stop a running device if it is requested to start.