### PR TITLE
fix(gpd_win4): fix back buttons

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/gpd_type3.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/gpd_type3.yaml
@@ -15,13 +15,13 @@ id: gpd3
 mapping:
   - name: Left Paddle
     source_events:
-      - keyboard: KeyPause
+      - keyboard: KeySysrq
     target_event:
       gamepad:
         button: LeftPaddle1
   - name: Right Paddle
     source_events:
-      - keyboard: KeySysrq
+      - keyboard: KeyPause
     target_event:
       gamepad:
         button: RightPaddle1

--- a/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_win4.yaml
@@ -24,14 +24,14 @@ matches:
 source_devices:
   - group: gamepad
     evdev:
-      name: Microsoft X-Box 360 pad
+      name: "Microsoft X-Box 360 pad"
       phys_path: usb-0000:73:00.3-4.1/input0
       handler: event*
   - group: keyboard
     evdev:
-      name: Mouse for Windows
-      phys_path: usb-0000:73:00.3-4.2/input0
+      name: "  Mouse for Windows"
       handler: event*
+      phys_path: usb-0000:73:00.3-4.2/input1
   - group: imu
     iio:
       name: i2c-BMI0160:00


### PR DESCRIPTION
Fix back buttons on the GPD Win 4

tested on the GPD Win 4 6800u

OS: Bazzite
InputPlumber version: inputplumber-0.35.2