### PR TITLE
fix(GPD): Add mount matrix for GPD Win Mini

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
@@ -35,6 +35,10 @@ source_devices:
   - group: imu
     iio:
       name: i2c-BMI0160:00
+      mount_matrix:
+        x: [1, 0, 0]
+        y: [0, -1, 0]
+        z: [0, 0, -1]
 
 # Optional configuration for the composite device
 options:

--- a/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
@@ -37,8 +37,8 @@ source_devices:
       name: i2c-BMI0160:00
       mount_matrix:
         x: [1, 0, 0]
-        y: [0, -1, 0]
-        z: [0, 0, -1]
+        y: [0, 0, -1]
+        z: [0, 1, 0]
 
 # Optional configuration for the composite device
 options:


### PR DESCRIPTION
This mount matrix felt right on the Win Mini 2023 playing games through Steam Input with the ds5 selected.

I've heard the 2024 has the same DMI device entries but may have the IMU mounted differently -- not sure what could be done about that.