### PR TITLE
chore(CI): remove redundant AUR publish and add GPG signing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,9 +30,24 @@ jobs:
       - name: Install Dependencies
         run: npm install @semantic-release/exec @google/semantic-release-replace-plugin @semantic-release/git
 
+      - name: Import GPG key
+        uses: crazy-max/ghaction-import-gpg@v6
+        id: gpg
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          git_config_global: true
+          git_user_signingkey: true
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GIT_AUTHOR_NAME: ${{ steps.gpg.outputs.name}}
+          GIT_AUTHOR_EMAIL: ${{ steps.gpg.outputs.email}}
+          GIT_COMMITTER_NAME: ${{ steps.gpg.outputs.name}}
+          GIT_COMMITTER_EMAIL: ${{ steps.gpg.outputs.email}}
         run: make sem-release
 
       # In ".releaserc.yaml" a step is defined to write the release version to
@@ -131,32 +146,6 @@ jobs:
       - name: Commit and publish git package
         shell: bash
         working-directory: inputplumber-git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "shadowblip+github-actions[bot]@users.noreply.github.com"
-          git add .SRCINFO PKGBUILD
-          git commit -m "Update to $(grep '^pkgver=' PKGBUILD | cut -d'=' -f2)"
-          git push origin master
-
-      - name: Checkout AUR
-        run: git clone ssh://aur@aur.archlinux.org/inputplumber.git
-
-      - name: Copy Makefile from git package and update PKGBUILD
-        run: |
-          cp inputplumber-git/Makefile inputplumber/Makefile
-          cp inputplumber-git/Dockerfile inputplumber/Dockerfile
-          curl -sL https://github.com/ShadowBlip/InputPlumber/archive/refs/tags/v$(cat .version.txt).tar.gz | sha256sum | cut -d' ' -f1 > hash.txt
-          sed -i "s/^pkgver=.*/pkgver=$(cat .version.txt)/g" inputplumber/PKGBUILD
-          sed -i "s/^sha256sums=.*/sha256sums=('$(cat hash.txt)')/g" inputplumber/PKGBUILD
-
-      - name: Build package
-        working-directory: inputplumber
-        run: |
-          make in-docker
-
-      - name: Commit and publish package
-        shell: bash
-        working-directory: inputplumber
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "shadowblip+github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
This change removes publishing the `inputplumber` AUR package as it has now landed in stable and also includes GPG signing of commits and tags.