### PR TITLE
Change some Ayaneo devices to xbox-elite

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml
@@ -57,7 +57,7 @@ options:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - xb360
+  - xbox-elite
   - mouse
   - keyboard
 

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
@@ -57,7 +57,7 @@ options:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - xb360
+  - xbox-elite
   - mouse
   - keyboard
 

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air.yaml
@@ -52,7 +52,7 @@ options:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - xb360
+  - xbox-elite
   - mouse
   - keyboard
 

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml
@@ -53,7 +53,7 @@ options:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - xb360
+  - xbox-elite
   - mouse
   - keyboard
 

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus.yaml
@@ -64,7 +64,7 @@ options:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - xb360
+  - xbox-elite
   - mouse
   - keyboard
 

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus_mendo.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_plus_mendo.yaml
@@ -55,7 +55,7 @@ options:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - xb360
+  - xbox-elite
   - mouse
   - keyboard
 

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml
@@ -57,7 +57,7 @@ options:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - xb360
+  - xbox-elite
   - mouse
   - keyboard
 

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_slide.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_slide.yaml
@@ -50,7 +50,7 @@ options:
 
 # The target input device(s) that the virtual device profile can use
 target_devices:
-  - xb360
+  - xbox-elite
   - mouse
   - keyboard
 


### PR DESCRIPTION
InputPlumber maps LC and RC to LeftPaddle1 and RightPaddle1, respectively.  However, Ayaneo devices are set to xb360 and cannot take advantage.

This changes tested Ayaneo devices to xbox-elite.  Air Plus Mendo and Kun are untested and are not included.