### PR TITLE
fix(target): Adjust QAM chord timing

### DIFF
--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -907,11 +907,11 @@ impl TargetInputDevice for DualSenseDevice {
 
             let (guide, south) = if pressed {
                 let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
                 (guide, south)
             } else {
-                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(160));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(240));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
                 (guide, south)
             };
 

--- a/src/input/target/xb360.rs
+++ b/src/input/target/xb360.rs
@@ -166,11 +166,11 @@ impl TargetInputDevice for XBox360Controller {
 
             let (guide, south) = if pressed {
                 let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
                 (guide, south)
             } else {
-                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(160));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(240));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
                 (guide, south)
             };
 

--- a/src/input/target/xbox_elite.rs
+++ b/src/input/target/xbox_elite.rs
@@ -171,11 +171,11 @@ impl TargetInputDevice for XboxEliteController {
 
             let (guide, south) = if pressed {
                 let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
                 (guide, south)
             } else {
-                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(160));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(240));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
                 (guide, south)
             };
 

--- a/src/input/target/xbox_series.rs
+++ b/src/input/target/xbox_series.rs
@@ -167,11 +167,11 @@ impl TargetInputDevice for XboxSeriesController {
 
             let (guide, south) = if pressed {
                 let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
                 (guide, south)
             } else {
-                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(160));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(80));
+                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(240));
+                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
                 (guide, south)
             };
 


### PR DESCRIPTION
Occasionally, pushing the QAM button may have SteamOS process the emitted Guide and A button outputs in the incorrect order (eg pressing A and then opening the Steam menu).  This seems to occur more often on devices that do not support holding the QAM output (such as ROG Ally and MSI Claw).

This changes the Guide button to be held an extra 80ms before emitting A.  In my testing I failed to see a single aberrant event once this change was applied.  Testing was performed on MSI Claw, Win600, ROG Ally and Ayaneo Air Plus.