### PR TITLE
feat(Manager): add configuration option to auto-manage devices

### DIFF
--- a/rootfs/usr/lib/systemd/system/inputplumber.service
+++ b/rootfs/usr/lib/systemd/system/inputplumber.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=InputPlumber Service
-After=graphical-session.target
 
 [Service]
 ExecStart=/usr/bin/inputplumber

--- a/rootfs/usr/share/inputplumber/devices/50-anbernic_win600.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-anbernic_win600.yaml
@@ -33,6 +33,13 @@ source_devices:
       phys_path: isa0060/serio0/input0
       handler: event*
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-aokzoe_a1.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-aokzoe_a1.yaml
@@ -44,6 +44,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml
@@ -48,6 +48,13 @@ source_devices:
         y: [0, 0, -1]
         z: [1, 0, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2021.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2021.yaml
@@ -52,6 +52,13 @@ source_devices:
         y: [0, 0, -1]
         z: [1, 0, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
@@ -48,6 +48,13 @@ source_devices:
         y: [0, 0, -1]
         z: [1, 0, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air.yaml
@@ -43,6 +43,13 @@ source_devices:
   #      y: [0, 0, -1]
   #      z: [1, 0, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml
@@ -44,6 +44,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus.yaml
@@ -55,6 +55,13 @@ source_devices:
         y: [0, 0, 1]
         z: [-1, 0, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus_mendo.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus_mendo.yaml
@@ -46,6 +46,13 @@ source_devices:
         y: [0, 0, 1]
         z: [-1, 0, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml
@@ -48,6 +48,13 @@ source_devices:
         y: [0, 0, -1]
         z: [1, 0, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_kun.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_kun.yaml
@@ -41,6 +41,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_next.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_next.yaml
@@ -58,6 +58,13 @@ source_devices:
         y: [0, 0, -1]
         z: [1, 0, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_slide.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_slide.yaml
@@ -41,6 +41,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_max.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_max.yaml
@@ -40,6 +40,13 @@ source_devices:
         y: [0, 0, -1]
         z: [0, 1, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_mini_pro.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_mini_pro.yaml
@@ -40,6 +40,13 @@ source_devices:
         y: [0, 0, -1]
         z: [0, 1, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_zero.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_zero.yaml
@@ -40,6 +40,13 @@ source_devices:
   #      y: [0, 0, -1]
   #      z: [0, 1, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-gpd_win3.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_win3.yaml
@@ -36,6 +36,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml
@@ -36,6 +36,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-gpd_winmax2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_winmax2.yaml
@@ -36,6 +36,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
@@ -36,6 +36,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
@@ -149,6 +149,13 @@ source_devices:
         y: [0, 0, -1]
         z: [-1, 0, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw.yaml
@@ -51,6 +51,13 @@ source_devices:
         y: [0, 0, -1]
         z: [-1, 0, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-onexplayer_2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-onexplayer_2.yaml
@@ -47,6 +47,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-onexplayer_amd.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-onexplayer_amd.yaml
@@ -58,6 +58,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-onexplayer_intel.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-onexplayer_intel.yaml
@@ -38,6 +38,13 @@ source_devices:
       phys_path: isa0060/serio0/input0
       handler: event*
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-onexplayer_mini_a07.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-onexplayer_mini_a07.yaml
@@ -37,6 +37,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-onexplayer_mini_pro.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-onexplayer_mini_pro.yaml
@@ -36,6 +36,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-onexplayer_onexfly.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-onexplayer_onexfly.yaml
@@ -36,6 +36,13 @@ source_devices:
     iio:
       name: i2c-BMI0160:00
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xb360

--- a/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
@@ -65,6 +65,13 @@ source_devices:
         y: [0, 0, -1]
         z: [0, -1, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-rog_ally.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-rog_ally.yaml
@@ -54,6 +54,13 @@ source_devices:
         y: [0, 0, -1]
         z: [0, 1, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml
@@ -53,6 +53,13 @@ source_devices:
         y: [0, 0, -1]
         z: [0, 1, 0]
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
@@ -51,6 +51,13 @@ source_devices:
       phys_path: isa0060/serio0/input0
       handler: event*
 
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
 # The target input device(s) that the virtual device profile can use
 target_devices:
   - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
@@ -56,7 +56,7 @@ options:
   # If true, InputPlumber will automatically try to manage the input device. If
   # this is false, InputPlumber will not try to manage the device unless an
   # external service enables management of the device. Defaults to 'false'
-  auto_manage: true
+  auto_manage: false
 
 # The target input device(s) that the virtual device profile can use
 target_devices:

--- a/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+++ b/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
@@ -42,6 +42,9 @@
           "description": "The ID of a device event mapping in the 'capability_maps' directory",
           "type": "string"
         },
+        "options": {
+          "$ref": "#/definitions/Options"
+        },
         "target_devices": {
           "description": "Target input device(s) to emulate. Can be one of ['mouse', 'keyboard', 'gamepad', 'xb360', 'xbox-elite', 'xbox-series', 'deck', 'ds5', 'ds5-edge', 'touchscreen', 'touchpad'].",
           "type": "array",
@@ -71,6 +74,19 @@
         "version"
       ],
       "title": "CompositeDevice"
+    },
+    "Options": {
+      "description": "Optional configuration for the composite device",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auto_manage": {
+          "description": "If true, InputPlumber will automatically try to manage the input device. If this is false, InputPlumber will not try to manage the device unless an external service enables management of the device. Defaults to 'false'",
+          "type": "boolean",
+          "default": false
+        }
+      },
+      "title": "Options"
     },
     "Match": {
       "description": "Only use this configuration if *any* of the given items match the system. If this list is empty, then matching source devices will always create a CompositeDevice.",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -268,7 +268,17 @@ pub struct TouchMotionCapability {
     pub speed_pps: Option<u64>,
 }
 
-/// Defines a platform match for loading a [CompositeDevice]
+/// Defines available options for loading a [CompositeDeviceConfig]
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct CompositeDeviceConfigOptions {
+    /// If true, InputPlumber will automatically try to manage the input device.
+    /// If this is false, InputPlumber will not try to manage the device unless
+    /// an external service enables management of all devices.
+    pub auto_manage: Option<bool>,
+}
+
+/// Defines a platform match for loading a [CompositeDeviceConfig]
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct Match {
@@ -352,6 +362,7 @@ pub struct CompositeDeviceConfig {
     pub capability_map_id: Option<String>,
     pub source_devices: Vec<SourceDevice>,
     pub target_devices: Option<Vec<String>>,
+    pub options: Option<CompositeDeviceConfigOptions>,
 }
 
 impl CompositeDeviceConfig {


### PR DESCRIPTION
This change fixes the systemd service definition as suggested by @gloriouseggroll and adds a new configuration section to the Composite Device Configuration to selectively define what devices should automatically be managed by InputPlumber. 

It also adds a new property to the `org.shadowblip.InputManager` DBus interface called `ManageAllDevices` which can be enabled over DBus by a user or external application like OpenGamepadUI to turn on InputPlumber management of all supported input devices. Note that with this change, we'll need to update OpenGamepadUI to toggle this property on startup to enable input remapping and input interception for external gamepads.