### PR TITLE
Fix back buttons for ASUS ROG ALLY and ROG ALLY X

### DIFF
--- a/src/drivers/rog_ally/driver.rs
+++ b/src/drivers/rog_ally/driver.rs
@@ -38,8 +38,8 @@ impl Driver {
                 "02" => {
                     // Ally and Ally X, map back buttons and ensure it is in gamepad mode.
                     log::debug!("Setting buttons and gamepad mode.");
-                    set_attribute(device.clone(), "btn_m1/remap", "kb_f15")?;
-                    set_attribute(device.clone(), "btn_m2/remap", "kb_f14")?;
+                    set_attribute(device.clone(), "btn_m1/remap", "KB_F15")?;
+                    set_attribute(device.clone(), "btn_m2/remap", "KB_F14")?;
                     set_attribute(device, "gamepad_mode", "1")?;
                     //TODO: Figure out why this fails and manually running the same thing
                     //doesn't.


### PR DESCRIPTION
Case sensitivity update (to all caps) for the button remapping fixes the back buttons to working status again for ASUS ROG ALLY and ROG ALLY X (with latest kernel patches from Luke Jones).