### PR TITLE
refactor(SourceDevice): implement source device client for channel communication

### DIFF
--- a/src/input/source/client.rs
+++ b/src/input/source/client.rs
@@ -1,0 +1,203 @@
+use std::{sync::mpsc::channel, time::Duration};
+
+use evdev::FFEffectData;
+use thiserror::Error;
+use tokio::sync::mpsc::{
+    error::{SendError, TrySendError},
+    Sender,
+};
+
+use crate::input::output_event::OutputEvent;
+
+use super::command::SourceCommand;
+
+/// Possible errors for a source device client
+#[derive(Error, Debug)]
+pub enum ClientError {
+    #[error("failed to send command to device")]
+    SendError(SendError<SourceCommand>),
+    #[error("failed to try to send command to device")]
+    TrySendError(TrySendError<SourceCommand>),
+    #[error("service encountered an error processing the request")]
+    ServiceError(Box<dyn std::error::Error + Send + Sync>),
+    #[error("device no longer exists")]
+    ChannelClosed,
+}
+
+impl From<SendError<SourceCommand>> for ClientError {
+    fn from(err: SendError<SourceCommand>) -> Self {
+        Self::SendError(err)
+    }
+}
+
+impl From<TrySendError<SourceCommand>> for ClientError {
+    fn from(err: TrySendError<SourceCommand>) -> Self {
+        Self::TrySendError(err)
+    }
+}
+
+/// A client for communicating with a source device
+#[derive(Debug, Clone)]
+pub struct SourceDeviceClient {
+    tx: Sender<SourceCommand>,
+}
+
+impl From<Sender<SourceCommand>> for SourceDeviceClient {
+    fn from(tx: Sender<SourceCommand>) -> Self {
+        SourceDeviceClient::new(tx)
+    }
+}
+
+impl SourceDeviceClient {
+    pub fn new(tx: Sender<SourceCommand>) -> Self {
+        Self { tx }
+    }
+
+    /// Write the given output event to the source device. Output events are
+    /// events that flow from an application (like a game) to the physical
+    /// input device, such as force feedback events.
+    pub async fn write_event(&self, event: OutputEvent) -> Result<(), ClientError> {
+        self.tx.send(SourceCommand::WriteEvent(event)).await?;
+        Ok(())
+    }
+
+    /// Upload the given force feedback effect data to the source device. Returns
+    /// a device-specific id of the uploaded effect if it is successful.
+    pub async fn upload_effect(&self, effect: FFEffectData) -> Result<i16, ClientError> {
+        let (tx, rx) = channel();
+        self.tx.try_send(SourceCommand::UploadEffect(effect, tx))?;
+        match rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => match result {
+                Ok(id) => Ok(id),
+                Err(err) => Err(ClientError::ServiceError(err)),
+            },
+            Err(_err) => Err(ClientError::ChannelClosed),
+        }
+    }
+
+    /// Update the effect with the given id using the given effect data.
+    pub async fn update_effect(
+        &self,
+        effect_id: i16,
+        effect: FFEffectData,
+    ) -> Result<(), ClientError> {
+        self.tx
+            .send(SourceCommand::UpdateEffect(effect_id, effect))
+            .await?;
+        Ok(())
+    }
+
+    /// Erase the effect with the given id from the source device.
+    pub async fn erase_effect(&self, effect_id: i16) -> Result<(), ClientError> {
+        let (tx, rx) = channel();
+        self.tx
+            .try_send(SourceCommand::EraseEffect(effect_id, tx))?;
+        match rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => match result {
+                Ok(_) => Ok(()),
+                Err(err) => Err(ClientError::ServiceError(err)),
+            },
+            Err(_err) => Err(ClientError::ChannelClosed),
+        }
+    }
+
+    /// Get the sample rate of the source device for the given property. This
+    /// returns how often the device polls for data. Typically used for IIO
+    /// source devices.
+    pub async fn get_sample_rate(&self, kind: &str) -> Result<f64, ClientError> {
+        let (tx, rx) = channel();
+        self.tx
+            .try_send(SourceCommand::GetSampleRate(kind.to_string(), tx))?;
+        match rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => match result {
+                Ok(rate) => Ok(rate),
+                Err(err) => Err(ClientError::ServiceError(err)),
+            },
+            Err(_err) => Err(ClientError::ChannelClosed),
+        }
+    }
+
+    /// Get the sample rates available on the source device for the given property.
+    /// Typically used for IIO source devices.
+    pub async fn get_sample_rates_avail(&self, kind: &str) -> Result<Vec<f64>, ClientError> {
+        let (tx, rx) = channel();
+        self.tx
+            .try_send(SourceCommand::GetSampleRatesAvail(kind.to_string(), tx))?;
+        match rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => match result {
+                Ok(rates) => Ok(rates),
+                Err(err) => Err(ClientError::ServiceError(err)),
+            },
+            Err(_err) => Err(ClientError::ChannelClosed),
+        }
+    }
+
+    /// Set the sample rate on the source device for the given property. Typically
+    /// used for IIO source devices.
+    pub async fn set_sample_rate(&self, kind: &str, rate: f64) -> Result<(), ClientError> {
+        let (tx, rx) = channel();
+        self.tx
+            .try_send(SourceCommand::SetSampleRate(kind.to_string(), rate, tx))?;
+        match rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => match result {
+                Ok(value) => Ok(value),
+                Err(err) => Err(ClientError::ServiceError(err)),
+            },
+            Err(_err) => Err(ClientError::ChannelClosed),
+        }
+    }
+
+    /// Get the scale of the given property on the source device. The scale is a
+    /// multiplier used to increase or decrease sensitivity of certain events.
+    /// Typically used by IIO source devices.
+    pub async fn get_scale(&self, kind: &str) -> Result<f64, ClientError> {
+        let (tx, rx) = channel();
+        self.tx
+            .try_send(SourceCommand::GetScale(kind.to_string(), tx))?;
+        match rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => match result {
+                Ok(value) => Ok(value),
+                Err(err) => Err(ClientError::ServiceError(err)),
+            },
+            Err(_err) => Err(ClientError::ChannelClosed),
+        }
+    }
+
+    /// Get the scales available on the source device for the given property.
+    /// Scale is a multiplier used to increase or decrease sensitivity of certain
+    /// events. Typically used for IIO source devices.
+    pub async fn get_scales_available(&self, kind: &str) -> Result<Vec<f64>, ClientError> {
+        let (tx, rx) = channel();
+        self.tx
+            .try_send(SourceCommand::GetScalesAvail(kind.to_string(), tx))?;
+        match rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => match result {
+                Ok(value) => Ok(value),
+                Err(err) => Err(ClientError::ServiceError(err)),
+            },
+            Err(_err) => Err(ClientError::ChannelClosed),
+        }
+    }
+
+    /// Set the scale on the source device for the given property.
+    /// Scale is a multiplier used to increase or decrease sensitivity of certain
+    /// events. Typically used for IIO source devices.
+    pub async fn set_scale(&self, kind: &str, scale: f64) -> Result<(), ClientError> {
+        let (tx, rx) = channel();
+        self.tx
+            .try_send(SourceCommand::SetScale(kind.to_string(), scale, tx))?;
+        match rx.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => match result {
+                Ok(value) => Ok(value),
+                Err(err) => Err(ClientError::ServiceError(err)),
+            },
+            Err(_err) => Err(ClientError::ChannelClosed),
+        }
+    }
+
+    /// Stop the source device.
+    pub async fn stop(&self) -> Result<(), ClientError> {
+        self.tx.send(SourceCommand::Stop).await?;
+        Ok(())
+    }
+}

--- a/src/input/source/command.rs
+++ b/src/input/source/command.rs
@@ -1,0 +1,39 @@
+use std::{error::Error, sync::mpsc::Sender};
+
+use evdev::FFEffectData;
+
+use crate::input::output_event::OutputEvent;
+
+/// A [SourceCommand] is a message that can be sent to a [SourceDevice] over
+/// a channel.
+#[derive(Debug, Clone)]
+pub enum SourceCommand {
+    WriteEvent(OutputEvent),
+    UploadEffect(
+        FFEffectData,
+        Sender<Result<i16, Box<dyn Error + Send + Sync>>>,
+    ),
+    UpdateEffect(i16, FFEffectData),
+    EraseEffect(i16, Sender<Result<(), Box<dyn Error + Send + Sync>>>),
+    GetSampleRate(String, Sender<Result<f64, Box<dyn Error + Send + Sync>>>),
+    GetSampleRatesAvail(
+        String,
+        Sender<Result<Vec<f64>, Box<dyn Error + Send + Sync>>>,
+    ),
+    SetSampleRate(
+        String,
+        f64,
+        Sender<Result<(), Box<dyn Error + Send + Sync>>>,
+    ),
+    GetScale(String, Sender<Result<f64, Box<dyn Error + Send + Sync>>>),
+    GetScalesAvail(
+        String,
+        Sender<Result<Vec<f64>, Box<dyn Error + Send + Sync>>>,
+    ),
+    SetScale(
+        String,
+        f64,
+        Sender<Result<(), Box<dyn Error + Send + Sync>>>,
+    ),
+    Stop,
+}

--- a/src/input/source/evdev.rs
+++ b/src/input/source/evdev.rs
@@ -19,7 +19,7 @@ use crate::{
     procfs,
 };
 
-use super::SourceCommand;
+use super::{client::SourceDeviceClient, SourceCommand};
 
 /// Size of the [SourceCommand] buffer for receiving output events
 const BUFFER_SIZE: usize = 2048;
@@ -51,8 +51,8 @@ impl EventDevice {
     }
 
     /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<SourceCommand> {
-        self.tx.clone()
+    pub fn client(&self) -> SourceDeviceClient {
+        self.tx.clone().into()
     }
 
     /// Run the source device handler

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -14,7 +14,7 @@ use crate::{
     input::{capability::Capability, composite_device::client::CompositeDeviceClient},
 };
 
-use super::SourceCommand;
+use super::{client::SourceDeviceClient, SourceCommand};
 
 /// Size of the [SourceCommand] buffer for receiving output events
 const BUFFER_SIZE: usize = 2048;
@@ -50,8 +50,8 @@ impl HIDRawDevice {
     }
 
     /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<SourceCommand> {
-        self.tx.clone()
+    pub fn client(&self) -> SourceDeviceClient {
+        self.tx.clone().into()
     }
 
     /// Run the source device handler. HIDRaw devices require device-specific

--- a/src/input/source/iio.rs
+++ b/src/input/source/iio.rs
@@ -15,7 +15,7 @@ use crate::{
     input::{capability::Capability, composite_device::client::CompositeDeviceClient},
 };
 
-use super::SourceCommand;
+use super::{client::SourceDeviceClient, SourceCommand};
 
 /// Size of the [SourceCommand] buffer for receiving output events
 const BUFFER_SIZE: usize = 2048;
@@ -93,8 +93,8 @@ impl IIODevice {
     }
 
     /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<SourceCommand> {
-        self.tx.clone()
+    pub fn client(&self) -> SourceDeviceClient {
+        self.tx.clone().into()
     }
 
     pub fn get_capabilities(&self) -> Result<Vec<Capability>, Box<dyn Error>> {

--- a/src/input/source/mod.rs
+++ b/src/input/source/mod.rs
@@ -1,10 +1,11 @@
-use std::{error::Error, sync::mpsc::Sender};
+use std::error::Error;
 
-use ::evdev::FFEffectData;
-use tokio::sync::mpsc;
+use self::{client::SourceDeviceClient, command::SourceCommand};
 
-use super::{capability::Capability, output_event::OutputEvent};
+use super::capability::Capability;
 
+pub mod client;
+pub mod command;
 pub mod evdev;
 pub mod hidraw;
 pub mod iio;
@@ -12,88 +13,54 @@ pub mod iio;
 /// A [SourceDevice] is any physical input device that emits input events
 #[derive(Debug)]
 pub enum SourceDevice {
-    EventDevice(evdev::EventDevice),
-    HIDRawDevice(hidraw::HIDRawDevice),
-    IIODevice(iio::IIODevice),
+    Event(evdev::EventDevice),
+    HIDRaw(hidraw::HIDRawDevice),
+    Iio(iio::IIODevice),
 }
 
 impl SourceDevice {
     /// Returns a unique identifier for the source device.
     pub fn get_id(&self) -> String {
         match self {
-            SourceDevice::EventDevice(device) => device.get_id(),
-            SourceDevice::HIDRawDevice(device) => device.get_id(),
-            SourceDevice::IIODevice(device) => device.get_id(),
+            SourceDevice::Event(device) => device.get_id(),
+            SourceDevice::HIDRaw(device) => device.get_id(),
+            SourceDevice::Iio(device) => device.get_id(),
         }
     }
 
-    /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<SourceCommand> {
+    /// Returns a client channel that can be used to send events to this device
+    pub fn client(&self) -> SourceDeviceClient {
         match self {
-            SourceDevice::EventDevice(device) => device.transmitter(),
-            SourceDevice::HIDRawDevice(device) => device.transmitter(),
-            SourceDevice::IIODevice(device) => device.transmitter(),
+            SourceDevice::Event(device) => device.client(),
+            SourceDevice::HIDRaw(device) => device.client(),
+            SourceDevice::Iio(device) => device.client(),
         }
     }
 
     /// Run the source device
     pub async fn run(&mut self) -> Result<(), Box<dyn Error>> {
         match self {
-            SourceDevice::EventDevice(device) => device.run().await,
-            SourceDevice::HIDRawDevice(device) => device.run().await,
-            SourceDevice::IIODevice(device) => device.run().await,
+            SourceDevice::Event(device) => device.run().await,
+            SourceDevice::HIDRaw(device) => device.run().await,
+            SourceDevice::Iio(device) => device.run().await,
         }
     }
 
     /// Returns the capabilities that this source device can fulfill.
     pub fn get_capabilities(&self) -> Result<Vec<Capability>, Box<dyn Error>> {
         match self {
-            SourceDevice::EventDevice(device) => device.get_capabilities(),
-            SourceDevice::HIDRawDevice(device) => device.get_capabilities(),
-            SourceDevice::IIODevice(device) => device.get_capabilities(),
+            SourceDevice::Event(device) => device.get_capabilities(),
+            SourceDevice::HIDRaw(device) => device.get_capabilities(),
+            SourceDevice::Iio(device) => device.get_capabilities(),
         }
     }
 
     /// Returns the full path to the device handler (e.g. /dev/input/event3, /dev/hidraw0)
     pub fn get_device_path(&self) -> String {
         match self {
-            SourceDevice::EventDevice(device) => device.get_device_path(),
-            SourceDevice::HIDRawDevice(device) => device.get_device_path(),
-            SourceDevice::IIODevice(device) => device.get_device_path(),
+            SourceDevice::Event(device) => device.get_device_path(),
+            SourceDevice::HIDRaw(device) => device.get_device_path(),
+            SourceDevice::Iio(device) => device.get_device_path(),
         }
     }
-}
-
-/// A [SourceCommand] is a message that can be sent to a [SourceDevice] over
-/// a channel.
-#[derive(Debug, Clone)]
-pub enum SourceCommand {
-    WriteEvent(OutputEvent),
-    UploadEffect(
-        FFEffectData,
-        Sender<Result<i16, Box<dyn Error + Send + Sync>>>,
-    ),
-    UpdateEffect(i16, FFEffectData),
-    EraseEffect(i16, Sender<Result<(), Box<dyn Error + Send + Sync>>>),
-    GetSampleRate(String, Sender<Result<f64, Box<dyn Error + Send + Sync>>>),
-    GetSampleRatesAvail(
-        String,
-        Sender<Result<Vec<f64>, Box<dyn Error + Send + Sync>>>,
-    ),
-    SetSampleRate(
-        String,
-        f64,
-        Sender<Result<(), Box<dyn Error + Send + Sync>>>,
-    ),
-    GetScale(String, Sender<Result<f64, Box<dyn Error + Send + Sync>>>),
-    GetScalesAvail(
-        String,
-        Sender<Result<Vec<f64>, Box<dyn Error + Send + Sync>>>,
-    ),
-    SetScale(
-        String,
-        f64,
-        Sender<Result<(), Box<dyn Error + Send + Sync>>>,
-    ),
-    Stop,
 }


### PR DESCRIPTION
This change, like #133 adds a new `SourceDeviceClient` to simplify communicating with a `SourceDevice`. It provides helper methods for sending and receiving data over a channel.

For example, instead of doing:

```rust
tx.send(SourceCommand::WriteEvent(event).await?;
```

we can now do:

```rust
source_device.write_event(event).await?;
```