### PR TITLE
feat(Manager): add suspend/wake hook methods to handle reconnecting Deck target device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1836,7 +1836,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 [[package]]
 name = "virtual-usb"
 version = "0.1.0"
-source = "git+https://github.com/ShadowBlip/virtual-usb-rs.git?rev=5a7a96a6aedc54f339d9ebff78bf484e5b17728d#5a7a96a6aedc54f339d9ebff78bf484e5b17728d"
+source = "git+https://github.com/ShadowBlip/virtual-usb-rs.git?rev=4bca5c6fb9f2b63944a286854405e3e7e0b5d259#4bca5c6fb9f2b63944a286854405e3e7e0b5d259"
 dependencies = [
  "libudev",
  "packed_struct",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ assets = [
   { source = "target/release/inputplumber", dest = "/usr/bin/inputplumber", mode = "755" },
   { source = "rootfs/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf", dest = "/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf", mode = "644" },
   { source = "rootfs/usr/lib/systemd/system/inputplumber.service", dest = "/usr/lib/systemd/system/inputplumber.service", mode = "644" },
+  { source = "rootfs/usr/lib/systemd/system/inputplumber-suspend.service", dest = "/usr/lib/systemd/system/inputplumber-suspend.service", mode = "644" },
   { source = "rootfs/usr/share/inputplumber/devices/*.yaml", dest = "/usr/share/inputplumber/devices/", mode = "644" },
   { source = "rootfs/usr/share/inputplumber/schema/*.json", dest = "/usr/share/inputplumber/schema/", mode = "644" },
   { source = "rootfs/usr/share/inputplumber/capability_maps/*.yaml", dest = "/usr/share/inputplumber/capability_maps/", mode = "644" },
@@ -48,7 +49,7 @@ thiserror = "1.0.61"
 tokio = { version = "*", features = ["full"] }
 udev = { version = "^0.8", features = ["mio"] }
 uhid-virt = "0.0.7"
-virtual-usb = { git = "https://github.com/ShadowBlip/virtual-usb-rs.git", rev = "5a7a96a6aedc54f339d9ebff78bf484e5b17728d" }
+virtual-usb = { git = "https://github.com/ShadowBlip/virtual-usb-rs.git", rev = "4bca5c6fb9f2b63944a286854405e3e7e0b5d259" }
 xdg = "2.5.2"
 zbus = { version = "4.3.1", default-features = false, features = ["tokio"] }
 zbus_macros = "4.3.1"

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ uninstall: ## Uninstall inputplumber
 	rm $(PREFIX)/bin/$(NAME)
 	rm $(PREFIX)/share/dbus-1/system.d/$(DBUS_NAME).conf
 	rm $(PREFIX)/lib/systemd/system/$(NAME).service
+	rm $(PREFIX)/lib/systemd/system/$(NAME)-suspend.service
 	rm $(PREFIX)/lib/udev/hwdb.d/59-inputplumber.hwdb
 	rm -rf $(PREFIX)/share/$(NAME)/devices/
 	rm -rf $(PREFIX)/share/$(NAME)/schema/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Then start the service with:
 
 ```bash
 sudo systemctl enable inputplumber
+sudo systemctl enable inputplumber-suspend
 sudo systemctl start inputplumber
 ```
 

--- a/pkg/rpm/inputplumber.spec
+++ b/pkg/rpm/inputplumber.spec
@@ -61,6 +61,7 @@ systemctl disable inputplumber.servce
 /usr/bin/inputplumber
 /usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf
 /usr/lib/systemd/system/inputplumber.service
+/usr/lib/systemd/system/inputplumber-suspend.service
 /usr/lib/udev/hwdb.d/59-inputplumber.hwdb
 /usr/share/inputplumber/capability_maps/ally_type1.yaml
 /usr/share/inputplumber/capability_maps/anbernic_type1.yaml

--- a/rootfs/usr/lib/systemd/system/inputplumber-suspend.service
+++ b/rootfs/usr/lib/systemd/system/inputplumber-suspend.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=InputPlumber Suspend Inhibit Service
+Before=sleep.target
+StopWhenUnneeded=yes
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=busctl call org.shadowblip.InputPlumber /org/shadowblip/InputPlumber/Manager org.shadowblip.InputManager HookSleep
+ExecStop=busctl call org.shadowblip.InputPlumber /org/shadowblip/InputPlumber/Manager org.shadowblip.InputManager HookWake
+
+[Install]
+WantedBy=sleep.target

--- a/src/input/composite_device/client.rs
+++ b/src/input/composite_device/client.rs
@@ -306,4 +306,26 @@ impl CompositeDeviceClient {
         self.tx.send(CompositeCommand::Stop).await?;
         Ok(())
     }
+
+    /// Calls the suspend handler to perform system suspend-related tasks.
+    pub async fn suspend(&self) -> Result<(), ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(CompositeCommand::Suspend(tx)).await?;
+
+        if let Some(result) = rx.recv().await {
+            return Ok(result);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
+    /// Calls the resume handler to perform system wake from suspend-related tasks.
+    pub async fn resume(&self) -> Result<(), ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(CompositeCommand::Resume(tx)).await?;
+
+        if let Some(result) = rx.recv().await {
+            return Ok(result);
+        }
+        Err(ClientError::ChannelClosed)
+    }
 }

--- a/src/input/composite_device/command.rs
+++ b/src/input/composite_device/command.rs
@@ -44,4 +44,6 @@ pub enum CompositeCommand {
     WriteEvent(NativeEvent),
     WriteSendEvent(NativeEvent),
     Stop,
+    Suspend(mpsc::Sender<()>),
+    Resume(mpsc::Sender<()>),
 }

--- a/src/input/target/steam_deck.rs
+++ b/src/input/target/steam_deck.rs
@@ -767,7 +767,23 @@ impl TargetInputDevice for SteamDeckDevice {
 
     /// Stop the virtual USB read/write threads
     fn stop(&mut self) -> Result<(), InputError> {
+        log::debug!("Stopping virtual Deck controller");
         self.device.stop();
+
+        // Read from the device
+        let xfer = self.device.blocking_read()?;
+
+        // Handle any non-standard transfers
+        if let Some(xfer) = xfer {
+            let reply = self.handle_xfer(xfer);
+
+            // Write to the device if a reply is necessary
+            if let Some(reply) = reply {
+                self.device.write(reply)?;
+            }
+        }
+
+        log::debug!("Finished stopping");
         Ok(())
     }
 }


### PR DESCRIPTION
This change adds new `HookSleep` and `HookWake` dbus methods that can be called by a systemd unit on suspend/resume to allow InputPlumber to prepare for sleep/wake. It also includes the latest version of the `virtual-usb` crate which contains a fix where the read/write threads of the virtual usb device would fail to stop, leaving a dangling virtual usb device.

This change seems to be required due to the appearance that the virtual usb kernel driver currently does not support suspend:
https://github.com/torvalds/linux/blob/master/drivers/usb/usbip/vhci_hcd.c#L1260

In order for this feature to work, users will need to ensure the suspend systemd unit is also enabled for InputPlumber:

```bash
sudo systemctl enable inputplumber-suspend
```

Fixes #165