### PR TITLE
fix(legion go): Temporarily disable accel_3d gyro to allow display gy…

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
@@ -134,13 +134,16 @@ source_devices:
       handler: event*
 
   # IMU
-  - group: imu
-    iio:
-      name: accel_3d
-      mount_matrix:
-        x: [0, 1, 0]
-        y: [0, 0, -1]
-        z: [-1, 0, 0]
+# Broken for now --causes IP to hard freeze
+# Enabling only gyro_3d allows the tablet gyro to work without needing kernel patch
+# TODO: Find out why this is broken and swap tablet gyro to controller gyro as default.
+#  - group: imu
+#    iio:
+#      name: accel_3d
+#      mount_matrix:
+#        x: [0, 1, 0]
+#        y: [0, 0, -1]
+#        z: [-1, 0, 0]
   - group: imu
     iio:
       name: gyro_3d


### PR DESCRIPTION
…ro to work without needing kernel patch

accel_3d is broken for now --causes IP to hard freeze 
Enabling only gyro_3d allows the tablet gyro to work without needing kernel patch 
TODO: Find out why this is broken, fix it, and swap tablet gyro(gyro_3d) to controller gyro(accel_3d) as default.