### PR TITLE
feat(TargetMouse): add MoveCursor method to virtual mouse interface

### DIFF
--- a/src/dbus/interface/target/mouse.rs
+++ b/src/dbus/interface/target/mouse.rs
@@ -1,20 +1,22 @@
 use zbus::fdo;
 use zbus_macros::interface;
 
+use crate::input::{
+    capability::{Capability, Mouse},
+    event::{native::NativeEvent, value::InputValue},
+    target::client::TargetDeviceClient,
+};
+
 /// The [TargetMouseInterface] provides a DBus interface that can be exposed for managing
 /// a [MouseDevice]. It works by sending command messages to a channel that the
 /// [MouseDevice] is listening on.
-pub struct TargetMouseInterface {}
-
-impl TargetMouseInterface {
-    pub fn new() -> TargetMouseInterface {
-        TargetMouseInterface {}
-    }
+pub struct TargetMouseInterface {
+    target_device: TargetDeviceClient,
 }
 
-impl Default for TargetMouseInterface {
-    fn default() -> Self {
-        Self::new()
+impl TargetMouseInterface {
+    pub fn new(target_device: TargetDeviceClient) -> TargetMouseInterface {
+        TargetMouseInterface { target_device }
     }
 }
 
@@ -24,5 +26,24 @@ impl TargetMouseInterface {
     #[zbus(property)]
     async fn name(&self) -> fdo::Result<String> {
         Ok("Mouse".into())
+    }
+
+    /// Move the virtual mouse by the given amount relative to the cursor's
+    /// relative position.
+    async fn move_cursor(&self, x: i32, y: i32) -> fdo::Result<()> {
+        // Create a mouse motion event
+        let value = InputValue::Vector2 {
+            x: Some(x as f64),
+            y: Some(y as f64),
+        };
+        let event = NativeEvent::new(Capability::Mouse(Mouse::Motion), value);
+
+        // Write the event to the virtual mouse
+        self.target_device
+            .write_event(event)
+            .await
+            .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+
+        Ok(())
     }
 }

--- a/src/input/target/mouse.rs
+++ b/src/input/target/mouse.rs
@@ -102,15 +102,10 @@ impl MouseDevice {
 }
 
 impl TargetInputDevice for MouseDevice {
-    fn start_dbus_interface(
-        &mut self,
-        dbus: Connection,
-        path: String,
-        _client: TargetDeviceClient,
-    ) {
+    fn start_dbus_interface(&mut self, dbus: Connection, path: String, client: TargetDeviceClient) {
         log::debug!("Starting dbus interface: {path}");
         tokio::task::spawn(async move {
-            let iface = TargetMouseInterface::new();
+            let iface = TargetMouseInterface::new(client);
             if let Err(e) = dbus.object_server().at(path.clone(), iface).await {
                 log::debug!("Failed to start dbus interface {path}: {e:?}");
             } else {


### PR DESCRIPTION
This change adds the `MoveCursor` method to the mouse DBus interface to allow mouse control over DBus.