### PR TITLE
feat(Manager): expose InputPlumber version over dbus

### DIFF
--- a/src/dbus/interface/manager.rs
+++ b/src/dbus/interface/manager.rs
@@ -25,6 +25,12 @@ impl ManagerInterface {
 #[interface(name = "org.shadowblip.InputManager")]
 impl ManagerInterface {
     #[zbus(property)]
+    async fn version(&self) -> fdo::Result<String> {
+        const VERSION: &str = env!("CARGO_PKG_VERSION");
+        Ok(VERSION.to_string())
+    }
+
+    #[zbus(property)]
     async fn intercept_mode(&self) -> fdo::Result<String> {
         Ok("InputPlumber".to_string())
     }


### PR DESCRIPTION
This change adds the `Version` property to the manager interface to expose the running InputPlumber version.