### PR TITLE
fix(ds5): dpad getting "stuck"

### DIFF
--- a/src/drivers/dualsense/driver.rs
+++ b/src/drivers/dualsense/driver.rs
@@ -246,125 +246,50 @@ impl Driver {
             })));
         }
         if state.dpad != old_state.dpad {
-            match state.dpad {
-                Direction::North => events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
+            let new_dpad = state.dpad.as_bitflag();
+            let old_dpad = old_state.dpad.as_bitflag();
+            let disabled_fields = old_dpad & !new_dpad;
+
+            if new_dpad & Direction::North.as_bitflag() != 0 {
+                events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
                     pressed: true,
-                }))),
-                Direction::NorthEast => {
-                    events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
-                        pressed: true,
-                    })));
-                    events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
-                        pressed: true,
-                    })));
-                }
-                Direction::East => {
-                    events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
-                        pressed: true,
-                    })))
-                }
-                Direction::SouthEast => {
-                    events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
-                        pressed: true,
-                    })));
-                    events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
-                        pressed: true,
-                    })))
-                }
-                Direction::South => {
-                    events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
-                        pressed: true,
-                    })))
-                }
-                Direction::SouthWest => {
-                    events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
-                        pressed: true,
-                    })));
-                    events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
-                        pressed: true,
-                    })))
-                }
-                Direction::West => events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
-                    pressed: true,
-                }))),
-                Direction::NorthWest => {
-                    events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
-                        pressed: true,
-                    })));
-                    events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
-                        pressed: true,
-                    })))
-                }
-                Direction::None => (),
+                })));
             }
-            // Find state that changed and release button presses for dpad's appropriate keys
-            match (state.dpad, old_state.dpad) {
-                // Release NORTH
-                (_, Direction::North) // if any other direction is used
-                | (Direction::East, Direction::NorthEast)
-                | (Direction::West, Direction::NorthWest) => {
-                    events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
-                        pressed: false,
-                    })))
-                }
-                // Release EAST
-                (_, Direction::East)
-                | (Direction::North, Direction::NorthEast)
-                | (Direction::South, Direction::SouthEast) => {
-                    events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
-                        pressed: false,
-                    })))
-                }
-                // Release SOUTH
-                (_, Direction::South)
-                | (Direction::East, Direction::SouthEast)
-                | (Direction::West, Direction::SouthWest) => {
-                    events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
-                        pressed: false,
-                    })))
-                }
-                // Release WEST
-                (_, Direction::West)
-                | (Direction::South, Direction::SouthWest)
-                | (Direction::North, Direction::NorthWest) => {
-                    events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
-                        pressed: false,
-                    })))
-                }
-                // If any other combination is used, simply release both buttons for given "combo" state
-                (_, Direction::NorthEast) => {
-                    events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
-                        pressed: false,
-                    })));
-                    events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
-                        pressed: false,
-                    })));
-                }
-                (_, Direction::SouthEast) => {
-                    events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
-                        pressed: false,
-                    })));
-                    events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
-                        pressed: false,
-                    })))
-                }
-                (_, Direction::NorthWest) => {
-                    events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
-                        pressed: false,
-                    })));
-                    events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
-                        pressed: false,
-                    })))
-                }
-                (_, Direction::SouthWest) => {
-                    events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
-                        pressed: false,
-                    })));
-                    events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
-                        pressed: false,
-                    })))
-                }
-                (_, _) => (),
+            if new_dpad & Direction::East.as_bitflag() != 0 {
+                events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
+                    pressed: true,
+                })))
+            }
+            if new_dpad & Direction::West.as_bitflag() != 0 {
+                events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
+                    pressed: true,
+                })))
+            }
+            if new_dpad & Direction::South.as_bitflag() != 0 {
+                events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
+                    pressed: true,
+                })))
+            }
+
+            if disabled_fields & Direction::North.as_bitflag() != 0 {
+                events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
+                    pressed: false,
+                })));
+            }
+            if disabled_fields & Direction::East.as_bitflag() != 0 {
+                events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
+                    pressed: false,
+                })))
+            }
+            if disabled_fields & Direction::West.as_bitflag() != 0 {
+                events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
+                    pressed: false,
+                })))
+            }
+            if disabled_fields & Direction::South.as_bitflag() != 0 {
+                events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
+                    pressed: false,
+                })))
             }
         }
         if state.l1 != old_state.l1 {

--- a/src/drivers/dualsense/driver.rs
+++ b/src/drivers/dualsense/driver.rs
@@ -295,61 +295,76 @@ impl Driver {
                         pressed: true,
                     })))
                 }
-                Direction::None => match old_state.dpad {
-                    Direction::North => {
-                        events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
-                            pressed: false,
-                        })))
-                    }
-                    Direction::NorthEast => {
-                        events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
-                            pressed: false,
-                        })));
-                        events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
-                            pressed: false,
-                        })));
-                    }
-                    Direction::East => {
-                        events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
-                            pressed: false,
-                        })))
-                    }
-                    Direction::SouthEast => {
-                        events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
-                            pressed: false,
-                        })));
-                        events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
-                            pressed: false,
-                        })))
-                    }
-                    Direction::South => {
-                        events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
-                            pressed: false,
-                        })))
-                    }
-                    Direction::SouthWest => {
-                        events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
-                            pressed: false,
-                        })));
-                        events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
-                            pressed: false,
-                        })))
-                    }
-                    Direction::West => {
-                        events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
-                            pressed: false,
-                        })))
-                    }
-                    Direction::NorthWest => {
-                        events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
-                            pressed: false,
-                        })));
-                        events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
-                            pressed: false,
-                        })))
-                    }
-                    Direction::None => (),
-                },
+                Direction::None => (),
+            }
+            // Find state that changed and release button presses for dpad's appropriate keys
+            match (state.dpad, old_state.dpad) {
+                // Release NORTH
+                (_, Direction::North) // if any other direction is used
+                | (Direction::East, Direction::NorthEast)
+                | (Direction::West, Direction::NorthWest) => {
+                    events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
+                        pressed: false,
+                    })))
+                }
+                // Release EAST
+                (_, Direction::East)
+                | (Direction::North, Direction::NorthEast)
+                | (Direction::South, Direction::SouthEast) => {
+                    events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
+                        pressed: false,
+                    })))
+                }
+                // Release SOUTH
+                (_, Direction::South)
+                | (Direction::East, Direction::SouthEast)
+                | (Direction::West, Direction::SouthWest) => {
+                    events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
+                        pressed: false,
+                    })))
+                }
+                // Release WEST
+                (_, Direction::West)
+                | (Direction::South, Direction::SouthWest)
+                | (Direction::North, Direction::NorthWest) => {
+                    events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
+                        pressed: false,
+                    })))
+                }
+                // If any other combination is used, simply release both buttons for given "combo" state
+                (_, Direction::NorthEast) => {
+                    events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
+                        pressed: false,
+                    })));
+                    events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
+                        pressed: false,
+                    })));
+                }
+                (_, Direction::SouthEast) => {
+                    events.push(Event::Button(ButtonEvent::DPadRight(BinaryInput {
+                        pressed: false,
+                    })));
+                    events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
+                        pressed: false,
+                    })))
+                }
+                (_, Direction::NorthWest) => {
+                    events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
+                        pressed: false,
+                    })));
+                    events.push(Event::Button(ButtonEvent::DPadUp(BinaryInput {
+                        pressed: false,
+                    })))
+                }
+                (_, Direction::SouthWest) => {
+                    events.push(Event::Button(ButtonEvent::DPadDown(BinaryInput {
+                        pressed: false,
+                    })));
+                    events.push(Event::Button(ButtonEvent::DPadLeft(BinaryInput {
+                        pressed: false,
+                    })))
+                }
+                (_, _) => (),
             }
         }
         if state.l1 != old_state.l1 {

--- a/src/drivers/dualsense/hid_report.rs
+++ b/src/drivers/dualsense/hid_report.rs
@@ -98,6 +98,22 @@ pub enum Direction {
     None = 8,
 }
 
+impl Direction {
+    pub fn as_bitflag(&self) -> u8 {
+        match *self {
+            Self::North => 1,                   // 00000001
+            Self::NorthEast => 1 | 1 << 1,      // 00000011
+            Self::East => 1 << 1,               // 00000010
+            Self::SouthEast => 1 << 2 | 1 << 1, // 00000110
+            Self::South => 1 << 2,              // 00000100
+            Self::SouthWest => 1 << 2 | 1 << 3, // 00001100
+            Self::West => 1 << 3,               // 00001000
+            Self::NorthWest => 1 | 1 << 3,      // 00001001
+            Self::None => 0,                    // 00000000
+        }
+    }
+}
+
 #[derive(PrimitiveEnum_u8, Clone, Copy, PartialEq, Debug, Default)]
 pub enum PowerState {
     Disharging = 0x00,


### PR DESCRIPTION
I hate this solution. 
If anyone has better idea on how to solve this, please please bring it up.  
Closes #230

This essentially moves logic for releasing buttons after the logic that maps button pressed events.
The logic especially handles transitions between in-between states like `NorthEast -> East` - this will release a North button.