### PR TITLE
fix(XPad Bluetooth): resolve race condition if a device is quickly added, removed, and added again

### DIFF
--- a/src/drivers/xpad_uhid/driver.rs
+++ b/src/drivers/xpad_uhid/driver.rs
@@ -104,7 +104,7 @@ impl Driver {
 
         let events = match report_id {
             DATA => {
-                log::debug!("Got touch data.");
+                log::debug!("Got input data.");
                 if bytes_read != PACKET_SIZE {
                     return Err("Invalid packet size for Keyboard or Touchpad Data.".into());
                 }
@@ -132,9 +132,9 @@ impl Driver {
         let input_report = XBoxSeriesInputDataReport::unpack(&buf)?;
 
         // Print input report for debugging
-        log::debug!("--- Input report ---");
-        log::debug!("{input_report}");
-        log::debug!("---- End Report ----");
+        log::trace!("--- Input report ---");
+        log::trace!("{input_report}");
+        log::trace!("---- End Report ----");
 
         // Update the state
         let old_dinput_state = self.update_state(input_report);

--- a/src/drivers/xpad_uhid/driver.rs
+++ b/src/drivers/xpad_uhid/driver.rs
@@ -84,9 +84,7 @@ impl Driver {
         _left_speed: u8,
         _right_speed: u8,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
-        let state = XpadUhidOutputData {
-            ..Default::default()
-        };
+        let state = XpadUhidOutputData {};
 
         self.write(state)
     }
@@ -104,7 +102,7 @@ impl Driver {
 
         let events = match report_id {
             DATA => {
-                log::debug!("Got input data.");
+                log::trace!("Got input data.");
                 if bytes_read != PACKET_SIZE {
                     return Err("Invalid packet size for Keyboard or Touchpad Data.".into());
                 }
@@ -300,7 +298,7 @@ impl Driver {
                     value: state.trigger_r,
                 })));
             }
-            log::debug!("Got events: {events:?}");
+            log::trace!("Got events: {events:?}");
 
             return events;
         };

--- a/src/input/manager.rs
+++ b/src/input/manager.rs
@@ -1147,7 +1147,7 @@ impl Manager {
                 // Signal that a source device was added
                 log::debug!("Spawing task to add source device: {id}");
                 self.on_source_device_added(id.clone(), device).await?;
-                log::debug!("Finished adding event device {id}");
+                log::debug!("Finished adding hidraw device {id}");
             }
 
             "iio" => {
@@ -1311,13 +1311,13 @@ impl Manager {
 
                     match action.to_str().unwrap() {
                         "add" => {
-                            log::debug!("Got add action for {path:?}");
+                            log::debug!("Got udev add action for {path:?}");
                             cmd_tx.blocking_send(ManagerCommand::DeviceAdded {
                                 device: device.into(),
                             })?;
                         }
                         "remove" => {
-                            log::debug!("Got remove action for {path:?}");
+                            log::debug!("Got udev remove action for {path:?}");
                             cmd_tx.blocking_send(ManagerCommand::DeviceRemoved {
                                 device: device.into(),
                             })?;
@@ -1410,7 +1410,7 @@ impl Manager {
                         };
 
                         // Notify the manager that a device was added
-                        log::debug!("Got add action for {base_path}/{name}");
+                        log::debug!("Got inotify add action for {base_path}/{name}");
                         let result = cmd_tx
                             .send(ManagerCommand::DeviceAdded {
                                 device: device.into(),
@@ -1422,7 +1422,7 @@ impl Manager {
                     }
                     WatchEvent::Delete { name, base_path } => {
                         let device = UdevDevice::from_devnode(base_path.as_str(), name.as_str());
-                        log::debug!("Got remove action for {base_path}/{name}");
+                        log::debug!("Got inotify remove action for {base_path}/{name}");
                         let result = cmd_tx.send(ManagerCommand::DeviceRemoved { device }).await;
                         if let Err(e) = result {
                             log::error!("Unable to send command: {:?}", e);

--- a/src/watcher/mod.rs
+++ b/src/watcher/mod.rs
@@ -35,10 +35,10 @@ pub fn watch(path: String, tx: Sender<WatchEvent>) {
 
         for event in events {
             // Send the event over our channel
-            log::debug!("inotify: {:?}", event.name);
             let name = String::from(event.name.unwrap().to_str().unwrap());
 
             if event.mask.contains(EventMask::CREATE) {
+                log::debug!("inotify CREATE: {:?}", event.name);
                 let value = WatchEvent::Create {
                     name,
                     base_path: path.clone(),
@@ -53,6 +53,7 @@ pub fn watch(path: String, tx: Sender<WatchEvent>) {
                 //    println!("File created: {:?}", event.name);
                 //}
             } else if event.mask.contains(EventMask::DELETE) {
+                log::debug!("inotify DELETE: {:?}", event.name);
                 let value = WatchEvent::Delete {
                     name,
                     base_path: path.clone(),
@@ -62,6 +63,7 @@ pub fn watch(path: String, tx: Sender<WatchEvent>) {
                     Err(e) => log::error!("Error sending event: {}", e),
                 }
             } else if event.mask.contains(EventMask::MODIFY) {
+                log::trace!("inotify MODIFY: {:?}", event.name);
                 let value = WatchEvent::Modify {
                     name,
                     base_path: path.clone(),


### PR DESCRIPTION
When connecting an XBox Series controller using bluetooth, this behavior was observed:

```
[2024-08-19T19:33:06Z DEBUG inputplumber::watcher] inotify CREATE: Some("hidraw4")
[2024-08-19T19:33:06Z DEBUG inputplumber::watcher] inotify DELETE: Some("hidraw4")
[2024-08-19T19:33:06Z DEBUG inputplumber::watcher] inotify CREATE: Some("hidraw4")
```

This would ultimately result in the `CompositeDevice` stopping when it received the `DELETE` event because no source devices would remain.

Normally this would be fine, and we'd expect the second `CREATE` event to create a new `CompositeDevice`. But because the input `Manager` and `CompositeDevice` run as separate tasks, processing at different speeds, we'd run into a situation where the `CompositeDevice` has not had a chance to actually stop before the `Manager` processes the second `CREATE` event. 

As a consequence, the `Manager` would see that a `CompositeDevice` still exists for this hidraw device, so it would send a command to the existing `CompositeDevice` asking it to manage that source device instead of creating a new `CompositeDevice`. Meanwhile, as soon as the `CompositeDevice` receives the `DELETE` event, the device will stop, even if a `CREATE` event is further in its queue.

This change resolves this issue by only actually stopping the `CompositeDevice` after processing all the commands in its queue.