### PR TITLE
feat(Touch): add basic touch input translation support

### DIFF
--- a/rootfs/usr/share/inputplumber/schema/device_profile_v1.json
+++ b/rootfs/usr/share/inputplumber/schema/device_profile_v1.json
@@ -31,13 +31,16 @@
               "keyboard",
               "gamepad",
               "xb360",
+              "xbox-elite",
+              "xbox-series",
               "deck",
               "ds5",
               "ds5-usb",
               "ds5-bt",
               "ds5-edge",
               "ds5-edge-usb",
-              "ds5-edge-bt"
+              "ds5-edge-bt",
+              "touchscreen-fts3528"
             ]
           }
         },
@@ -254,6 +257,12 @@
         "mouse": {
           "$ref": "#/definitions/MouseEvent"
         },
+        "touchpad": {
+          "$ref": "#/definitions/TouchpadEvent"
+        },
+        "touchscreen": {
+          "$ref": "#/definitions/TouchEvent"
+        },
         "dbus": {
           "type": "string",
           "enum": [
@@ -276,7 +285,11 @@
             "ui_r2",
             "ui_r3",
             "ui_volume_up",
-            "ui_volume_down"
+            "ui_volume_down",
+            "ui_volume_mute",
+            "ui_osk",
+            "ui_screenshot",
+            "ui_touch"
           ]
         },
         "gamepad": {
@@ -324,6 +337,68 @@
             "right",
             "up",
             "down"
+          ]
+        },
+        "speed_pps": {
+          "type": "number",
+          "description": "Speed of the target motion event in pixels per second",
+          "default": 800
+        }
+      }
+    },
+    "TouchpadEvent": {
+      "title": "TouchpadEvent",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "enum": [
+            "LeftPad",
+            "RightPad",
+            "CenterPad"
+          ]
+        },
+        "touch": {
+          "$ref": "#/definitions/TouchEvent"
+        }
+      }
+    },
+    "TouchEvent": {
+      "title": "TouchEvent",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "motion": {
+          "$ref": "#/definitions/TouchMotionEvent"
+        },
+        "button": {
+          "type": "string",
+          "enum": [
+            "Touch",
+            "Press"
+          ]
+        }
+      },
+      "required": []
+    },
+    "TouchMotionEvent": {
+      "title": "TouchMotionEvent",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "region": {
+          "type": "string",
+          "description": "Map from a specific region of the touch device",
+          "enum": [
+            "left",
+            "right",
+            "top",
+            "bottom",
+            "top-left",
+            "top-right",
+            "bottom-left",
+            "bottom-right"
           ]
         },
         "speed_pps": {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -135,6 +135,22 @@ impl ProfileMapping {
             }
         }
 
+        // Touchpad event
+        // TODO: implement touchpad specific matching
+
+        // Touchscreen event
+        if let Some(touch) = self.source_event.touchscreen.as_ref() {
+            // Touch motion
+            if let Some(motion) = touch.motion.as_ref() {
+                // Touch motion was defined for source event!
+                if let Some(_direction) = motion.region.as_ref() {
+                    // TODO: Implement ability to map certain parts of the touch
+                    // screen.
+                    return true;
+                }
+            }
+        }
+
         // If no other input types were defined in the config, then it counts as
         // a match.
         true
@@ -182,6 +198,8 @@ pub struct CapabilityConfig {
     pub keyboard: Option<String>,
     pub mouse: Option<MouseCapability>,
     pub dbus: Option<String>,
+    pub touchpad: Option<TouchpadCapability>,
+    pub touchscreen: Option<TouchCapability>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -228,6 +246,27 @@ pub struct MouseCapability {
 #[serde(rename_all = "snake_case")]
 pub struct MouseMotionCapability {
     pub direction: Option<String>,
+    pub speed_pps: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct TouchpadCapability {
+    pub name: String,
+    pub touch: TouchCapability,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct TouchCapability {
+    pub button: Option<String>,
+    pub motion: Option<TouchMotionCapability>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "snake_case")]
+pub struct TouchMotionCapability {
+    pub region: Option<String>,
     pub speed_pps: Option<u64>,
 }
 


### PR DESCRIPTION
This change adds two new config entries for input profiles: `touchpad` and `touchscreen`.

To add these translations, I had to:
* Update the `CapabilityConfig` struct with the new translation config
* Update the device profile schema with the new config fields
* Update `From<CapabilityConfig> for Capability` to convert a translation config into a capability
* Update `InputValue::translate` to translate the input value to the target