### PR TITLE
feat(SteamDeckTarget): add Steam Deck Controller target device through USB emulation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ thiserror = "1.0.61"
 tokio = { version = "*", features = ["full"] }
 udev = { version = "^0.8", features = ["mio"] }
 uhid-virt = "0.0.7"
+virtual-usb = { git = "https://github.com/ShadowBlip/virtual-usb-rs.git", rev = "5a7a96a6aedc54f339d9ebff78bf484e5b17728d" }
 zbus = { version = "4.3.1", default-features = false, features = ["tokio"] }
 zbus_macros = "4.3.1"
 

--- a/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
@@ -151,6 +151,6 @@ source_devices:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - xbox-elite
+  - deck
   - mouse
   - keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
@@ -151,6 +151,6 @@ source_devices:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - deck
+  - xbox-elite
   - mouse
   - keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
@@ -31,14 +31,14 @@ source_devices:
   - group: mouse
     blocked: true
     evdev:
-      name: { OPI0001:00 0911:5288 Touchpad, SYNA3602:00 0911:5288 Touchpad }
-      phys_path: { i2c-OPI0001:00, i2c-SYNA3602:00 }
+      name: "{OPI0001:00 0911:5288 Touchpad,SYNA3602:00 0911:5288 Touchpad}"
+      phys_path: "{i2c-OPI0001:00,i2c-SYNA3602:00}"
       handler: event*
   - group: mouse
     blocked: true
     evdev:
-      name: { OPI0002:00 0911:5288 Touchpad, SYNA3602:01 0911:5288 Touchpad }
-      phys_path: { i2c-OPI0002:00, i2c-SYNA3602:01 }
+      name: "{OPI0002:00 0911:5288 Touchpad,SYNA3602:01 0911:5288 Touchpad}"
+      phys_path: "{i2c-OPI0002:00,i2c-SYNA3602:01}"
       handler: event*
 
   ## Gamepad Devices

--- a/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
@@ -67,7 +67,7 @@ source_devices:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - deck
+  - xbox-elite
   - mouse
   - keyboard
 

--- a/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
@@ -22,24 +22,24 @@ matches:
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.
 source_devices:
-  ## Touch Devices
-  #- group: mouse
-  #  unique: false
-  #  hidraw:
-  #    vendor_id: 0x0911
-  #    product_id: 0x5288
-  #- group: mouse
-  #  blocked: true
-  #  evdev:
-  #    name: OPI0001:00 0911:5288 Touchpad
-  #    phys_path: i2c-OPI0001:00
-  #    handler: event*
-  #- group: mouse
-  #  blocked: true
-  #  evdev:
-  #    name: OPI0002:00 0911:5288 Touchpad
-  #    phys_path: i2c-OPI0002:00
-  #    handler: event*
+  # Touch Devices
+  - group: mouse
+    unique: false
+    hidraw:
+      vendor_id: 0x0911
+      product_id: 0x5288
+  - group: mouse
+    blocked: true
+    evdev:
+      name: OPI0001:00 0911:5288 Touchpad
+      phys_path: i2c-OPI0001:00
+      handler: event*
+  - group: mouse
+    blocked: true
+    evdev:
+      name: OPI0002:00 0911:5288 Touchpad
+      phys_path: i2c-OPI0002:00
+      handler: event*
 
   ## Gamepad Devices
   - group: gamepad
@@ -67,7 +67,7 @@ source_devices:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - xb360
+  - deck
   - mouse
   - keyboard
 

--- a/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
@@ -31,14 +31,14 @@ source_devices:
   - group: mouse
     blocked: true
     evdev:
-      name: OPI0001:00 0911:5288 Touchpad
-      phys_path: i2c-OPI0001:00
+      name: { OPI0001:00 0911:5288 Touchpad, SYNA3602:00 0911:5288 Touchpad }
+      phys_path: { i2c-OPI0001:00, i2c-SYNA3602:00 }
       handler: event*
   - group: mouse
     blocked: true
     evdev:
-      name: OPI0002:00 0911:5288 Touchpad
-      phys_path: i2c-OPI0002:00
+      name: { OPI0002:00 0911:5288 Touchpad, SYNA3602:01 0911:5288 Touchpad }
+      phys_path: { i2c-OPI0002:00, i2c-SYNA3602:01 }
       handler: event*
 
   ## Gamepad Devices

--- a/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
@@ -53,7 +53,7 @@ source_devices:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - xbox-elite
+  - deck
   - mouse
   - keyboard
   - touchscreen

--- a/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
@@ -53,7 +53,7 @@ source_devices:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - deck
+  - xbox-elite
   - mouse
   - keyboard
   - touchscreen

--- a/rootfs/usr/share/inputplumber/profiles/default.yaml
+++ b/rootfs/usr/share/inputplumber/profiles/default.yaml
@@ -16,15 +16,6 @@ name: Default
 
 # Profile mappings
 mapping:
-  - name: QuickAccess
-    source_event:
-      gamepad:
-        button: QuickAccess
-    target_events:
-      - gamepad:
-          button: Guide
-      - gamepad:
-          button: South
   - name: LeftTop
     source_event:
       gamepad:

--- a/src/drivers/opineo/driver.rs
+++ b/src/drivers/opineo/driver.rs
@@ -18,12 +18,18 @@ use super::{
 // Hardware ID's
 pub const VID: u16 = 0x0911;
 pub const PID: u16 = 0x5288;
+pub const LPAD_NAMES: [&str; 2] = ["OPI0001:00", "SYNA3602:00"];
+pub const RPAD_NAMES: [&str; 2] = ["OPI0002:00", "SYNA3602:01"];
+
 // Report ID
 pub const TOUCH_DATA: u8 = 0x04;
+
 // Input report size
 const TOUCHPAD_PACKET_SIZE: usize = 10;
+
 // HID buffer read timeout
 const HID_TIMEOUT: i32 = 10;
+
 // Input report axis ranges
 pub const PAD_X_MAX: f64 = 512.0;
 pub const PAD_Y_MAX: f64 = 512.0;

--- a/src/drivers/opineo/hid_report.rs
+++ b/src/drivers/opineo/hid_report.rs
@@ -41,15 +41,15 @@ pub struct TouchpadDataReport {
     // BYTE 2-3
     #[packed_field(bytes = "2..=3", endian = "lsb")]
     pub touch_x: Integer<u16, packed_bits::Bits<16>>,
-    // BYTE 4
-    #[packed_field(bytes = "4")]
-    pub unk_4: u8,
-    // BYTE 5-6
-    #[packed_field(bytes = "5..=6", endian = "lsb")]
+    // BYTE 4-5
+    #[packed_field(bytes = "4..=5", endian = "lsb")]
     pub touch_y: Integer<u16, packed_bits::Bits<16>>,
-    // BYTE 7-8
-    #[packed_field(bytes = "7..=8", endian = "lsb")]
+    // BYTE 6-7
+    #[packed_field(bytes = "6..=7", endian = "lsb")]
     pub scan_time: Integer<u16, packed_bits::Bits<16>>,
+    // BYTE 8
+    #[packed_field(bytes = "8")]
+    pub contact_count: u8,
     // BYTE 9
     #[packed_field(bytes = "9")]
     pub unk_9: u8,
@@ -61,9 +61,9 @@ impl Default for TouchpadDataReport {
             report_id: Default::default(),
             confidence: Default::default(),
             touch_x: Default::default(),
-            unk_4: Default::default(),
             touch_y: Default::default(),
             scan_time: Default::default(),
+            contact_count: Default::default(),
             unk_9: Default::default(),
         }
     }

--- a/src/drivers/steam_deck/hid_report.rs
+++ b/src/drivers/steam_deck/hid_report.rs
@@ -57,6 +57,37 @@ pub enum ReportType {
     TriggerRumbleCommand = 0xeb,
 }
 
+impl TryFrom<u8> for ReportType {
+    type Error = &'static str;
+
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x09 => Ok(Self::InputData),
+            0x80 => Ok(Self::SetMappings),
+            0x81 => Ok(Self::ClearMappings),
+            0x82 => Ok(Self::GetMappings),
+            0x83 => Ok(Self::GetAttrib),
+            0x84 => Ok(Self::GetAttribLabel),
+            0x85 => Ok(Self::DefaultMappings),
+            0x86 => Ok(Self::FactoryReset),
+            0x87 => Ok(Self::WriteRegister),
+            0x88 => Ok(Self::ClearRegister),
+            0x89 => Ok(Self::ReadRegister),
+            0x8a => Ok(Self::GetRegisterLabel),
+            0x8b => Ok(Self::GetRegisterMax),
+            0x8c => Ok(Self::GetRegisterDefault),
+            0x8d => Ok(Self::SetMode),
+            0x8e => Ok(Self::DefaultMouse),
+            0x8f => Ok(Self::TriggerHapticPulse),
+            0xb4 => Ok(Self::RequestCommStatus),
+            0xae => Ok(Self::GetSerial),
+            0xea => Ok(Self::TriggerHapticCommand),
+            0xeb => Ok(Self::TriggerRumbleCommand),
+            _ => Err("Invalid report type"),
+        }
+    }
+}
+
 pub enum Register {
     LPadMode = 0x07,
     RPadMode = 0x08,

--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -460,11 +460,13 @@ impl CompositeDevice {
         // Stop all target devices
         log::debug!("Stopping target devices");
         for (path, target) in &self.target_devices {
+            log::debug!("Stopping target device: {path}");
             if let Err(e) = target.stop().await {
                 log::error!("Failed to stop target device {path}: {e:?}");
             }
         }
         for (path, target) in &self.target_dbus_devices {
+            log::debug!("Stopping target dbus device: {path}");
             if let Err(e) = target.stop().await {
                 log::error!("Failed to stop dbus device {path}: {e:?}");
             }
@@ -484,6 +486,7 @@ impl CompositeDevice {
 
         // Send stop command to all source devices
         for (path, source) in &self.source_devices {
+            log::debug!("Stopping source device: {path}");
             if let Err(e) = source.stop().await {
                 log::debug!("Failed to stop source device {path}: {e:?}");
             }

--- a/src/input/event/native.rs
+++ b/src/input/event/native.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use evdev::AbsoluteAxisCode;
 
 use crate::input::capability::{Capability, Gamepad, GamepadButton};
@@ -128,5 +130,47 @@ impl From<EvdevEvent> for NativeEvent {
             value,
             source_capability: None,
         }
+    }
+}
+
+impl From<ScheduledNativeEvent> for NativeEvent {
+    fn from(value: ScheduledNativeEvent) -> Self {
+        value.event
+    }
+}
+
+/// A scheduled event represents an input event that should be sent sometime in
+/// the future.
+#[derive(Debug, Clone)]
+pub struct ScheduledNativeEvent {
+    event: NativeEvent,
+    scheduled_time: Instant,
+    wait_time: Duration,
+}
+
+impl ScheduledNativeEvent {
+    /// Create a new scheduled event with the given time to wait before being
+    /// emitted.
+    pub fn new(event: NativeEvent, wait_time: Duration) -> Self {
+        Self {
+            event,
+            scheduled_time: Instant::now(),
+            wait_time,
+        }
+    }
+
+    /// Create a new scheduled event with the given timestamp and wait time before
+    /// being emitted
+    pub fn new_with_time(event: NativeEvent, timestamp: Instant, wait_time: Duration) -> Self {
+        Self {
+            event,
+            scheduled_time: timestamp,
+            wait_time,
+        }
+    }
+
+    /// Returns true when the scheduled event is ready to be emitted
+    pub fn is_ready(&self) -> bool {
+        self.scheduled_time.elapsed() > self.wait_time
     }
 }

--- a/src/input/source/hidraw/opineo.rs
+++ b/src/input/source/hidraw/opineo.rs
@@ -2,7 +2,7 @@ use std::{error::Error, fmt::Debug};
 
 use crate::{
     drivers::opineo::{
-        driver::{self, Driver},
+        driver::{self, Driver, LPAD_NAMES, RPAD_NAMES},
         event,
     },
     input::{
@@ -34,10 +34,10 @@ impl OrangePiNeoTouchpad {
         // Query the udev module to determine if this is the left or right touchpad.
         let name = device_info.name();
         let touchpad_side = {
-            if name == "OPI0001:00" {
+            if LPAD_NAMES.contains(&name.as_str()) {
                 log::debug!("Detected left pad.");
                 TouchpadSide::Left
-            } else if name == "OPI0002:00" {
+            } else if RPAD_NAMES.contains(&name.as_str()) {
                 log::debug!("Detected right pad.");
                 TouchpadSide::Right
             } else {

--- a/src/input/source/hidraw/opineo.rs
+++ b/src/input/source/hidraw/opineo.rs
@@ -87,11 +87,14 @@ fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
 /// Normalize the value to something between -1.0 and 1.0 based on the Deck's
 /// minimum and maximum axis ranges.
 fn normalize_axis_value(event: event::TouchAxisInput) -> InputValue {
+    let x = event.x;
+    let y = event.y;
+    log::trace!("Got axis to normalize: {x}, {y}");
     let max = driver::PAD_X_MAX;
-    let x = normalize_unsigned_value(event.x as f64, max);
+    let x = normalize_unsigned_value(x as f64, max);
 
     let max = driver::PAD_Y_MAX;
-    let y = normalize_unsigned_value(event.y as f64, max);
+    let y = normalize_unsigned_value(y as f64, max);
 
     // If this is an UP event, don't override the position of X/Y
     let (x, y) = if !event.is_touching {
@@ -100,6 +103,7 @@ fn normalize_axis_value(event: event::TouchAxisInput) -> InputValue {
         (Some(x), Some(y))
     };
 
+    log::trace!("Normalized axis: {x:?}, {y:?}");
     InputValue::Touch {
         index: event.index,
         is_touching: event.is_touching,

--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -2,14 +2,7 @@
 //! The DualSense implementation is based on the great work done by NeroReflex
 //! and the ROGueENEMY project:
 //! https://github.com/NeroReflex/ROGueENEMY/
-use std::{
-    cmp::Ordering,
-    error::Error,
-    fmt::Debug,
-    fs::File,
-    time::{Duration, SystemTime, UNIX_EPOCH},
-    usize,
-};
+use std::{cmp::Ordering, error::Error, fs::File, time::Duration};
 
 use packed_struct::prelude::*;
 use rand::{self, Rng};

--- a/src/input/target/mouse.rs
+++ b/src/input/target/mouse.rs
@@ -1,13 +1,8 @@
-use std::{collections::HashMap, error::Error, time::Duration};
+use std::{collections::HashMap, error::Error, time::Instant};
 
 use evdev::{
     uinput::{VirtualDevice, VirtualDeviceBuilder},
     AbsInfo, AbsoluteAxisCode, AttributeSet, InputEvent, KeyCode, RelativeAxisCode,
-    SynchronizationCode, SynchronizationEvent,
-};
-use tokio::{
-    sync::mpsc::{self, error::TryRecvError},
-    time::Instant,
 };
 use zbus::Connection;
 
@@ -17,190 +12,53 @@ use crate::{
         capability::{Capability, Mouse, MouseButton},
         composite_device::client::CompositeDeviceClient,
         event::{evdev::EvdevEvent, native::NativeEvent, value::InputValue},
+        output_event::OutputEvent,
     },
 };
 
-use super::{client::TargetDeviceClient, command::TargetCommand};
+use super::{
+    client::TargetDeviceClient, InputError, OutputError, TargetInputDevice, TargetOutputDevice,
+};
 
-/// Size of the target command channel buffer for processing events
-const BUFFER_SIZE: usize = 2048;
-
-/// Poll rate that the virtual mouse uses to process translated mouse events
-const STATE_POLL_RATE: Duration = Duration::from_millis(16);
+/// The [MouseMotionState] keeps track of the mouse velocity from translated
+/// input events (like a joystick), and sends mouse motion events to the
+/// [MouseDevice] based on the current velocity.
+#[derive(Debug, Default)]
+pub struct MouseMotionState {
+    mouse_remainder: (f64, f64),
+    mouse_velocity: (f64, f64),
+}
 
 /// [MouseDevice] is a target virtual mouse that can be used to send mouse input
 #[derive(Debug)]
 pub struct MouseDevice {
-    conn: Connection,
-    dbus_path: Option<String>,
-    tx: mpsc::Sender<TargetCommand>,
-    rx: mpsc::Receiver<TargetCommand>,
-    composite_device: Option<CompositeDeviceClient>,
+    device: VirtualDevice,
+    state: MouseMotionState,
+    axis_map: HashMap<AbsoluteAxisCode, AbsInfo>,
+    last_poll: Instant,
 }
 
 impl MouseDevice {
-    pub fn new(conn: Connection) -> Self {
-        let (tx, rx) = mpsc::channel(BUFFER_SIZE);
-        Self {
-            conn,
-            dbus_path: None,
-            composite_device: None,
-            tx,
-            rx,
-        }
-    }
-
-    /// Returns the DBus path of this device
-    pub fn get_dbus_path(&self) -> Option<String> {
-        self.dbus_path.clone()
-    }
-
-    /// Returns a client channel that can be used to send events to this device
-    pub fn client(&self) -> TargetDeviceClient {
-        self.tx.clone().into()
-    }
-
-    /// Configures the device to send output events to the given composite device
-    /// channel.
-    pub fn set_composite_device(&mut self, composite_device: CompositeDeviceClient) {
-        self.composite_device = Some(composite_device);
-    }
-
-    /// Creates a new instance of the device interface on DBus.
-    pub async fn listen_on_dbus(&mut self, path: String) -> Result<(), Box<dyn Error>> {
-        log::debug!("Starting dbus interface on {path}");
-        let conn = self.conn.clone();
-        self.dbus_path = Some(path.clone());
-        tokio::spawn(async move {
-            log::debug!("Starting dbus interface: {path}");
-            let iface = TargetMouseInterface::new();
-            if let Err(e) = conn.object_server().at(path.clone(), iface).await {
-                log::debug!("Failed to start dbus interface {path}: {e:?}");
-            } else {
-                log::debug!("Started dbus interface on {path}");
-            }
-        });
-        Ok(())
-    }
-
-    /// Creates and runs the target device
-    pub async fn run(&mut self) -> Result<(), Box<dyn Error>> {
-        log::debug!("Creating virtual mouse");
-        let mut device = self.create_virtual_device()?;
-        let axis_map = HashMap::new();
-
-        // Create a thread with the virtual mouse state
-        let tx = self.tx.clone();
-        let mut state = MouseMotionState::new(tx);
-        let state_tx = state.transmitter();
-        tokio::spawn(async move {
-            // Create the state
-            let mut interval = tokio::time::interval(STATE_POLL_RATE);
-            let mut current_time = Instant::now();
-            loop {
-                // Calculate the delta between each tick
-                let last_time = current_time;
-                current_time = Instant::now();
-                let delta = current_time - last_time;
-
-                // Process the current mouse state
-                if let Err(e) = state.process(delta).await {
-                    log::debug!("Channel disconnected for processing mouse state: {:?}", e);
-                    break;
-                }
-                interval.tick().await;
-            }
-        });
-
-        // Listen for send events
-        log::debug!("Started listening for events to send");
-        while let Some(command) = self.rx.recv().await {
-            match command {
-                TargetCommand::SetCompositeDevice(composite_device) => {
-                    self.set_composite_device(composite_device);
-                }
-                TargetCommand::WriteEvent(event) => {
-                    log::trace!("Got event to emit: {:?}", event);
-
-                    // Check if this event needs to be processed by the
-                    // mouse state.
-                    if event.is_translated()
-                        && matches!(event.as_capability(), Capability::Mouse(Mouse::Motion))
-                    {
-                        log::trace!("Got translated mouse motion event: {:?}", event);
-                        if let Some(tx) = state_tx.as_ref() {
-                            if let Err(e) = tx.send(event).await {
-                                log::warn!(
-                                    "Failed to send translated event to mouse state: {:?}",
-                                    e
-                                );
-                                continue;
-                            }
-                        }
-                        continue;
-                    }
-
-                    // Translate and emit the event(s)
-                    let evdev_events = self.translate_event(event, axis_map.clone());
-                    device.emit(evdev_events.as_slice())?;
-                    device.emit(&[SynchronizationEvent::new(
-                        SynchronizationCode::SYN_REPORT,
-                        0,
-                    )
-                    .into()])?;
-                }
-                TargetCommand::GetCapabilities(tx) => {
-                    let caps = self.get_capabilities();
-                    if let Err(e) = tx.send(caps).await {
-                        log::error!("Failed to send target capabilities: {e:?}");
-                    }
-                }
-                TargetCommand::GetType(tx) => {
-                    if let Err(e) = tx.send("mouse".to_string()).await {
-                        log::error!("Failed to send target type: {e:?}");
-                    }
-                }
-                TargetCommand::Stop => break,
-            };
-        }
-
-        log::debug!("Stopping device");
-
-        // Remove the DBus interface
-        if let Some(path) = self.dbus_path.clone() {
-            let conn = self.conn.clone();
-            let path = path.clone();
-            tokio::task::spawn(async move {
-                log::debug!("Stopping dbus interface for {path}");
-                let result = conn
-                    .object_server()
-                    .remove::<TargetMouseInterface, String>(path.clone())
-                    .await;
-                if let Err(e) = result {
-                    log::error!("Failed to stop dbus interface {path}: {e:?}");
-                } else {
-                    log::debug!("Stopped dbus interface for {path}");
-                }
-            });
-        }
-
-        Ok(())
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        let device = MouseDevice::create_virtual_device()?;
+        Ok(Self {
+            device,
+            state: MouseMotionState::default(),
+            axis_map: HashMap::new(),
+            last_poll: Instant::now(),
+        })
     }
 
     /// Translate the given native event into an evdev event
-    fn translate_event(
-        &self,
-        event: NativeEvent,
-        axis_map: HashMap<AbsoluteAxisCode, AbsInfo>,
-    ) -> Vec<InputEvent> {
-        EvdevEvent::from_native_event(event, axis_map)
+    fn translate_event(&self, event: NativeEvent) -> Vec<InputEvent> {
+        EvdevEvent::from_native_event(event, self.axis_map.clone())
             .into_iter()
             .map(|event| event.as_input_event())
             .collect()
     }
 
     /// Create the virtual device to emulate
-    fn create_virtual_device(&self) -> Result<VirtualDevice, Box<dyn Error>> {
+    fn create_virtual_device() -> Result<VirtualDevice, Box<dyn Error>> {
         let mut buttons = AttributeSet::<KeyCode>::new();
         buttons.insert(KeyCode::BTN_LEFT);
         buttons.insert(KeyCode::BTN_RIGHT);
@@ -221,122 +79,6 @@ impl MouseDevice {
         Ok(device)
     }
 
-    fn get_capabilities(&self) -> Vec<Capability> {
-        vec![
-            Capability::Mouse(Mouse::Button(MouseButton::Left)),
-            Capability::Mouse(Mouse::Button(MouseButton::Right)),
-            Capability::Mouse(Mouse::Button(MouseButton::Middle)),
-            Capability::Mouse(Mouse::Button(MouseButton::Side)),
-            Capability::Mouse(Mouse::Button(MouseButton::Extra)),
-            Capability::Mouse(Mouse::Button(MouseButton::WheelUp)),
-            Capability::Mouse(Mouse::Button(MouseButton::WheelDown)),
-            Capability::Mouse(Mouse::Motion),
-        ]
-    }
-}
-
-/// The [MouseMotionState] keeps track of the mouse velocity from translated
-/// input events (like a joystick), and sends mouse motion events to the
-/// [MouseDevice] based on the current velocity.
-#[derive(Debug)]
-pub struct MouseMotionState {
-    rx: mpsc::Receiver<NativeEvent>,
-    tx: Option<mpsc::Sender<NativeEvent>>,
-    device_tx: mpsc::Sender<TargetCommand>,
-    mouse_remainder: (f64, f64),
-    mouse_velocity: (f64, f64),
-}
-
-impl MouseMotionState {
-    /// Create a new mouse motion state to keep track of mouse velocity.
-    pub fn new(device_tx: mpsc::Sender<TargetCommand>) -> Self {
-        let (tx, rx) = mpsc::channel(BUFFER_SIZE);
-        Self {
-            rx,
-            tx: Some(tx),
-            device_tx,
-            mouse_remainder: (0.0, 0.0),
-            mouse_velocity: (0.0, 0.0),
-        }
-    }
-
-    /// Returns a transmitter that can be used to send events to process.
-    pub fn transmitter(&mut self) -> Option<mpsc::Sender<NativeEvent>> {
-        let tx = self.tx.clone();
-        self.tx = None;
-        tx
-    }
-
-    /// Move the mouse based on the given input event translation
-    pub async fn process(&mut self, delta: Duration) -> Result<(), TryRecvError> {
-        // Process any events that come over the channel from the device
-        loop {
-            match self.rx.try_recv() {
-                Ok(event) => self.update_state(event),
-                Err(err) => match err {
-                    TryRecvError::Empty => break,
-                    TryRecvError::Disconnected => return Err(err),
-                },
-            }
-        }
-
-        // Calculate how much the mouse should move based on the current mouse velocity
-        let mut pixels_to_move = (0.0, 0.0);
-        pixels_to_move.0 = delta.as_secs_f64() * self.mouse_velocity.0;
-        pixels_to_move.1 = delta.as_secs_f64() * self.mouse_velocity.1;
-
-        // Get the fractional value of the position so we can accumulate them
-        // in between invocations
-        let mut x = pixels_to_move.0 as i32; // E.g. 3.14 -> 3
-        let mut y = pixels_to_move.1 as i32;
-        self.mouse_remainder.0 += pixels_to_move.0 - x as f64;
-        self.mouse_remainder.1 += pixels_to_move.1 - y as f64;
-
-        // Keep track of relative mouse movements to keep around fractional values
-        if self.mouse_remainder.0 >= 1.0 {
-            x += 1;
-            self.mouse_remainder.0 -= 1.0;
-        }
-        if self.mouse_remainder.0 <= -1.0 {
-            x -= 1;
-            self.mouse_remainder.0 += 1.0;
-        }
-        if self.mouse_remainder.1 >= 1.0 {
-            y += 1;
-            self.mouse_remainder.1 -= 1.0;
-        }
-        if self.mouse_remainder.1 <= -1.0 {
-            y -= 1;
-            self.mouse_remainder.1 += 1.0;
-        }
-
-        // Send events to the device if the mouse state has changed
-        if x != 0 {
-            let value = InputValue::Vector2 {
-                x: Some(x as f64),
-                y: None,
-            };
-            let event = NativeEvent::new(Capability::Mouse(Mouse::Motion), value);
-            if let Err(e) = self.device_tx.send(TargetCommand::WriteEvent(event)).await {
-                log::warn!("Failed to send write event: {:?}", e);
-                return Err(TryRecvError::Disconnected);
-            }
-        }
-        if y != 0 {
-            let value = InputValue::Vector2 {
-                x: None,
-                y: Some(y as f64),
-            };
-            let event = NativeEvent::new(Capability::Mouse(Mouse::Motion), value);
-            if let Err(e) = self.device_tx.send(TargetCommand::WriteEvent(event)).await {
-                log::warn!("Failed to send write event: {:?}", e);
-                return Err(TryRecvError::Disconnected);
-            }
-        }
-
-        Ok(())
-    }
-
     /// Processes the given mouse motion or button input event.
     fn update_state(&mut self, event: NativeEvent) {
         // Get the mouse position from the event value
@@ -349,12 +91,144 @@ impl MouseMotionState {
 
         // Update the mouse velocity
         if let Some(x) = x {
-            self.mouse_velocity.0 = x;
-            log::trace!("Updating mouse state: {:?}", self.mouse_velocity);
+            self.state.mouse_velocity.0 = x;
+            log::trace!("Updating mouse state: {:?}", self.state.mouse_velocity);
         }
         if let Some(y) = y {
-            self.mouse_velocity.1 = y;
-            log::trace!("Updating mouse state: {:?}", self.mouse_velocity);
+            self.state.mouse_velocity.1 = y;
+            log::trace!("Updating mouse state: {:?}", self.state.mouse_velocity);
         }
+    }
+}
+
+impl TargetInputDevice for MouseDevice {
+    fn start_dbus_interface(
+        &mut self,
+        dbus: Connection,
+        path: String,
+        _client: TargetDeviceClient,
+    ) {
+        log::debug!("Starting dbus interface: {path}");
+        tokio::task::spawn(async move {
+            let iface = TargetMouseInterface::new();
+            if let Err(e) = dbus.object_server().at(path.clone(), iface).await {
+                log::debug!("Failed to start dbus interface {path}: {e:?}");
+            } else {
+                log::debug!("Started dbus interface on {path}");
+            };
+        });
+    }
+
+    fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
+        log::trace!("Received event: {event:?}");
+
+        // Check if this event needs to be processed by the
+        // mouse state.
+        if event.is_translated()
+            && matches!(event.as_capability(), Capability::Mouse(Mouse::Motion))
+        {
+            log::trace!("Got translated mouse motion event: {:?}", event);
+            self.update_state(event);
+            return Ok(());
+        }
+
+        // Translate and emit the event(s)
+        let evdev_events = self.translate_event(event);
+        if let Err(e) = self.device.emit(evdev_events.as_slice()) {
+            return Err(e.to_string().into());
+        }
+
+        Ok(())
+    }
+
+    fn get_capabilities(&self) -> Result<Vec<crate::input::capability::Capability>, InputError> {
+        Ok(vec![
+            Capability::Mouse(Mouse::Button(MouseButton::Left)),
+            Capability::Mouse(Mouse::Button(MouseButton::Right)),
+            Capability::Mouse(Mouse::Button(MouseButton::Middle)),
+            Capability::Mouse(Mouse::Button(MouseButton::Side)),
+            Capability::Mouse(Mouse::Button(MouseButton::Extra)),
+            Capability::Mouse(Mouse::Button(MouseButton::WheelUp)),
+            Capability::Mouse(Mouse::Button(MouseButton::WheelDown)),
+            Capability::Mouse(Mouse::Motion),
+        ])
+    }
+
+    fn stop_dbus_interface(&mut self, dbus: Connection, path: String) {
+        log::debug!("Stopping dbus interface for {path}");
+        tokio::task::spawn(async move {
+            let result = dbus
+                .object_server()
+                .remove::<TargetMouseInterface, String>(path.clone())
+                .await;
+            if let Err(e) = result {
+                log::error!("Failed to stop dbus interface {path}: {e:?}");
+            } else {
+                log::debug!("Stopped dbus interface for {path}");
+            };
+        });
+    }
+}
+
+impl TargetOutputDevice for MouseDevice {
+    /// Move the mouse based on the given input event translation
+    fn poll(&mut self, _: &Option<CompositeDeviceClient>) -> Result<Vec<OutputEvent>, OutputError> {
+        // Calculate the delta between the last poll
+        let delta = self.last_poll.elapsed();
+        self.last_poll = Instant::now();
+
+        // Calculate how much the mouse should move based on the current mouse velocity
+        let mut pixels_to_move = (0.0, 0.0);
+        pixels_to_move.0 = delta.as_secs_f64() * self.state.mouse_velocity.0;
+        pixels_to_move.1 = delta.as_secs_f64() * self.state.mouse_velocity.1;
+
+        // Get the fractional value of the position so we can accumulate them
+        // in between invocations
+        let mut x = pixels_to_move.0 as i32; // E.g. 3.14 -> 3
+        let mut y = pixels_to_move.1 as i32;
+        self.state.mouse_remainder.0 += pixels_to_move.0 - x as f64;
+        self.state.mouse_remainder.1 += pixels_to_move.1 - y as f64;
+
+        // Keep track of relative mouse movements to keep around fractional values
+        if self.state.mouse_remainder.0 >= 1.0 {
+            x += 1;
+            self.state.mouse_remainder.0 -= 1.0;
+        }
+        if self.state.mouse_remainder.0 <= -1.0 {
+            x -= 1;
+            self.state.mouse_remainder.0 += 1.0;
+        }
+        if self.state.mouse_remainder.1 >= 1.0 {
+            y += 1;
+            self.state.mouse_remainder.1 -= 1.0;
+        }
+        if self.state.mouse_remainder.1 <= -1.0 {
+            y -= 1;
+            self.state.mouse_remainder.1 += 1.0;
+        }
+
+        // Send events to the device if the mouse state has changed
+        if x != 0 {
+            let value = InputValue::Vector2 {
+                x: Some(x as f64),
+                y: None,
+            };
+            let event = NativeEvent::new(Capability::Mouse(Mouse::Motion), value);
+            if let Err(e) = self.write_event(event) {
+                return Err(e.to_string().into());
+            }
+        }
+        if y != 0 {
+            let value = InputValue::Vector2 {
+                x: None,
+                y: Some(y as f64),
+            };
+            let event = NativeEvent::new(Capability::Mouse(Mouse::Motion), value);
+            if let Err(e) = self.write_event(event) {
+                return Err(e.to_string().into());
+            }
+        }
+
+        Ok(vec![])
     }
 }

--- a/src/input/target/touchscreen.rs
+++ b/src/input/target/touchscreen.rs
@@ -1,8 +1,4 @@
-use std::{
-    error::Error,
-    os::fd::AsRawFd,
-    sync::{Arc, Mutex},
-};
+use std::{error::Error, os::fd::AsRawFd};
 
 use evdev::{
     uinput::{VirtualDevice, VirtualDeviceBuilder},
@@ -10,22 +6,15 @@ use evdev::{
     MiscCode, PropType, UinputAbsSetup,
 };
 use nix::fcntl::{FcntlArg, OFlag};
-use tokio::{sync::mpsc, time::Duration};
-use zbus::Connection;
 
-use crate::{
-    dbus::interface::target::gamepad::TargetGamepadInterface,
-    input::{
-        capability::{Capability, Touch},
-        composite_device::client::CompositeDeviceClient,
-        event::{native::NativeEvent, value::InputValue},
-    },
+use crate::input::{
+    capability::{Capability, Touch},
+    composite_device::client::CompositeDeviceClient,
+    event::{native::NativeEvent, value::InputValue},
+    output_event::OutputEvent,
 };
 
-use super::{client::TargetDeviceClient, command::TargetCommand};
-
-/// Size of the [TargetCommand] buffer for receiving input events
-const BUFFER_SIZE: usize = 2048;
+use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
 
 /// Describes the touchscreen orientation. Used to translate touch inputs based
 /// on whether the screen is rotated.
@@ -80,186 +69,122 @@ pub struct TouchEvent {
 /// the touchscreen.
 #[derive(Debug)]
 pub struct TouchscreenDevice {
-    conn: Connection,
     config: TouchscreenConfig,
-    dbus_path: Option<String>,
-    tx: mpsc::Sender<TargetCommand>,
-    rx: mpsc::Receiver<TargetCommand>,
-    composite_device: Option<CompositeDeviceClient>,
-    is_touching: Arc<Mutex<bool>>,
-    should_set_timestamp: Arc<Mutex<bool>>,
-    timestamp: Arc<Mutex<i32>>,
+    device: VirtualDevice,
+    is_touching: bool,
+    should_set_timestamp: bool,
+    timestamp: i32,
     tracking_id_next: u16,
     touch_state: [TouchEvent; 10],
 }
 
 impl TouchscreenDevice {
     /// Create a new emulated touchscreen device with the default configuration.
-    pub fn new(conn: Connection) -> Self {
-        TouchscreenDevice::new_with_config(conn, TouchscreenConfig::default())
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        TouchscreenDevice::new_with_config(TouchscreenConfig::default())
     }
 
     /// Create a new emulated touchscreen device with the given configuration.
-    pub fn new_with_config(conn: Connection, config: TouchscreenConfig) -> Self {
-        let (tx, rx) = mpsc::channel(BUFFER_SIZE);
-        Self {
-            conn,
+    pub fn new_with_config(config: TouchscreenConfig) -> Result<Self, Box<dyn Error>> {
+        let device = TouchscreenDevice::create_virtual_device(&config)?;
+        Ok(Self {
             config,
-            dbus_path: None,
-            tx,
-            rx,
-            composite_device: None,
-            is_touching: Arc::new(Mutex::new(false)),
-            should_set_timestamp: Arc::new(Mutex::new(true)),
-            timestamp: Arc::new(Mutex::new(0)),
+            device,
+            is_touching: false,
+            should_set_timestamp: true,
+            timestamp: 0,
             tracking_id_next: 0,
             touch_state: [TouchEvent::default(); 10],
-        }
+        })
     }
 
-    /// Returns the DBus path of this device
-    pub fn _get_dbus_path(&self) -> Option<String> {
-        self.dbus_path.clone()
-    }
+    /// Create the virtual device to emulate
+    fn create_virtual_device(config: &TouchscreenConfig) -> Result<VirtualDevice, Box<dyn Error>> {
+        // Setup Key inputs
+        let mut keys = AttributeSet::<KeyCode>::new();
+        keys.insert(KeyCode::BTN_TOUCH);
 
-    /// Returns a client channel that can be used to send events to this device
-    pub fn client(&self) -> TargetDeviceClient {
-        self.tx.clone().into()
-    }
+        // Get the size based on orientation
+        let (width, height) = match config.orientation {
+            TouchscreenOrientation::Normal => (config.width, config.height),
+            TouchscreenOrientation::UpsideDown => (config.width, config.height),
+            TouchscreenOrientation::RotateLeft => (config.height, config.width),
+            TouchscreenOrientation::RotateRight => (config.height, config.width),
+        };
 
-    /// Configures the device to send output events to the given composite device
-    /// channel.
-    pub fn set_composite_device(&mut self, composite_device: CompositeDeviceClient) {
-        self.composite_device = Some(composite_device);
-    }
+        // Setup ABS inputs
+        let screen_width_setup = AbsInfo::new(0, 0, width as i32, 0, 0, 3);
+        let screen_height_setup = AbsInfo::new(0, 0, height as i32, 0, 0, 9);
+        let abs_x = UinputAbsSetup::new(AbsoluteAxisCode::ABS_X, screen_width_setup);
+        let abs_y = UinputAbsSetup::new(AbsoluteAxisCode::ABS_Y, screen_height_setup);
+        let abs_mt_pos_x =
+            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_POSITION_X, screen_width_setup);
+        let abs_mt_pos_y =
+            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_POSITION_Y, screen_height_setup);
+        let abs_mt_tool_x =
+            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_TOOL_X, screen_width_setup);
+        let abs_mt_tool_y =
+            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_TOOL_Y, screen_height_setup);
 
-    /// Creates a new instance of the dbus device interface on DBus.
-    pub async fn listen_on_dbus(&mut self, path: String) -> Result<(), Box<dyn Error>> {
-        log::debug!("Starting dbus interface on {path}");
-        let conn = self.conn.clone();
-        self.dbus_path = Some(path.clone());
-        tokio::spawn(async move {
-            log::debug!("Starting dbus interface: {path}");
-            let iface = TargetGamepadInterface::new("Gamepad".into());
-            if let Err(e) = conn.object_server().at(path.clone(), iface).await {
-                log::debug!("Failed to start dbus interface {path}: {e:?}");
-            } else {
-                log::debug!("Started dbus interface on {path}");
-            }
-        });
-        Ok(())
-    }
+        let slot_setup = AbsInfo::new(0, 0, 9, 0, 0, 0);
+        let abs_mt_slot = UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_SLOT, slot_setup);
 
-    /// Creates and runs the target device
-    pub async fn run(&mut self) -> Result<(), Box<dyn Error>> {
-        log::debug!("Creating virtual gamepad");
-        let device = self.create_virtual_device()?;
+        let touch_min_maj_setup = AbsInfo::new(0, 0, 255, 0, 0, 10);
+        let abs_mt_touch_major =
+            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_TOUCH_MAJOR, touch_min_maj_setup);
+        let abs_mt_touch_minor =
+            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_TOUCH_MINOR, touch_min_maj_setup);
 
-        // Put the device behind an Arc Mutex so it can be shared between the
-        // read and write threads
-        let device = Arc::new(Mutex::new(device));
+        let orientation_setup = AbsInfo::new(0, 0, 1, 0, 0, 0);
+        let abs_mt_orientation =
+            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_ORIENTATION, orientation_setup);
 
-        // Spawn a task that checks to see if MSC_TIMESTAMP events should
-        // be sent. Timestamp events should be sent continuously during active
-        // touches.
-        let timestamp = self.timestamp.clone();
-        let should_set_timestamp = self.should_set_timestamp.clone();
-        let is_touching = self.is_touching.clone();
-        let dev = device.clone();
-        tokio::task::spawn(async move {
-            let duration = Duration::from_micros(13605);
-            loop {
-                // Check to see if the main input thread still has a reference
-                // to the virtual device. If it does not, it means the device
-                // has stopped.
-                let num_refs = Arc::strong_count(&dev);
-                if num_refs == 1 {
-                    log::debug!("Virtual device stopped. Stopping timestamp thread.");
-                    break;
-                }
+        let tracking_id_setup = AbsInfo::new(0, 0, u16::MAX.into(), 0, 0, 0);
+        let abs_mt_tracking_id =
+            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_TRACKING_ID, tracking_id_setup);
 
-                // Send timestamp events whenever a touch is active
-                let touching = *is_touching.lock().unwrap();
-                let set_timestamp = *should_set_timestamp.lock().unwrap();
-                if touching {
-                    // By default, always send a timestamp event, unless one
-                    // was sent with touch events.
-                    if set_timestamp {
-                        let value = *timestamp.lock().unwrap();
-                        let event =
-                            InputEvent::new(EventType::MISC.0, MiscCode::MSC_TIMESTAMP.0, value);
-                        if let Ok(mut d) = dev.lock() {
-                            if let Err(e) = d.emit(&[event]) {
-                                log::error!("Failed to emit timestamp event: {e:?}");
-                            }
-                        }
-                        let ts = *timestamp.lock().unwrap();
-                        *timestamp.lock().unwrap() = ts.wrapping_add(10000);
-                    } else {
-                        *should_set_timestamp.lock().unwrap() = true;
-                    }
-                } else {
-                    // Reset the timestamp to zero when no touches are active
-                    *timestamp.lock().unwrap() = 0;
-                }
+        // Setup MSC inputs
+        let mut mscs = AttributeSet::<MiscCode>::new();
+        mscs.insert(MiscCode::MSC_TIMESTAMP);
 
-                tokio::time::sleep(duration).await;
-            }
-        });
+        // Setup properties
+        let mut properties = AttributeSet::<PropType>::new();
+        properties.insert(PropType::DIRECT);
 
-        // Listen for events from source devices
-        log::debug!("Started listening for events");
-        while let Some(command) = self.rx.recv().await {
-            match command {
-                TargetCommand::SetCompositeDevice(composite_device) => {
-                    self.set_composite_device(composite_device.clone());
-                }
-                TargetCommand::WriteEvent(event) => {
-                    log::trace!("Got event to emit: {:?}", event);
-                    let evdev_events = self.translate_event(event);
-                    if let Ok(mut dev) = device.lock() {
-                        dev.emit(evdev_events.as_slice())?;
-                    }
-                }
-                TargetCommand::GetCapabilities(tx) => {
-                    let caps = self.get_capabilities();
-                    if let Err(e) = tx.send(caps).await {
-                        log::error!("Failed to send target capabilities: {e:?}");
-                    }
-                }
-                TargetCommand::GetType(tx) => {
-                    if let Err(e) = tx.send("touchscreen".to_string()).await {
-                        log::error!("Failed to send target type: {e:?}");
-                    }
-                }
-                TargetCommand::Stop => break,
-            }
-        }
+        // Identify to the kernel as a touchscreen
+        let name = config.name.as_str();
+        let vendor = config.vendor_id;
+        let product = config.product_id;
+        let version = config.version;
+        let id = InputId::new(BusType(3), vendor, product, version);
 
-        log::debug!(
-            "Stopping device {}",
-            self.dbus_path.clone().unwrap_or_default()
-        );
+        // Build the device
+        let device = VirtualDeviceBuilder::new()?
+            .name(name)
+            .input_id(id)
+            .with_properties(&properties)?
+            .with_keys(&keys)?
+            .with_msc(&mscs)?
+            .with_absolute_axis(&abs_x)?
+            .with_absolute_axis(&abs_y)?
+            .with_absolute_axis(&abs_mt_slot)?
+            .with_absolute_axis(&abs_mt_touch_major)?
+            .with_absolute_axis(&abs_mt_touch_minor)?
+            .with_absolute_axis(&abs_mt_orientation)?
+            .with_absolute_axis(&abs_mt_pos_x)?
+            .with_absolute_axis(&abs_mt_pos_y)?
+            .with_absolute_axis(&abs_mt_tracking_id)?
+            .with_absolute_axis(&abs_mt_tool_x)?
+            .with_absolute_axis(&abs_mt_tool_y)?
+            .build()?;
 
-        // Remove the DBus interface
-        if let Some(path) = self.dbus_path.clone() {
-            let conn = self.conn.clone();
-            let path = path.clone();
-            tokio::task::spawn(async move {
-                log::debug!("Stopping dbus interface for {path}");
-                let result = conn
-                    .object_server()
-                    .remove::<TargetGamepadInterface, String>(path.clone())
-                    .await;
-                if let Err(e) = result {
-                    log::error!("Failed to stop dbus interface {path}: {e:?}");
-                } else {
-                    log::debug!("Stopped dbus interface for {path}");
-                }
-            });
-        }
+        // Set the device to do non-blocking reads
+        // TODO: use epoll to wake up when data is available
+        // https://github.com/emberian/evdev/blob/main/examples/evtest_nonblocking.rs
+        let raw_fd = device.as_raw_fd();
+        nix::fcntl::fcntl(raw_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))?;
 
-        Ok(())
+        Ok(device)
     }
 
     /// Translate the given native event into a series of evdev events
@@ -336,8 +261,7 @@ impl TouchscreenDevice {
                 if last_num_touches == 0 {
                     let touch_event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_TOUCH.0, 1);
                     events.push(touch_event);
-                    let mut touching = self.is_touching.lock().unwrap();
-                    *touching = true;
+                    self.is_touching = true;
                 }
                 let tracking_id = self.tracking_id_next;
                 self.tracking_id_next = self.tracking_id_next.wrapping_add(1);
@@ -349,8 +273,7 @@ impl TouchscreenDevice {
                     let touch_event = InputEvent::new(EventType::KEY.0, KeyCode::BTN_TOUCH.0, 0);
                     events.push(touch_event);
                 }
-                let mut touching = self.is_touching.lock().unwrap();
-                *touching = false;
+                self.is_touching = false;
                 -1
             };
             let tracking_event = InputEvent::new(
@@ -417,108 +340,54 @@ impl TouchscreenDevice {
         }
 
         // Update and handle timestamps
-        let value = *self.timestamp.lock().unwrap();
+        let value = self.timestamp;
         let event = InputEvent::new(EventType::MISC.0, MiscCode::MSC_TIMESTAMP.0, value);
         events.push(event);
-        let ts = *self.timestamp.lock().unwrap();
-        *self.timestamp.lock().unwrap() = ts.wrapping_add(10000);
-        *self.should_set_timestamp.lock().unwrap() = false;
+        self.timestamp = self.timestamp.wrapping_add(10000);
+        self.should_set_timestamp = false;
 
         events
     }
+}
 
-    /// Create the virtual device to emulate
-    fn create_virtual_device(&self) -> Result<VirtualDevice, Box<dyn Error>> {
-        // Setup Key inputs
-        let mut keys = AttributeSet::<KeyCode>::new();
-        keys.insert(KeyCode::BTN_TOUCH);
+impl TargetInputDevice for TouchscreenDevice {
+    fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
+        log::trace!("Received event: {event:?}");
+        let evdev_events = self.translate_event(event);
+        self.device.emit(evdev_events.as_slice())?;
 
-        // Get the size based on orientation
-        let (width, height) = match self.config.orientation {
-            TouchscreenOrientation::Normal => (self.config.width, self.config.height),
-            TouchscreenOrientation::UpsideDown => (self.config.width, self.config.height),
-            TouchscreenOrientation::RotateLeft => (self.config.height, self.config.width),
-            TouchscreenOrientation::RotateRight => (self.config.height, self.config.width),
-        };
-
-        // Setup ABS inputs
-        let screen_width_setup = AbsInfo::new(0, 0, width as i32, 0, 0, 3);
-        let screen_height_setup = AbsInfo::new(0, 0, height as i32, 0, 0, 9);
-        let abs_x = UinputAbsSetup::new(AbsoluteAxisCode::ABS_X, screen_width_setup);
-        let abs_y = UinputAbsSetup::new(AbsoluteAxisCode::ABS_Y, screen_height_setup);
-        let abs_mt_pos_x =
-            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_POSITION_X, screen_width_setup);
-        let abs_mt_pos_y =
-            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_POSITION_Y, screen_height_setup);
-        let abs_mt_tool_x =
-            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_TOOL_X, screen_width_setup);
-        let abs_mt_tool_y =
-            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_TOOL_Y, screen_height_setup);
-
-        let slot_setup = AbsInfo::new(0, 0, 9, 0, 0, 0);
-        let abs_mt_slot = UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_SLOT, slot_setup);
-
-        let touch_min_maj_setup = AbsInfo::new(0, 0, 255, 0, 0, 10);
-        let abs_mt_touch_major =
-            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_TOUCH_MAJOR, touch_min_maj_setup);
-        let abs_mt_touch_minor =
-            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_TOUCH_MINOR, touch_min_maj_setup);
-
-        let orientation_setup = AbsInfo::new(0, 0, 1, 0, 0, 0);
-        let abs_mt_orientation =
-            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_ORIENTATION, orientation_setup);
-
-        let tracking_id_setup = AbsInfo::new(0, 0, u16::MAX.into(), 0, 0, 0);
-        let abs_mt_tracking_id =
-            UinputAbsSetup::new(AbsoluteAxisCode::ABS_MT_TRACKING_ID, tracking_id_setup);
-
-        // Setup MSC inputs
-        let mut mscs = AttributeSet::<MiscCode>::new();
-        mscs.insert(MiscCode::MSC_TIMESTAMP);
-
-        // Setup properties
-        let mut properties = AttributeSet::<PropType>::new();
-        properties.insert(PropType::DIRECT);
-
-        // Identify to the kernel as a touchscreen
-        let name = self.config.name.as_str();
-        let vendor = self.config.vendor_id;
-        let product = self.config.product_id;
-        let version = self.config.version;
-        let id = InputId::new(BusType(3), vendor, product, version);
-
-        // Build the device
-        let device = VirtualDeviceBuilder::new()?
-            .name(name)
-            .input_id(id)
-            .with_properties(&properties)?
-            .with_keys(&keys)?
-            .with_msc(&mscs)?
-            .with_absolute_axis(&abs_x)?
-            .with_absolute_axis(&abs_y)?
-            .with_absolute_axis(&abs_mt_slot)?
-            .with_absolute_axis(&abs_mt_touch_major)?
-            .with_absolute_axis(&abs_mt_touch_minor)?
-            .with_absolute_axis(&abs_mt_orientation)?
-            .with_absolute_axis(&abs_mt_pos_x)?
-            .with_absolute_axis(&abs_mt_pos_y)?
-            .with_absolute_axis(&abs_mt_tracking_id)?
-            .with_absolute_axis(&abs_mt_tool_x)?
-            .with_absolute_axis(&abs_mt_tool_y)?
-            .build()?;
-
-        // Set the device to do non-blocking reads
-        // TODO: use epoll to wake up when data is available
-        // https://github.com/emberian/evdev/blob/main/examples/evtest_nonblocking.rs
-        let raw_fd = device.as_raw_fd();
-        nix::fcntl::fcntl(raw_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))?;
-
-        Ok(device)
+        Ok(())
     }
 
-    /// Returns capabilities of the target device
-    fn get_capabilities(&self) -> Vec<Capability> {
-        vec![Capability::Touchscreen(Touch::Motion)]
+    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
+        Ok(vec![Capability::Touchscreen(Touch::Motion)])
+    }
+}
+
+impl TargetOutputDevice for TouchscreenDevice {
+    // Check to see if MSC_TIMESTAMP events should be sent. Timestamp events
+    // should be sent continuously during active touches.
+    fn poll(&mut self, _: &Option<CompositeDeviceClient>) -> Result<Vec<OutputEvent>, OutputError> {
+        // Send timestamp events whenever a touch is active
+        let touching = self.is_touching;
+        let set_timestamp = self.should_set_timestamp;
+        if touching {
+            // By default, always send a timestamp event, unless one
+            // was sent with touch events.
+            if set_timestamp {
+                let value = self.timestamp;
+                let event = InputEvent::new(EventType::MISC.0, MiscCode::MSC_TIMESTAMP.0, value);
+                self.device.emit(&[event])?;
+                self.timestamp = self.timestamp.wrapping_add(10000);
+            } else {
+                self.should_set_timestamp = true;
+            }
+        } else {
+            // Reset the timestamp to zero when no touches are active
+            self.timestamp = 0;
+        }
+
+        Ok(vec![])
     }
 }
 

--- a/src/input/target/xb360.rs
+++ b/src/input/target/xb360.rs
@@ -1,182 +1,40 @@
-use std::{
-    collections::HashMap,
-    error::Error,
-    ops::DerefMut,
-    os::fd::AsRawFd,
-    sync::{Arc, Mutex},
-    thread,
-};
+use std::os::fd::AsRawFd;
+use std::time::Duration;
+use std::{collections::HashMap, error::Error};
 
 use evdev::{
     uinput::{VirtualDevice, VirtualDeviceBuilder},
-    AbsInfo, AbsoluteAxisCode, AttributeSet, BusType, EventSummary, FFEffectCode, FFStatusCode,
-    InputEvent, InputId, KeyCode, SynchronizationCode, SynchronizationEvent, UInputCode,
+    AbsInfo, AbsoluteAxisCode, AttributeSet, BusType, FFEffectCode, InputId, KeyCode,
     UinputAbsSetup,
 };
+use evdev::{EventSummary, FFStatusCode, InputEvent, UInputCode};
 use nix::fcntl::{FcntlArg, OFlag};
-use tokio::{sync::mpsc, time::Duration};
-use zbus::Connection;
 
-use crate::{
-    dbus::interface::target::gamepad::TargetGamepadInterface,
-    input::{
-        capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger},
-        composite_device::client::CompositeDeviceClient,
-        event::{evdev::EvdevEvent, native::NativeEvent},
-        output_event::{OutputEvent, UinputOutputEvent},
-    },
-};
+use crate::input::capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger};
+use crate::input::composite_device::client::CompositeDeviceClient;
+use crate::input::event::evdev::EvdevEvent;
+use crate::input::event::native::NativeEvent;
+use crate::input::output_capability::OutputCapability;
+use crate::input::output_event::{OutputEvent, UinputOutputEvent};
 
-use super::{client::TargetDeviceClient, command::TargetCommand};
-
-/// Size of the [TargetCommand] buffer for receiving input events
-const BUFFER_SIZE: usize = 2048;
-/// How long to sleep before polling for events.
-const POLL_RATE: Duration = Duration::from_millis(8); //125Hz is standard for xbox controllers
+use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
 
 #[derive(Debug)]
 pub struct XBox360Controller {
-    conn: Connection,
-    dbus_path: Option<String>,
-    tx: mpsc::Sender<TargetCommand>,
-    rx: mpsc::Receiver<TargetCommand>,
-    composite_device: Option<CompositeDeviceClient>,
+    device: VirtualDevice,
+    axis_map: HashMap<AbsoluteAxisCode, AbsInfo>,
 }
 
 impl XBox360Controller {
-    pub fn new(conn: Connection) -> Self {
-        let (tx, rx) = mpsc::channel(BUFFER_SIZE);
-        Self {
-            conn,
-            dbus_path: None,
-            tx,
-            rx,
-            composite_device: None,
-        }
-    }
-
-    /// Returns the DBus path of this device
-    pub fn _get_dbus_path(&self) -> Option<String> {
-        self.dbus_path.clone()
-    }
-
-    /// Returns a client channel that can be used to send events to this device
-    pub fn client(&self) -> TargetDeviceClient {
-        self.tx.clone().into()
-    }
-
-    /// Configures the device to send output events to the given composite device
-    /// channel.
-    pub fn set_composite_device(&mut self, composite_device: CompositeDeviceClient) {
-        self.composite_device = Some(composite_device);
-    }
-
-    /// Creates a new instance of the dbus device interface on DBus.
-    pub async fn listen_on_dbus(&mut self, path: String) -> Result<(), Box<dyn Error>> {
-        log::debug!("Starting dbus interface on {path}");
-        let conn = self.conn.clone();
-        self.dbus_path = Some(path.clone());
-        tokio::spawn(async move {
-            log::debug!("Starting dbus interface: {path}");
-            let iface = TargetGamepadInterface::new("Gamepad".into());
-            if let Err(e) = conn.object_server().at(path.clone(), iface).await {
-                log::debug!("Failed to start dbus interface {path}: {e:?}");
-            } else {
-                log::debug!("Started dbus interface on {path}");
-            }
-        });
-        Ok(())
-    }
-
-    /// Creates and runs the target device
-    pub async fn run(&mut self) -> Result<(), Box<dyn Error>> {
-        log::debug!("Creating virtual gamepad");
-        let device = self.create_virtual_device()?;
-
-        // Put the device behind an Arc Mutex so it can be shared between the
-        // read and write threads
-        let device = Arc::new(Mutex::new(device));
-
-        // Query information about the device to get the absolute ranges
-        let axes_map = self.get_abs_info();
-
-        // Listen for events from source devices
-        log::debug!("Started listening for events");
-        while let Some(command) = self.rx.recv().await {
-            match command {
-                TargetCommand::SetCompositeDevice(composite_device) => {
-                    self.set_composite_device(composite_device.clone());
-
-                    // Spawn a thread to listen for force feedback events
-                    let ff_device = device.clone();
-                    XBox360Controller::spawn_ff_thread(ff_device, composite_device);
-                }
-                TargetCommand::WriteEvent(event) => {
-                    log::trace!("Got event to emit: {:?}", event);
-                    let evdev_events = self.translate_event(event, axes_map.clone());
-                    if let Ok(mut dev) = device.lock() {
-                        dev.emit(evdev_events.as_slice())?;
-                        dev.emit(&[
-                            SynchronizationEvent::new(SynchronizationCode::SYN_REPORT, 0).into(),
-                        ])?;
-                    }
-                }
-                TargetCommand::GetCapabilities(tx) => {
-                    let caps = self.get_capabilities();
-                    if let Err(e) = tx.send(caps).await {
-                        log::error!("Failed to send target capabilities: {e:?}");
-                    }
-                }
-                TargetCommand::GetType(tx) => {
-                    if let Err(e) = tx.send("xb360".to_string()).await {
-                        log::error!("Failed to send target type: {e:?}");
-                    }
-                }
-                TargetCommand::Stop => break,
-            }
-        }
-
-        log::debug!(
-            "Stopping device {}",
-            self.dbus_path.clone().unwrap_or_default()
-        );
-
-        // Remove the DBus interface
-        if let Some(path) = self.dbus_path.clone() {
-            let conn = self.conn.clone();
-            let path = path.clone();
-            tokio::task::spawn(async move {
-                log::debug!("Stopping dbus interface for {path}");
-                let result = conn
-                    .object_server()
-                    .remove::<TargetGamepadInterface, String>(path.clone())
-                    .await;
-                if let Err(e) = result {
-                    log::error!("Failed to stop dbus interface {path}: {e:?}");
-                } else {
-                    log::debug!("Stopped dbus interface for {path}");
-                }
-            });
-        }
-
-        Ok(())
-    }
-
-    /// Translate the given native event into an evdev event
-    fn translate_event(
-        &self,
-        event: NativeEvent,
-        axis_map: HashMap<AbsoluteAxisCode, AbsInfo>,
-    ) -> Vec<InputEvent> {
-        EvdevEvent::from_native_event(event, axis_map)
-            .into_iter()
-            .map(|event| event.as_input_event())
-            .collect()
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        let axis_map = XBox360Controller::get_abs_info();
+        let device = XBox360Controller::create_virtual_device(&axis_map)?;
+        Ok(Self { device, axis_map })
     }
 
     /// Return a hashmap of ABS information for this virtual device. This information
     /// is used to denormalize input event values.
-    fn get_abs_info(&self) -> HashMap<AbsoluteAxisCode, AbsInfo> {
+    fn get_abs_info() -> HashMap<AbsoluteAxisCode, AbsInfo> {
         let mut axes_info = HashMap::new();
 
         let joystick_setup = AbsInfo::new(0, -32768, 32767, 16, 128, 1);
@@ -197,7 +55,9 @@ impl XBox360Controller {
     }
 
     /// Create the virtual device to emulate
-    fn create_virtual_device(&self) -> Result<VirtualDevice, Box<dyn Error>> {
+    fn create_virtual_device(
+        axis_map: &HashMap<AbsoluteAxisCode, AbsInfo>,
+    ) -> Result<VirtualDevice, Box<dyn Error>> {
         // Setup Key inputs
         let mut keys = AttributeSet::<KeyCode>::new();
         keys.insert(KeyCode::BTN_SOUTH);
@@ -217,17 +77,23 @@ impl XBox360Controller {
         keys.insert(KeyCode::BTN_TRIGGER_HAPPY4);
 
         // Setup ABS inputs
-        let joystick_setup = AbsInfo::new(0, -32768, 32767, 16, 128, 1);
-        let abs_x = UinputAbsSetup::new(AbsoluteAxisCode::ABS_X, joystick_setup);
-        let abs_y = UinputAbsSetup::new(AbsoluteAxisCode::ABS_Y, joystick_setup);
-        let abs_rx = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RX, joystick_setup);
-        let abs_ry = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RY, joystick_setup);
-        let triggers_setup = AbsInfo::new(0, 0, 255, 0, 0, 1);
-        let abs_z = UinputAbsSetup::new(AbsoluteAxisCode::ABS_Z, triggers_setup);
-        let abs_rz = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RZ, triggers_setup);
-        let dpad_setup = AbsInfo::new(0, -1, 1, 0, 0, 1);
-        let abs_hat0x = UinputAbsSetup::new(AbsoluteAxisCode::ABS_HAT0X, dpad_setup);
-        let abs_hat0y = UinputAbsSetup::new(AbsoluteAxisCode::ABS_HAT0Y, dpad_setup);
+        let Some(joystick_setup) = axis_map.get(&AbsoluteAxisCode::ABS_X) else {
+            return Err("No axis information for ABS_X".to_string().into());
+        };
+        let abs_x = UinputAbsSetup::new(AbsoluteAxisCode::ABS_X, *joystick_setup);
+        let abs_y = UinputAbsSetup::new(AbsoluteAxisCode::ABS_Y, *joystick_setup);
+        let abs_rx = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RX, *joystick_setup);
+        let abs_ry = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RY, *joystick_setup);
+        let Some(triggers_setup) = axis_map.get(&AbsoluteAxisCode::ABS_Z) else {
+            return Err("No axis information for ABS_Z".to_string().into());
+        };
+        let abs_z = UinputAbsSetup::new(AbsoluteAxisCode::ABS_Z, *triggers_setup);
+        let abs_rz = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RZ, *triggers_setup);
+        let Some(dpad_setup) = axis_map.get(&AbsoluteAxisCode::ABS_HAT0X) else {
+            return Err("No axis information for ABS_HAT0X".to_string().into());
+        };
+        let abs_hat0x = UinputAbsSetup::new(AbsoluteAxisCode::ABS_HAT0X, *dpad_setup);
+        let abs_hat0y = UinputAbsSetup::new(AbsoluteAxisCode::ABS_HAT0Y, *dpad_setup);
 
         // Setup Force Feedback
         let mut ff = AttributeSet::<FFEffectCode>::new();
@@ -267,142 +133,25 @@ impl XBox360Controller {
         Ok(device)
     }
 
-    /// Spawns the force-feedback handler thread
-    fn spawn_ff_thread(
-        ff_device: Arc<Mutex<VirtualDevice>>,
-        composite_device: CompositeDeviceClient,
-    ) {
-        tokio::task::spawn_blocking(move || {
-            loop {
-                // Check to see if the main input thread still has a reference
-                // to the virtual device. If it does not, it means the device
-                // has stopped.
-                let num_refs = Arc::strong_count(&ff_device);
-                if num_refs == 1 {
-                    log::debug!("Virtual device stopped. Stopping FF handler thread.");
-                    break;
-                }
-
-                // Read any events
-                if let Err(e) = XBox360Controller::process_ff(&ff_device, &composite_device) {
-                    log::warn!("Error processing FF events: {:?}", e);
-                }
-
-                // Sleep for the poll rate interval
-                thread::sleep(POLL_RATE);
-            }
-        });
+    /// Translate the given native event into an evdev event
+    fn translate_event(&self, event: NativeEvent) -> Vec<InputEvent> {
+        EvdevEvent::from_native_event(event, self.axis_map.clone())
+            .into_iter()
+            .map(|event| event.as_input_event())
+            .collect()
     }
+}
 
-    /// Process force feedback events from the given device
-    fn process_ff(
-        device: &Arc<Mutex<VirtualDevice>>,
-        composite_device: &CompositeDeviceClient,
-    ) -> Result<(), Box<dyn Error>> {
-        // Listen for events (Force Feedback Events)
-        let events = match device.lock() {
-            Ok(mut dev) => {
-                let res = dev.deref_mut().fetch_events();
-                match res {
-                    Ok(events) => events.collect(),
-                    Err(err) => match err.kind() {
-                        // Do nothing if this would block
-                        std::io::ErrorKind::WouldBlock => vec![],
-                        _ => {
-                            log::trace!("Failed to fetch events: {:?}", err);
-                            return Err(err.into());
-                        }
-                    },
-                }
-            }
-            Err(err) => {
-                log::trace!("Failed to lock device mutex: {:?}", err);
-                return Err(err.to_string().into());
-            }
-        };
-
-        const STOPPED: i32 = FFStatusCode::FF_STATUS_STOPPED.0 as i32;
-        const PLAYING: i32 = FFStatusCode::FF_STATUS_PLAYING.0 as i32;
-
-        // Process the events
-        for event in events {
-            match event.destructure() {
-                EventSummary::UInput(event, UInputCode::UI_FF_UPLOAD, ..) => {
-                    log::debug!("Got FF upload event");
-                    // Claim ownership of the FF upload and convert it to a FF_UPLOAD
-                    // event
-                    let mut event = device
-                        .lock()
-                        .map_err(|e| e.to_string())?
-                        .process_ff_upload(event)?;
-                    let effect_id = event.effect_id();
-
-                    log::debug!("Upload effect: {:?} with id {}", event.effect(), effect_id);
-
-                    // Send the effect data to be uploaded to the device and wait
-                    // for an effect ID to be generated.
-                    let (tx, rx) = std::sync::mpsc::channel::<Option<i16>>();
-                    let upload = OutputEvent::Uinput(UinputOutputEvent::FFUpload(
-                        effect_id,
-                        event.effect(),
-                        tx,
-                    ));
-                    if let Err(e) = composite_device.blocking_process_output_event(upload) {
-                        event.set_retval(-1);
-                        return Err(e.into());
-                    }
-                    let effect_id = match rx.recv_timeout(Duration::from_secs(1)) {
-                        Ok(id) => id,
-                        Err(e) => {
-                            event.set_retval(-1);
-                            return Err(e.into());
-                        }
-                    };
-
-                    // Set the effect ID for the FF effect
-                    if let Some(id) = effect_id {
-                        event.set_effect_id(id);
-                        event.set_retval(0);
-                    } else {
-                        log::warn!("Failed to get effect ID to upload FF effect");
-                        event.set_retval(-1);
-                    }
-                }
-                EventSummary::UInput(event, UInputCode::UI_FF_ERASE, ..) => {
-                    log::debug!("Got FF erase event");
-                    // Claim ownership of the FF erase event and convert it to a FF_ERASE
-                    // event.
-                    let event = device
-                        .lock()
-                        .map_err(|e| e.to_string())?
-                        .process_ff_erase(event)?;
-                    log::debug!("Erase effect: {:?}", event.effect_id());
-
-                    let erase = OutputEvent::Uinput(UinputOutputEvent::FFErase(event.effect_id()));
-                    composite_device.blocking_process_output_event(erase)?;
-                }
-                EventSummary::ForceFeedback(.., effect_id, STOPPED) => {
-                    log::debug!("Stopped effect ID: {}", effect_id.0);
-                    log::debug!("Stopping event: {:?}", event);
-                    composite_device.blocking_process_output_event(OutputEvent::Evdev(event))?;
-                }
-                EventSummary::ForceFeedback(.., effect_id, PLAYING) => {
-                    log::debug!("Playing effect ID: {}", effect_id.0);
-                    log::debug!("Playing event: {:?}", event);
-                    composite_device.blocking_process_output_event(OutputEvent::Evdev(event))?;
-                }
-                _ => {
-                    log::debug!("Unhandled event: {:?}", event);
-                }
-            }
-        }
-
+impl TargetInputDevice for XBox360Controller {
+    fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
+        log::trace!("Received event: {event:?}");
+        let evdev_events = self.translate_event(event);
+        self.device.emit(evdev_events.as_slice())?;
         Ok(())
     }
 
-    /// Returns capabilities of the target device
-    fn get_capabilities(&self) -> Vec<Capability> {
-        vec![
+    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
+        Ok(vec![
             Capability::Gamepad(Gamepad::Axis(GamepadAxis::LeftStick)),
             Capability::Gamepad(Gamepad::Axis(GamepadAxis::RightStick)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::DPadDown)),
@@ -424,6 +173,107 @@ impl XBox360Controller {
             Capability::Gamepad(Gamepad::Button(GamepadButton::West)),
             Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::LeftTrigger)),
             Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::RightTrigger)),
-        ]
+        ])
+    }
+}
+
+impl TargetOutputDevice for XBox360Controller {
+    /// Process force feedback events from the device
+    fn poll(
+        &mut self,
+        composite_device: &Option<CompositeDeviceClient>,
+    ) -> Result<Vec<OutputEvent>, OutputError> {
+        // Fetch any force feedback events from the device
+        let events: Vec<InputEvent> = match self.device.fetch_events() {
+            Ok(events) => events.collect(),
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::WouldBlock => vec![],
+                _ => {
+                    return Err(e.to_string().into());
+                }
+            },
+        };
+
+        const STOPPED: i32 = FFStatusCode::FF_STATUS_STOPPED.0 as i32;
+        const PLAYING: i32 = FFStatusCode::FF_STATUS_PLAYING.0 as i32;
+
+        // Process the events
+        let mut output_events = vec![];
+        for event in events {
+            match event.destructure() {
+                EventSummary::UInput(event, UInputCode::UI_FF_UPLOAD, ..) => {
+                    log::debug!("Got FF upload event");
+                    // Claim ownership of the FF upload and convert it to a FF_UPLOAD
+                    // event
+                    let mut event = self.device.process_ff_upload(event)?;
+                    let effect_id = event.effect_id();
+
+                    log::debug!("Upload effect: {:?} with id {}", event.effect(), effect_id);
+                    let Some(composite_device) = composite_device else {
+                        log::debug!("No composite device to upload effect to!");
+                        event.set_retval(-1);
+                        return Ok(vec![]);
+                    };
+
+                    // Send the effect data to be uploaded to the device and wait
+                    // for an effect ID to be generated.
+                    let (tx, rx) = std::sync::mpsc::channel::<Option<i16>>();
+                    let upload = OutputEvent::Uinput(UinputOutputEvent::FFUpload(
+                        effect_id,
+                        event.effect(),
+                        tx,
+                    ));
+                    if let Err(e) = composite_device.blocking_process_output_event(upload) {
+                        event.set_retval(-1);
+                        return Err(e.to_string().into());
+                    }
+                    let effect_id = match rx.recv_timeout(Duration::from_secs(1)) {
+                        Ok(id) => id,
+                        Err(e) => {
+                            event.set_retval(-1);
+                            return Err(e.to_string().into());
+                        }
+                    };
+
+                    // Set the effect ID for the FF effect
+                    if let Some(id) = effect_id {
+                        event.set_effect_id(id);
+                        event.set_retval(0);
+                    } else {
+                        log::warn!("Failed to get effect ID to upload FF effect");
+                        event.set_retval(-1);
+                    }
+                }
+                EventSummary::UInput(event, UInputCode::UI_FF_ERASE, ..) => {
+                    log::debug!("Got FF erase event");
+                    // Claim ownership of the FF erase event and convert it to a FF_ERASE
+                    // event.
+                    let event = self.device.process_ff_erase(event)?;
+                    log::debug!("Erase effect: {:?}", event.effect_id());
+
+                    let erase = OutputEvent::Uinput(UinputOutputEvent::FFErase(event.effect_id()));
+                    output_events.push(erase);
+                }
+                EventSummary::ForceFeedback(.., effect_id, STOPPED) => {
+                    log::debug!("Stopped effect ID: {}", effect_id.0);
+                    log::debug!("Stopping event: {:?}", event);
+                    output_events.push(OutputEvent::Evdev(event));
+                }
+                EventSummary::ForceFeedback(.., effect_id, PLAYING) => {
+                    log::debug!("Playing effect ID: {}", effect_id.0);
+                    log::debug!("Playing event: {:?}", event);
+                    output_events.push(OutputEvent::Evdev(event));
+                }
+                _ => {
+                    log::debug!("Unhandled event: {:?}", event);
+                }
+            }
+        }
+
+        Ok(output_events)
+    }
+
+    fn get_output_capabilities(&self) -> Result<Vec<OutputCapability>, OutputError> {
+        Ok(vec![OutputCapability::ForceFeedback])
     }
 }

--- a/src/input/target/xbox_elite.rs
+++ b/src/input/target/xbox_elite.rs
@@ -13,7 +13,7 @@ use nix::fcntl::{FcntlArg, OFlag};
 use crate::input::capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger};
 use crate::input::composite_device::client::CompositeDeviceClient;
 use crate::input::event::evdev::EvdevEvent;
-use crate::input::event::native::NativeEvent;
+use crate::input::event::native::{NativeEvent, ScheduledNativeEvent};
 use crate::input::output_capability::OutputCapability;
 use crate::input::output_event::{OutputEvent, UinputOutputEvent};
 
@@ -23,13 +23,18 @@ use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
 pub struct XboxEliteController {
     device: VirtualDevice,
     axis_map: HashMap<AbsoluteAxisCode, AbsInfo>,
+    queued_events: Vec<ScheduledNativeEvent>,
 }
 
 impl XboxEliteController {
     pub fn new() -> Result<Self, Box<dyn Error>> {
         let axis_map = XboxEliteController::get_abs_info();
         let device = XboxEliteController::create_virtual_device(&axis_map)?;
-        Ok(Self { device, axis_map })
+        Ok(Self {
+            device,
+            axis_map,
+            queued_events: Vec::new(),
+        })
     }
 
     /// Return a hashmap of ABS information for this virtual device. This information
@@ -149,7 +154,37 @@ impl XboxEliteController {
 
 impl TargetInputDevice for XboxEliteController {
     fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
-        log::trace!("Received event: {event:?}");
+        log::debug!("Received event: {event:?}");
+
+        // Check for QuickAccess, create chord for event.
+        let cap = event.as_capability();
+        if cap == Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)) {
+            let pressed = event.pressed();
+            let guide = NativeEvent::new(
+                Capability::Gamepad(Gamepad::Button(GamepadButton::Guide)),
+                event.get_value(),
+            );
+            let south = NativeEvent::new(
+                Capability::Gamepad(Gamepad::Button(GamepadButton::South)),
+                event.get_value(),
+            );
+
+            let (guide, south) = if pressed {
+                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                (guide, south)
+            } else {
+                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(160));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                (guide, south)
+            };
+
+            self.queued_events.push(guide);
+            self.queued_events.push(south);
+            log::debug!("Added QAM Chord to queued events!");
+            return Ok(());
+        }
+
         let evdev_events = self.translate_event(event);
         self.device.emit(evdev_events.as_slice())?;
         Ok(())
@@ -171,6 +206,7 @@ impl TargetInputDevice for XboxEliteController {
             Capability::Gamepad(Gamepad::Button(GamepadButton::LeftStick)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::LeftTrigger)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::North)),
+            Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::RightBumper)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::RightPaddle1)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::RightPaddle2)),
@@ -184,6 +220,14 @@ impl TargetInputDevice for XboxEliteController {
             Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::LeftTrigger)),
             Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::RightTrigger)),
         ])
+    }
+
+    /// Returns any events in the queue up to the [TargetDriver]
+    fn scheduled_events(&mut self) -> Option<Vec<ScheduledNativeEvent>> {
+        if self.queued_events.is_empty() {
+            return None;
+        }
+        Some(self.queued_events.drain(..).collect())
     }
 }
 

--- a/src/input/target/xbox_series.rs
+++ b/src/input/target/xbox_series.rs
@@ -13,7 +13,7 @@ use nix::fcntl::{FcntlArg, OFlag};
 use crate::input::capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger};
 use crate::input::composite_device::client::CompositeDeviceClient;
 use crate::input::event::evdev::EvdevEvent;
-use crate::input::event::native::NativeEvent;
+use crate::input::event::native::{NativeEvent, ScheduledNativeEvent};
 use crate::input::output_capability::OutputCapability;
 use crate::input::output_event::{OutputEvent, UinputOutputEvent};
 
@@ -23,13 +23,18 @@ use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
 pub struct XboxSeriesController {
     device: VirtualDevice,
     axis_map: HashMap<AbsoluteAxisCode, AbsInfo>,
+    queued_events: Vec<ScheduledNativeEvent>,
 }
 
 impl XboxSeriesController {
     pub fn new() -> Result<Self, Box<dyn Error>> {
         let axis_map = XboxSeriesController::get_abs_info();
         let device = XboxSeriesController::create_virtual_device(&axis_map)?;
-        Ok(Self { device, axis_map })
+        Ok(Self {
+            device,
+            axis_map,
+            queued_events: Vec::new(),
+        })
     }
 
     /// Return a hashmap of ABS information for this virtual device. This information
@@ -146,6 +151,35 @@ impl XboxSeriesController {
 impl TargetInputDevice for XboxSeriesController {
     fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
         log::trace!("Received event: {event:?}");
+
+        // Check for QuickAccess, create chord for event.
+        let cap = event.as_capability();
+        if cap == Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)) {
+            let pressed = event.pressed();
+            let guide = NativeEvent::new(
+                Capability::Gamepad(Gamepad::Button(GamepadButton::Guide)),
+                event.get_value(),
+            );
+            let south = NativeEvent::new(
+                Capability::Gamepad(Gamepad::Button(GamepadButton::South)),
+                event.get_value(),
+            );
+
+            let (guide, south) = if pressed {
+                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                (guide, south)
+            } else {
+                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(160));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                (guide, south)
+            };
+
+            self.queued_events.push(guide);
+            self.queued_events.push(south);
+            return Ok(());
+        }
+
         let evdev_events = self.translate_event(event);
         self.device.emit(evdev_events.as_slice())?;
         Ok(())
@@ -165,6 +199,7 @@ impl TargetInputDevice for XboxSeriesController {
             Capability::Gamepad(Gamepad::Button(GamepadButton::LeftStick)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::LeftTrigger)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::North)),
+            Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::RightBumper)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::RightStick)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::RightTrigger)),
@@ -176,6 +211,14 @@ impl TargetInputDevice for XboxSeriesController {
             Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::LeftTrigger)),
             Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::RightTrigger)),
         ])
+    }
+
+    /// Returns any events in the queue up to the [TargetDriver]
+    fn scheduled_events(&mut self) -> Option<Vec<ScheduledNativeEvent>> {
+        if self.queued_events.is_empty() {
+            return None;
+        }
+        Some(self.queued_events.drain(..).collect())
     }
 }
 

--- a/src/input/target/xbox_series.rs
+++ b/src/input/target/xbox_series.rs
@@ -1,182 +1,40 @@
-use std::{
-    collections::HashMap,
-    error::Error,
-    ops::DerefMut,
-    os::fd::AsRawFd,
-    sync::{Arc, Mutex},
-    thread,
-};
+use std::os::fd::AsRawFd;
+use std::time::Duration;
+use std::{collections::HashMap, error::Error};
 
 use evdev::{
     uinput::{VirtualDevice, VirtualDeviceBuilder},
-    AbsInfo, AbsoluteAxisCode, AttributeSet, BusType, EventSummary, FFEffectCode, FFStatusCode,
-    InputEvent, InputId, KeyCode, SynchronizationCode, SynchronizationEvent, UInputCode,
+    AbsInfo, AbsoluteAxisCode, AttributeSet, BusType, FFEffectCode, InputId, KeyCode,
     UinputAbsSetup,
 };
+use evdev::{EventSummary, FFStatusCode, InputEvent, UInputCode};
 use nix::fcntl::{FcntlArg, OFlag};
-use tokio::{sync::mpsc, time::Duration};
-use zbus::Connection;
 
-use crate::{
-    dbus::interface::target::gamepad::TargetGamepadInterface,
-    input::{
-        capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger},
-        composite_device::client::CompositeDeviceClient,
-        event::{evdev::EvdevEvent, native::NativeEvent},
-        output_event::{OutputEvent, UinputOutputEvent},
-    },
-};
+use crate::input::capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger};
+use crate::input::composite_device::client::CompositeDeviceClient;
+use crate::input::event::evdev::EvdevEvent;
+use crate::input::event::native::NativeEvent;
+use crate::input::output_capability::OutputCapability;
+use crate::input::output_event::{OutputEvent, UinputOutputEvent};
 
-use super::{client::TargetDeviceClient, command::TargetCommand};
-
-/// Size of the [TargetCommand] buffer for receiving input events
-const BUFFER_SIZE: usize = 2048;
-/// How long to sleep before polling for events.
-const POLL_RATE: Duration = Duration::from_millis(8); //125Hz is standard for xbox controllers
+use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
 
 #[derive(Debug)]
 pub struct XboxSeriesController {
-    conn: Connection,
-    dbus_path: Option<String>,
-    tx: mpsc::Sender<TargetCommand>,
-    rx: mpsc::Receiver<TargetCommand>,
-    composite_device: Option<CompositeDeviceClient>,
+    device: VirtualDevice,
+    axis_map: HashMap<AbsoluteAxisCode, AbsInfo>,
 }
 
 impl XboxSeriesController {
-    pub fn new(conn: Connection) -> Self {
-        let (tx, rx) = mpsc::channel(BUFFER_SIZE);
-        Self {
-            conn,
-            dbus_path: None,
-            tx,
-            rx,
-            composite_device: None,
-        }
-    }
-
-    /// Returns the DBus path of this device
-    pub fn _get_dbus_path(&self) -> Option<String> {
-        self.dbus_path.clone()
-    }
-
-    /// Returns a client channel that can be used to send events to this device
-    pub fn client(&self) -> TargetDeviceClient {
-        self.tx.clone().into()
-    }
-
-    /// Configures the device to send output events to the given composite device
-    /// channel.
-    pub fn set_composite_device(&mut self, composite_device: CompositeDeviceClient) {
-        self.composite_device = Some(composite_device);
-    }
-
-    /// Creates a new instance of the dbus device interface on DBus.
-    pub async fn listen_on_dbus(&mut self, path: String) -> Result<(), Box<dyn Error>> {
-        log::debug!("Starting dbus interface on {path}");
-        let conn = self.conn.clone();
-        self.dbus_path = Some(path.clone());
-        tokio::spawn(async move {
-            log::debug!("Starting dbus interface: {path}");
-            let iface = TargetGamepadInterface::new("Gamepad".into());
-            if let Err(e) = conn.object_server().at(path.clone(), iface).await {
-                log::debug!("Failed to start dbus interface {path}: {e:?}");
-            } else {
-                log::debug!("Started dbus interface on {path}");
-            }
-        });
-        Ok(())
-    }
-
-    /// Creates and runs the target device
-    pub async fn run(&mut self) -> Result<(), Box<dyn Error>> {
-        log::debug!("Creating virtual Xbox Series gamepad");
-        let device = self.create_virtual_device()?;
-
-        // Put the device behind an Arc Mutex so it can be shared between the
-        // read and write threads
-        let device = Arc::new(Mutex::new(device));
-
-        // Query information about the device to get the absolute ranges
-        let axes_map = self.get_abs_info();
-
-        // Listen for events from source devices
-        log::debug!("Started listening for events");
-        while let Some(command) = self.rx.recv().await {
-            match command {
-                TargetCommand::SetCompositeDevice(composite_device) => {
-                    self.set_composite_device(composite_device.clone());
-
-                    // Spawn a thread to listen for force feedback events
-                    let ff_device = device.clone();
-                    XboxSeriesController::spawn_ff_thread(ff_device, composite_device);
-                }
-                TargetCommand::WriteEvent(event) => {
-                    log::trace!("Got event to emit: {:?}", event);
-                    let evdev_events = self.translate_event(event, axes_map.clone());
-                    if let Ok(mut dev) = device.lock() {
-                        dev.emit(evdev_events.as_slice())?;
-                        dev.emit(&[
-                            SynchronizationEvent::new(SynchronizationCode::SYN_REPORT, 0).into(),
-                        ])?;
-                    }
-                }
-                TargetCommand::GetCapabilities(tx) => {
-                    let caps = self.get_capabilities();
-                    if let Err(e) = tx.send(caps).await {
-                        log::error!("Failed to send target capabilities: {e:?}");
-                    }
-                }
-                TargetCommand::GetType(tx) => {
-                    if let Err(e) = tx.send("xbox-elite".to_string()).await {
-                        log::error!("Failed to send target type: {e:?}");
-                    }
-                }
-                TargetCommand::Stop => break,
-            }
-        }
-
-        log::debug!(
-            "Stopping device {}",
-            self.dbus_path.clone().unwrap_or_default()
-        );
-
-        // Remove the DBus interface
-        if let Some(path) = self.dbus_path.clone() {
-            let conn = self.conn.clone();
-            let path = path.clone();
-            tokio::task::spawn(async move {
-                log::debug!("Stopping dbus interface for {path}");
-                let result = conn
-                    .object_server()
-                    .remove::<TargetGamepadInterface, String>(path.clone())
-                    .await;
-                if let Err(e) = result {
-                    log::error!("Failed to stop dbus interface {path}: {e:?}");
-                } else {
-                    log::debug!("Stopped dbus interface for {path}");
-                }
-            });
-        }
-
-        Ok(())
-    }
-
-    /// Translate the given native event into an evdev event
-    fn translate_event(
-        &self,
-        event: NativeEvent,
-        axis_map: HashMap<AbsoluteAxisCode, AbsInfo>,
-    ) -> Vec<InputEvent> {
-        EvdevEvent::from_native_event(event, axis_map)
-            .into_iter()
-            .map(|event| event.as_input_event())
-            .collect()
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        let axis_map = XboxSeriesController::get_abs_info();
+        let device = XboxSeriesController::create_virtual_device(&axis_map)?;
+        Ok(Self { device, axis_map })
     }
 
     /// Return a hashmap of ABS information for this virtual device. This information
     /// is used to denormalize input event values.
-    fn get_abs_info(&self) -> HashMap<AbsoluteAxisCode, AbsInfo> {
+    fn get_abs_info() -> HashMap<AbsoluteAxisCode, AbsInfo> {
         let mut axes_info = HashMap::new();
 
         let joystick_setup = AbsInfo::new(0, -32768, 32767, 16, 128, 1);
@@ -197,7 +55,9 @@ impl XboxSeriesController {
     }
 
     /// Create the virtual device to emulate
-    fn create_virtual_device(&self) -> Result<VirtualDevice, Box<dyn Error>> {
+    fn create_virtual_device(
+        axis_map: &HashMap<AbsoluteAxisCode, AbsInfo>,
+    ) -> Result<VirtualDevice, Box<dyn Error>> {
         // Setup Key inputs
         let mut keys = AttributeSet::<KeyCode>::new();
         keys.insert(KeyCode::KEY_RECORD);
@@ -218,17 +78,23 @@ impl XboxSeriesController {
         keys.insert(KeyCode::BTN_TRIGGER_HAPPY4);
 
         // Setup ABS inputs
-        let joystick_setup = AbsInfo::new(0, -32768, 32767, 16, 128, 1);
-        let abs_x = UinputAbsSetup::new(AbsoluteAxisCode::ABS_X, joystick_setup);
-        let abs_y = UinputAbsSetup::new(AbsoluteAxisCode::ABS_Y, joystick_setup);
-        let abs_rx = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RX, joystick_setup);
-        let abs_ry = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RY, joystick_setup);
-        let triggers_setup = AbsInfo::new(0, 0, 255, 0, 0, 1);
-        let abs_z = UinputAbsSetup::new(AbsoluteAxisCode::ABS_Z, triggers_setup);
-        let abs_rz = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RZ, triggers_setup);
-        let dpad_setup = AbsInfo::new(0, -1, 1, 0, 0, 1);
-        let abs_hat0x = UinputAbsSetup::new(AbsoluteAxisCode::ABS_HAT0X, dpad_setup);
-        let abs_hat0y = UinputAbsSetup::new(AbsoluteAxisCode::ABS_HAT0Y, dpad_setup);
+        let Some(joystick_setup) = axis_map.get(&AbsoluteAxisCode::ABS_X) else {
+            return Err("No axis information for ABS_X".to_string().into());
+        };
+        let abs_x = UinputAbsSetup::new(AbsoluteAxisCode::ABS_X, *joystick_setup);
+        let abs_y = UinputAbsSetup::new(AbsoluteAxisCode::ABS_Y, *joystick_setup);
+        let abs_rx = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RX, *joystick_setup);
+        let abs_ry = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RY, *joystick_setup);
+        let Some(triggers_setup) = axis_map.get(&AbsoluteAxisCode::ABS_Z) else {
+            return Err("No axis information for ABS_Z".to_string().into());
+        };
+        let abs_z = UinputAbsSetup::new(AbsoluteAxisCode::ABS_Z, *triggers_setup);
+        let abs_rz = UinputAbsSetup::new(AbsoluteAxisCode::ABS_RZ, *triggers_setup);
+        let Some(dpad_setup) = axis_map.get(&AbsoluteAxisCode::ABS_HAT0X) else {
+            return Err("No axis information for ABS_HAT0X".to_string().into());
+        };
+        let abs_hat0x = UinputAbsSetup::new(AbsoluteAxisCode::ABS_HAT0X, *dpad_setup);
+        let abs_hat0y = UinputAbsSetup::new(AbsoluteAxisCode::ABS_HAT0Y, *dpad_setup);
 
         // Setup Force Feedback
         let mut ff = AttributeSet::<FFEffectCode>::new();
@@ -239,7 +105,7 @@ impl XboxSeriesController {
         ff.insert(FFEffectCode::FF_SINE);
         ff.insert(FFEffectCode::FF_GAIN);
 
-        // Identify to the kernel as an Xbox One Series
+        // Identify to the kernel as an Xbox One Elite
         let id = InputId::new(BusType(3), 0x045e, 0x0b12, 0x0001);
 
         // Build the device
@@ -268,142 +134,25 @@ impl XboxSeriesController {
         Ok(device)
     }
 
-    /// Spawns the force-feedback handler thread
-    fn spawn_ff_thread(
-        ff_device: Arc<Mutex<VirtualDevice>>,
-        composite_device: CompositeDeviceClient,
-    ) {
-        tokio::task::spawn_blocking(move || {
-            loop {
-                // Check to see if the main input thread still has a reference
-                // to the virtual device. If it does not, it means the device
-                // has stopped.
-                let num_refs = Arc::strong_count(&ff_device);
-                if num_refs == 1 {
-                    log::debug!("Virtual device stopped. Stopping FF handler thread.");
-                    break;
-                }
-
-                // Read any events
-                if let Err(e) = XboxSeriesController::process_ff(&ff_device, &composite_device) {
-                    log::warn!("Error processing FF events: {:?}", e);
-                }
-
-                // Sleep for the poll rate interval
-                thread::sleep(POLL_RATE);
-            }
-        });
+    /// Translate the given native event into an evdev event
+    fn translate_event(&self, event: NativeEvent) -> Vec<InputEvent> {
+        EvdevEvent::from_native_event(event, self.axis_map.clone())
+            .into_iter()
+            .map(|event| event.as_input_event())
+            .collect()
     }
+}
 
-    /// Process force feedback events from the given device
-    fn process_ff(
-        device: &Arc<Mutex<VirtualDevice>>,
-        composite_device: &CompositeDeviceClient,
-    ) -> Result<(), Box<dyn Error>> {
-        // Listen for events (Force Feedback Events)
-        let events = match device.lock() {
-            Ok(mut dev) => {
-                let res = dev.deref_mut().fetch_events();
-                match res {
-                    Ok(events) => events.collect(),
-                    Err(err) => match err.kind() {
-                        // Do nothing if this would block
-                        std::io::ErrorKind::WouldBlock => vec![],
-                        _ => {
-                            log::trace!("Failed to fetch events: {:?}", err);
-                            return Err(err.into());
-                        }
-                    },
-                }
-            }
-            Err(err) => {
-                log::trace!("Failed to lock device mutex: {:?}", err);
-                return Err(err.to_string().into());
-            }
-        };
-
-        const STOPPED: i32 = FFStatusCode::FF_STATUS_STOPPED.0 as i32;
-        const PLAYING: i32 = FFStatusCode::FF_STATUS_PLAYING.0 as i32;
-
-        // Process the events
-        for event in events {
-            match event.destructure() {
-                EventSummary::UInput(event, UInputCode::UI_FF_UPLOAD, ..) => {
-                    log::debug!("Got FF upload event");
-                    // Claim ownership of the FF upload and convert it to a FF_UPLOAD
-                    // event
-                    let mut event = device
-                        .lock()
-                        .map_err(|e| e.to_string())?
-                        .process_ff_upload(event)?;
-                    let effect_id = event.effect_id();
-
-                    log::debug!("Upload effect: {:?} with id {}", event.effect(), effect_id);
-
-                    // Send the effect data to be uploaded to the device and wait
-                    // for an effect ID to be generated.
-                    let (tx, rx) = std::sync::mpsc::channel::<Option<i16>>();
-                    let upload = OutputEvent::Uinput(UinputOutputEvent::FFUpload(
-                        effect_id,
-                        event.effect(),
-                        tx,
-                    ));
-                    if let Err(e) = composite_device.blocking_process_output_event(upload) {
-                        event.set_retval(-1);
-                        return Err(e.into());
-                    }
-                    let effect_id = match rx.recv_timeout(Duration::from_secs(1)) {
-                        Ok(id) => id,
-                        Err(e) => {
-                            event.set_retval(-1);
-                            return Err(e.into());
-                        }
-                    };
-
-                    // Set the effect ID for the FF effect
-                    if let Some(id) = effect_id {
-                        event.set_effect_id(id);
-                        event.set_retval(0);
-                    } else {
-                        log::warn!("Failed to get effect ID to upload FF effect");
-                        event.set_retval(-1);
-                    }
-                }
-                EventSummary::UInput(event, UInputCode::UI_FF_ERASE, ..) => {
-                    log::debug!("Got FF erase event");
-                    // Claim ownership of the FF erase event and convert it to a FF_ERASE
-                    // event.
-                    let event = device
-                        .lock()
-                        .map_err(|e| e.to_string())?
-                        .process_ff_erase(event)?;
-                    log::debug!("Erase effect: {:?}", event.effect_id());
-
-                    let erase = OutputEvent::Uinput(UinputOutputEvent::FFErase(event.effect_id()));
-                    composite_device.blocking_process_output_event(erase)?;
-                }
-                EventSummary::ForceFeedback(.., effect_id, STOPPED) => {
-                    log::debug!("Stopped effect ID: {}", effect_id.0);
-                    log::debug!("Stopping event: {:?}", event);
-                    composite_device.blocking_process_output_event(OutputEvent::Evdev(event))?;
-                }
-                EventSummary::ForceFeedback(.., effect_id, PLAYING) => {
-                    log::debug!("Playing effect ID: {}", effect_id.0);
-                    log::debug!("Playing event: {:?}", event);
-                    composite_device.blocking_process_output_event(OutputEvent::Evdev(event))?;
-                }
-                _ => {
-                    log::debug!("Unhandled event: {:?}", event);
-                }
-            }
-        }
-
+impl TargetInputDevice for XboxSeriesController {
+    fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
+        log::trace!("Received event: {event:?}");
+        let evdev_events = self.translate_event(event);
+        self.device.emit(evdev_events.as_slice())?;
         Ok(())
     }
 
-    /// Returns capabilities of the target device
-    fn get_capabilities(&self) -> Vec<Capability> {
-        vec![
+    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
+        Ok(vec![
             Capability::Gamepad(Gamepad::Axis(GamepadAxis::LeftStick)),
             Capability::Gamepad(Gamepad::Axis(GamepadAxis::RightStick)),
             Capability::Gamepad(Gamepad::Button(GamepadButton::DPadDown)),
@@ -426,6 +175,107 @@ impl XboxSeriesController {
             Capability::Gamepad(Gamepad::Button(GamepadButton::West)),
             Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::LeftTrigger)),
             Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::RightTrigger)),
-        ]
+        ])
+    }
+}
+
+impl TargetOutputDevice for XboxSeriesController {
+    /// Process force feedback events from the device
+    fn poll(
+        &mut self,
+        composite_device: &Option<CompositeDeviceClient>,
+    ) -> Result<Vec<OutputEvent>, OutputError> {
+        // Fetch any force feedback events from the device
+        let events: Vec<InputEvent> = match self.device.fetch_events() {
+            Ok(events) => events.collect(),
+            Err(e) => match e.kind() {
+                std::io::ErrorKind::WouldBlock => vec![],
+                _ => {
+                    return Err(e.to_string().into());
+                }
+            },
+        };
+
+        const STOPPED: i32 = FFStatusCode::FF_STATUS_STOPPED.0 as i32;
+        const PLAYING: i32 = FFStatusCode::FF_STATUS_PLAYING.0 as i32;
+
+        // Process the events
+        let mut output_events = vec![];
+        for event in events {
+            match event.destructure() {
+                EventSummary::UInput(event, UInputCode::UI_FF_UPLOAD, ..) => {
+                    log::debug!("Got FF upload event");
+                    // Claim ownership of the FF upload and convert it to a FF_UPLOAD
+                    // event
+                    let mut event = self.device.process_ff_upload(event)?;
+                    let effect_id = event.effect_id();
+
+                    log::debug!("Upload effect: {:?} with id {}", event.effect(), effect_id);
+                    let Some(composite_device) = composite_device else {
+                        log::debug!("No composite device to upload effect to!");
+                        event.set_retval(-1);
+                        return Ok(vec![]);
+                    };
+
+                    // Send the effect data to be uploaded to the device and wait
+                    // for an effect ID to be generated.
+                    let (tx, rx) = std::sync::mpsc::channel::<Option<i16>>();
+                    let upload = OutputEvent::Uinput(UinputOutputEvent::FFUpload(
+                        effect_id,
+                        event.effect(),
+                        tx,
+                    ));
+                    if let Err(e) = composite_device.blocking_process_output_event(upload) {
+                        event.set_retval(-1);
+                        return Err(e.to_string().into());
+                    }
+                    let effect_id = match rx.recv_timeout(Duration::from_secs(1)) {
+                        Ok(id) => id,
+                        Err(e) => {
+                            event.set_retval(-1);
+                            return Err(e.to_string().into());
+                        }
+                    };
+
+                    // Set the effect ID for the FF effect
+                    if let Some(id) = effect_id {
+                        event.set_effect_id(id);
+                        event.set_retval(0);
+                    } else {
+                        log::warn!("Failed to get effect ID to upload FF effect");
+                        event.set_retval(-1);
+                    }
+                }
+                EventSummary::UInput(event, UInputCode::UI_FF_ERASE, ..) => {
+                    log::debug!("Got FF erase event");
+                    // Claim ownership of the FF erase event and convert it to a FF_ERASE
+                    // event.
+                    let event = self.device.process_ff_erase(event)?;
+                    log::debug!("Erase effect: {:?}", event.effect_id());
+
+                    let erase = OutputEvent::Uinput(UinputOutputEvent::FFErase(event.effect_id()));
+                    output_events.push(erase);
+                }
+                EventSummary::ForceFeedback(.., effect_id, STOPPED) => {
+                    log::debug!("Stopped effect ID: {}", effect_id.0);
+                    log::debug!("Stopping event: {:?}", event);
+                    output_events.push(OutputEvent::Evdev(event));
+                }
+                EventSummary::ForceFeedback(.., effect_id, PLAYING) => {
+                    log::debug!("Playing effect ID: {}", effect_id.0);
+                    log::debug!("Playing event: {:?}", event);
+                    output_events.push(OutputEvent::Evdev(event));
+                }
+                _ => {
+                    log::debug!("Unhandled event: {:?}", event);
+                }
+            }
+        }
+
+        Ok(output_events)
+    }
+
+    fn get_output_capabilities(&self) -> Result<Vec<OutputCapability>, OutputError> {
+        Ok(vec![OutputCapability::ForceFeedback])
     }
 }

--- a/src/udev/device.rs
+++ b/src/udev/device.rs
@@ -300,7 +300,7 @@ impl UdevDevice {
 
     /// Returns true if this device is virtual
     pub fn is_virtual(&self) -> bool {
-        self.syspath().contains("/devices/virtual")
+        self.syspath().contains("/devices/virtual") || self.syspath().contains("vhci_hcd")
     }
 
     /// Returns the devnode of the device. The devnode is the full path to the


### PR DESCRIPTION
Tested with Sony DualSense source device.

![image](https://github.com/user-attachments/assets/f25d8d19-d112-46cd-99fe-647f773984bd)

![image](https://github.com/user-attachments/assets/36479405-3571-4390-9127-6b5ca5a290ed)
