### PR TITLE
refactor(TargetDevice): implement target device client

### DIFF
--- a/src/input/composite_device/client.rs
+++ b/src/input/composite_device/client.rs
@@ -3,9 +3,9 @@ use thiserror::Error;
 use tokio::sync::mpsc::{channel, error::SendError, Sender};
 
 use crate::input::event::native::NativeEvent;
+use crate::input::target::client::TargetDeviceClient;
 use crate::input::{
     capability::Capability, event::Event, manager::SourceDeviceInfo, output_event::OutputEvent,
-    target::TargetCommand,
 };
 
 use super::{CompositeCommand, InterceptMode};
@@ -35,7 +35,7 @@ pub struct CompositeDeviceClient {
 
 impl From<Sender<CompositeCommand>> for CompositeDeviceClient {
     fn from(tx: Sender<CompositeCommand>) -> Self {
-        Self { tx }
+        CompositeDeviceClient::new(tx)
     }
 }
 
@@ -193,7 +193,7 @@ impl CompositeDeviceClient {
     /// Attach the given target devices to the composite device
     pub async fn attach_target_devices(
         &self,
-        devices: HashMap<String, Sender<TargetCommand>>,
+        devices: HashMap<String, TargetDeviceClient>,
     ) -> Result<(), ClientError> {
         self.tx
             .send(CompositeCommand::AttachTargetDevices(devices))

--- a/src/input/composite_device/command.rs
+++ b/src/input/composite_device/command.rs
@@ -7,7 +7,7 @@ use crate::input::{
     event::{native::NativeEvent, Event},
     manager::SourceDeviceInfo,
     output_event::OutputEvent,
-    target::TargetCommand,
+    target::client::TargetDeviceClient,
 };
 
 use super::InterceptMode;
@@ -31,7 +31,7 @@ pub enum CompositeCommand {
     SourceDeviceStopped(String),
     SourceDeviceRemoved(String),
     SetTargetDevices(Vec<String>),
-    AttachTargetDevices(HashMap<String, mpsc::Sender<TargetCommand>>),
+    AttachTargetDevices(HashMap<String, TargetDeviceClient>),
     GetProfileName(mpsc::Sender<String>),
     LoadProfilePath(String, mpsc::Sender<Result<(), String>>),
     WriteEvent(NativeEvent),

--- a/src/input/target/client.rs
+++ b/src/input/target/client.rs
@@ -1,0 +1,109 @@
+use thiserror::Error;
+use tokio::sync::mpsc::{
+    channel,
+    error::{SendError, TrySendError},
+    Sender,
+};
+
+use crate::input::{
+    capability::Capability, composite_device::client::CompositeDeviceClient,
+    event::native::NativeEvent,
+};
+
+use super::command::TargetCommand;
+
+/// Possible errors for a target device client
+#[derive(Error, Debug)]
+pub enum ClientError {
+    #[error("failed to send command to device")]
+    SendError(SendError<TargetCommand>),
+    #[error("failed to try to send command to device")]
+    TrySendError(TrySendError<TargetCommand>),
+    #[error("device no longer exists")]
+    ChannelClosed,
+}
+
+impl From<SendError<TargetCommand>> for ClientError {
+    fn from(err: SendError<TargetCommand>) -> Self {
+        Self::SendError(err)
+    }
+}
+
+impl From<TrySendError<TargetCommand>> for ClientError {
+    fn from(err: TrySendError<TargetCommand>) -> Self {
+        Self::TrySendError(err)
+    }
+}
+
+/// A client for communicating with a target device
+#[derive(Debug, Clone)]
+pub struct TargetDeviceClient {
+    tx: Sender<TargetCommand>,
+}
+
+impl From<Sender<TargetCommand>> for TargetDeviceClient {
+    fn from(tx: Sender<TargetCommand>) -> Self {
+        TargetDeviceClient::new(tx)
+    }
+}
+
+impl TargetDeviceClient {
+    /// Create a new [TargetDeviceClient] from the given channel
+    pub fn new(tx: Sender<TargetCommand>) -> Self {
+        Self { tx }
+    }
+
+    /// Write the given input event to the target device.
+    pub async fn write_event(&self, event: NativeEvent) -> Result<(), ClientError> {
+        self.tx.try_send(TargetCommand::WriteEvent(event))?;
+        Ok(())
+    }
+
+    /// Configure the target device with the given CompositeDevice. Target devices
+    /// may need to communicate with the composite device in order to send output
+    /// events (like force feedback events) back to source devices.
+    pub async fn set_composite_device(
+        &self,
+        device: CompositeDeviceClient,
+    ) -> Result<(), ClientError> {
+        self.tx
+            .send(TargetCommand::SetCompositeDevice(device))
+            .await?;
+        Ok(())
+    }
+
+    /// Returns the target device input capabilities that the device can handle.
+    pub async fn get_capabilities(&self) -> Result<Vec<Capability>, ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(TargetCommand::GetCapabilities(tx)).await?;
+        if let Some(value) = rx.recv().await {
+            return Ok(value);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Returns a string identifier of the type of target device. This identifier
+    /// should be the same text identifier used in device and input configs.
+    pub async fn get_type(&self) -> Result<String, ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(TargetCommand::GetType(tx)).await?;
+        if let Some(value) = rx.recv().await {
+            return Ok(value);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Stop the target device.
+    pub async fn stop(&self) -> Result<(), ClientError> {
+        self.tx.send(TargetCommand::Stop).await?;
+        Ok(())
+    }
+
+    /// Completes when the receiver has dropped.
+    ///
+    /// This allows the producers to get notified when interest in the produced
+    /// values is canceled and immediately stop doing work.
+    pub async fn closed(&self) {
+        self.tx.closed().await
+    }
+}

--- a/src/input/target/command.rs
+++ b/src/input/target/command.rs
@@ -1,0 +1,17 @@
+use tokio::sync::mpsc::Sender;
+
+use crate::input::{
+    capability::Capability, composite_device::client::CompositeDeviceClient,
+    event::native::NativeEvent,
+};
+
+/// A [TargetCommand] is a message that can be sent to a [TargetDevice] over
+/// a channel.
+#[derive(Debug, Clone)]
+pub enum TargetCommand {
+    WriteEvent(NativeEvent),
+    SetCompositeDevice(CompositeDeviceClient),
+    GetCapabilities(Sender<Vec<Capability>>),
+    GetType(Sender<String>),
+    Stop,
+}

--- a/src/input/target/dbus.rs
+++ b/src/input/target/dbus.rs
@@ -16,7 +16,7 @@ use crate::{
     },
 };
 
-use super::TargetCommand;
+use super::{client::TargetDeviceClient, command::TargetCommand};
 
 /// Size of the channel buffer for events
 const BUFFER_SIZE: usize = 2048;
@@ -65,9 +65,9 @@ impl DBusDevice {
         self.dbus_path.clone()
     }
 
-    /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<TargetCommand> {
-        self.tx.clone()
+    /// Returns a client channel that can be used to send events to this device
+    pub fn client(&self) -> TargetDeviceClient {
+        self.tx.clone().into()
     }
 
     /// Configures the device to send output events to the given composite device

--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -47,7 +47,7 @@ use crate::{
     },
 };
 
-use super::TargetCommand;
+use super::{client::TargetDeviceClient, command::TargetCommand};
 
 const POLL_INTERVAL_MS: u64 = 4;
 const BUFFER_SIZE: usize = 2048;
@@ -147,9 +147,9 @@ impl DualSenseDevice {
         }
     }
 
-    /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<TargetCommand> {
-        self.tx.clone()
+    /// Returns a client channel that can be used to send events to this device
+    pub fn client(&self) -> TargetDeviceClient {
+        self.tx.clone().into()
     }
 
     /// Configures the device to send output events to the given composite device

--- a/src/input/target/mod.rs
+++ b/src/input/target/mod.rs
@@ -1,10 +1,9 @@
-use tokio::sync::mpsc::Sender;
+use std::error::Error;
 
-use super::{
-    capability::Capability, composite_device::client::CompositeDeviceClient,
-    event::native::NativeEvent,
-};
+use self::client::TargetDeviceClient;
 
+pub mod client;
+pub mod command;
 pub mod dbus;
 pub mod dualsense;
 pub mod keyboard;
@@ -30,13 +29,70 @@ pub enum TargetDeviceType {
     Touchscreen(touchscreen_fts3528::Fts3528TouchscreenDevice),
 }
 
-/// A [TargetCommand] is a message that can be sent to a [TargetDevice] over
-/// a channel.
-#[derive(Debug, Clone)]
-pub enum TargetCommand {
-    WriteEvent(NativeEvent),
-    SetCompositeDevice(CompositeDeviceClient),
-    GetCapabilities(Sender<Vec<Capability>>),
-    GetType(Sender<String>),
-    Stop,
+impl TargetDeviceType {
+    /// Returns a string of the base name that should be used for this kind
+    /// of device. E.g. a gamepad will return "gamepad" so it can be named
+    /// "gamepad0", "gamepad1", etc. when requesting a DBus path.
+    pub fn dbus_device_class(&self) -> &str {
+        match self {
+            TargetDeviceType::Null => "null",
+            TargetDeviceType::DBus(_) => "dbus",
+            TargetDeviceType::Keyboard(_) => "keyboard",
+            TargetDeviceType::Mouse(_) => "mouse",
+            TargetDeviceType::XBox360(_) => "gamepad",
+            TargetDeviceType::XBoxElite(_) => "gamepad",
+            TargetDeviceType::XBoxSeries(_) => "gamepad",
+            TargetDeviceType::SteamDeck(_) => "gamepad",
+            TargetDeviceType::DualSense(_) => "gamepad",
+            TargetDeviceType::Touchscreen(_) => "touchscreen",
+        }
+    }
+
+    /// Returns a client channel that can be used to send events to this device
+    pub fn client(&self) -> Option<TargetDeviceClient> {
+        match self {
+            TargetDeviceType::Null => None,
+            TargetDeviceType::DBus(device) => Some(device.client()),
+            TargetDeviceType::Keyboard(device) => Some(device.client()),
+            TargetDeviceType::Mouse(device) => Some(device.client()),
+            TargetDeviceType::XBox360(device) => Some(device.client()),
+            TargetDeviceType::XBoxElite(device) => Some(device.client()),
+            TargetDeviceType::XBoxSeries(device) => Some(device.client()),
+            TargetDeviceType::SteamDeck(device) => Some(device.client()),
+            TargetDeviceType::DualSense(device) => Some(device.client()),
+            TargetDeviceType::Touchscreen(device) => Some(device.client()),
+        }
+    }
+
+    /// Creates a new instance of the device interface on DBus.
+    pub async fn listen_on_dbus(&mut self, path: String) -> Result<(), Box<dyn Error>> {
+        match self {
+            TargetDeviceType::Null => Ok(()),
+            TargetDeviceType::DBus(device) => device.listen_on_dbus(path).await,
+            TargetDeviceType::Keyboard(device) => device.listen_on_dbus(path).await,
+            TargetDeviceType::Mouse(device) => device.listen_on_dbus(path).await,
+            TargetDeviceType::XBox360(device) => device.listen_on_dbus(path).await,
+            TargetDeviceType::XBoxElite(device) => device.listen_on_dbus(path).await,
+            TargetDeviceType::XBoxSeries(device) => device.listen_on_dbus(path).await,
+            TargetDeviceType::SteamDeck(device) => device.listen_on_dbus(path).await,
+            TargetDeviceType::DualSense(device) => device.listen_on_dbus(path).await,
+            TargetDeviceType::Touchscreen(device) => device.listen_on_dbus(path).await,
+        }
+    }
+
+    /// Run the target device
+    pub async fn run(&mut self) -> Result<(), Box<dyn Error>> {
+        match self {
+            TargetDeviceType::Null => Ok(()),
+            TargetDeviceType::DBus(device) => device.run().await,
+            TargetDeviceType::Keyboard(device) => device.run().await,
+            TargetDeviceType::Mouse(device) => device.run().await,
+            TargetDeviceType::XBox360(device) => device.run().await,
+            TargetDeviceType::XBoxElite(device) => device.run().await,
+            TargetDeviceType::XBoxSeries(device) => device.run().await,
+            TargetDeviceType::SteamDeck(device) => device.run().await,
+            TargetDeviceType::DualSense(device) => device.run().await,
+            TargetDeviceType::Touchscreen(device) => device.run().await,
+        }
+    }
 }

--- a/src/input/target/mouse.rs
+++ b/src/input/target/mouse.rs
@@ -20,7 +20,7 @@ use crate::{
     },
 };
 
-use super::TargetCommand;
+use super::{client::TargetDeviceClient, command::TargetCommand};
 
 /// Size of the target command channel buffer for processing events
 const BUFFER_SIZE: usize = 2048;
@@ -55,9 +55,9 @@ impl MouseDevice {
         self.dbus_path.clone()
     }
 
-    /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<TargetCommand> {
-        self.tx.clone()
+    /// Returns a client channel that can be used to send events to this device
+    pub fn client(&self) -> TargetDeviceClient {
+        self.tx.clone().into()
     }
 
     /// Configures the device to send output events to the given composite device

--- a/src/input/target/steam_deck.rs
+++ b/src/input/target/steam_deck.rs
@@ -26,7 +26,7 @@ use crate::{
     },
 };
 
-use super::TargetCommand;
+use super::{client::TargetDeviceClient, command::TargetCommand};
 
 const POLL_INTERVAL_MS: u64 = 4;
 const BUFFER_SIZE: usize = 2048;
@@ -73,9 +73,9 @@ impl SteamDeckDevice {
         }
     }
 
-    /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<TargetCommand> {
-        self.tx.clone()
+    /// Returns a client channel that can be used to send events to this device
+    pub fn client(&self) -> TargetDeviceClient {
+        self.tx.clone().into()
     }
 
     /// Configures the device to send output events to the given composite device

--- a/src/input/target/touchscreen_fts3528.rs
+++ b/src/input/target/touchscreen_fts3528.rs
@@ -28,7 +28,7 @@ use crate::{
     },
 };
 
-use super::TargetCommand;
+use super::{client::TargetDeviceClient, command::TargetCommand};
 
 const POLL_INTERVAL_MS: u64 = 10;
 const BUFFER_SIZE: usize = 2048;
@@ -56,9 +56,9 @@ impl Fts3528TouchscreenDevice {
         }
     }
 
-    /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<TargetCommand> {
-        self.tx.clone()
+    /// Returns a client channel that can be used to send events to this device
+    pub fn client(&self) -> TargetDeviceClient {
+        self.tx.clone().into()
     }
 
     /// Configures the device to send output events to the given composite device

--- a/src/input/target/xb360.rs
+++ b/src/input/target/xb360.rs
@@ -27,7 +27,7 @@ use crate::{
     },
 };
 
-use super::TargetCommand;
+use super::{client::TargetDeviceClient, command::TargetCommand};
 
 /// Size of the [TargetCommand] buffer for receiving input events
 const BUFFER_SIZE: usize = 2048;
@@ -60,9 +60,9 @@ impl XBox360Controller {
         self.dbus_path.clone()
     }
 
-    /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<TargetCommand> {
-        self.tx.clone()
+    /// Returns a client channel that can be used to send events to this device
+    pub fn client(&self) -> TargetDeviceClient {
+        self.tx.clone().into()
     }
 
     /// Configures the device to send output events to the given composite device

--- a/src/input/target/xbox_elite.rs
+++ b/src/input/target/xbox_elite.rs
@@ -27,7 +27,7 @@ use crate::{
     },
 };
 
-use super::TargetCommand;
+use super::{client::TargetDeviceClient, command::TargetCommand};
 
 /// Size of the [TargetCommand] buffer for receiving input events
 const BUFFER_SIZE: usize = 2048;
@@ -60,9 +60,9 @@ impl XboxEliteController {
         self.dbus_path.clone()
     }
 
-    /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<TargetCommand> {
-        self.tx.clone()
+    /// Returns a client channel that can be used to send events to this device
+    pub fn client(&self) -> TargetDeviceClient {
+        self.tx.clone().into()
     }
 
     /// Configures the device to send output events to the given composite device

--- a/src/input/target/xbox_series.rs
+++ b/src/input/target/xbox_series.rs
@@ -27,7 +27,7 @@ use crate::{
     },
 };
 
-use super::TargetCommand;
+use super::{client::TargetDeviceClient, command::TargetCommand};
 
 /// Size of the [TargetCommand] buffer for receiving input events
 const BUFFER_SIZE: usize = 2048;
@@ -60,9 +60,9 @@ impl XboxSeriesController {
         self.dbus_path.clone()
     }
 
-    /// Returns a transmitter channel that can be used to send events to this device
-    pub fn transmitter(&self) -> mpsc::Sender<TargetCommand> {
-        self.tx.clone()
+    /// Returns a client channel that can be used to send events to this device
+    pub fn client(&self) -> TargetDeviceClient {
+        self.tx.clone().into()
     }
 
     /// Configures the device to send output events to the given composite device


### PR DESCRIPTION
This change, like #133 and #142  adds a new `TargetDeviceClient` to simplify communicating with a `TargetDevice`. It provides helper methods for sending and receiving data over a channel.

For example, instead of doing:

```rust
tx.send(TargetCommand::WriteEvent(event).await?;
```

we can now do:

```rust
target_device.write_event(event).await?;
```