### PR TITLE
feat(CompositeDeviceConfig): add udev-based source device matching

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/60-xbox_one_bt_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-xbox_one_bt_gamepad.yaml
@@ -13,22 +13,31 @@ name: Microsoft X-Box One pad
 # /sys/class/dmi/id/product_name
 matches: []
 
-# Only allow a single source device per composite device of this type.
-single_source: false
+# Only allow a CompositeDevice to manage at most the given number of
+# source devices. When this limit is reached, a new CompositeDevice will be
+# created for any new matching devices.
+maximum_sources: 2
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.
 source_devices:
   - group: gamepad
     blocked: true
-    evdev:
-      vendor_id: "045e"
-      product_id: "0b13"
-      handler: event*
+    udev:
+      attributes:
+        - name: name
+          value: Xbox Wireless Controller
+      properties:
+        - name: ID_BUS
+          value: bluetooth
+      driver: microsoft
+      sys_name: "event*"
+      subsystem: input
   - group: gamepad
-    hidraw:
-      vendor_id: 0x045e
-      product_id: 0x0b13
+    udev:
+      # NOTE: This might also capture other non-xbox microsoft devices :(
+      driver: microsoft
+      subsystem: hidraw
 
 # The target input device(s) to emulate by default
 target_devices:

--- a/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+++ b/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
@@ -168,6 +168,9 @@
           "type": "boolean",
           "default": false
         },
+        "udev": {
+          "$ref": "#/definitions/Udev"
+        },
         "evdev": {
           "$ref": "#/definitions/Evdev"
         },
@@ -186,6 +189,70 @@
         "group"
       ],
       "title": "SourceDevice"
+    },
+    "Udev": {
+      "description": "Source device to manage. Properties support globbing patterns.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "attributes": {
+          "description": "Device attributes to match. Attributes can be found by running `udevadm info --attribute-walk /path/to/device` and looking at fields that look like: `ATTR{name}==\"value\"`.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UdevKeyValue"
+          }
+        },
+        "dev_node": {
+          "description": "Full device node path to match. E.g. '/dev/hidraw3', '/dev/input/event*'",
+          "type": "string"
+        },
+        "dev_path": {
+          "description": "Full kernel device path to match. The path does not contain the sys mount point, but does start with a `/`. For example, the dev_path for `hidraw3` could be `/devices/pci0000:00/0000:00:08.1/.../hidraw/hidraw3`.",
+          "type": "string"
+        },
+        "driver": {
+          "description": "Driver being used by the device (or parent devices) to match. E.g. `playstation`, `microsoft`",
+          "type": "string"
+        },
+        "properties": {
+          "description": "Device properties to match. Properties can be found by running `udevadm info -q property /path/to/device`.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/UdevKeyValue"
+          }
+        },
+        "subsystem": {
+          "description": "Subsystem to match. E.g. `input`, `hidraw`, `iio`",
+          "type": "string"
+        },
+        "sys_name": {
+          "description": "Sysname to match. The sysname is typically the last part of the path to the device. E.g. `hidraw3`, `event6`",
+          "type": "string"
+        },
+        "sys_path": {
+          "description": "Syspath to match. The syspath is an absolute path and includes the sys mount point. For example, the syspath for `hidraw3` could be `/sys/devices/pci0000:00/0000:00:08.1/.../hidraw/hidraw3`, which includes the sys mount point `/sys`.",
+          "type": "string"
+        }
+      },
+      "required": [],
+      "title": "Udev"
+    },
+    "UdevKeyValue": {
+      "description": "Udev attribute or property key/value pair"
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "Name of the property or attribute to match. Does NOT support globbing patterns.",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value of the property or attribute to match. Supports globbing patterns.",
+          "type": "string"
+        },
+      },
+      "required": ["name"],
+      "title": "UdevKeyValue"
     },
     "Evdev": {
       "description": "Source device to manage. Properties support globbing patterns.",

--- a/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+++ b/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
@@ -20,9 +20,14 @@
           "type": "string"
         },
         "single_source": {
-          "description": "If true, this composite device should only use one source device. Defaults to false.",
+          "description": "DEPRECATED: use 'maximum_sources' instead. If true, this composite device should only use one source device. Defaults to false.",
           "type": "boolean",
           "default": false
+        },
+        "maximum_sources": {
+          "description": "Maximum number of source devices that this composite device can manage. When this composite device reaches this maximum and a new matching source device is detected, a new composite device will be created instead of adding the source device to the existing one. Any value less than 1 indicates no maximum. Defaults to 0 (unlimited).",
+          "type": "integer",
+          "default": 0
         },
         "matches": {
           "description": "Only use this profile if *any* of the given DMI system matches match. If this list is empty, then the source devices will *always* be checked.",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -379,7 +379,8 @@ pub struct CompositeDeviceConfig {
     pub kind: String,
     pub name: String,
     pub matches: Vec<Match>,
-    pub single_source: Option<bool>,
+    pub single_source: Option<bool>, // DEPRECATED; use 'maximum_sources' instead
+    pub maximum_sources: Option<i32>,
     pub capability_map_id: Option<String>,
     pub source_devices: Vec<SourceDevice>,
     pub target_devices: Option<Vec<String>>,

--- a/src/input/source/evdev/blocked.rs
+++ b/src/input/source/evdev/blocked.rs
@@ -23,6 +23,7 @@ impl BlockedEventDevice {
         log::debug!("Opening device at: {}", path);
         let mut device = Device::open(path.clone())?;
         device.grab()?;
+        log::info!("Blocking input events from {path}");
 
         Ok(Self { device })
     }

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -149,18 +149,20 @@ impl HidRawDevice {
             return DriverType::Fts3528Touchscreen;
         }
 
-        // XpadUhid
-        if drivers::xpad_uhid::driver::VIDS.contains(&vid)
-            && drivers::xpad_uhid::driver::PIDS.contains(&pid)
-        {
-            log::info!("Detected UHID XPAD");
-            return DriverType::XpadUhid;
-        }
-
         // Rog Ally
         if vid == drivers::rog_ally::driver::VID && drivers::rog_ally::driver::PIDS.contains(&pid) {
             log::info!("Detected ROG Ally");
             return DriverType::RogAlly;
+        }
+
+        // XpadUhid
+        let drivers = device.drivers();
+        if drivers.contains(&"microsoft".to_string()) {
+            let syspath = device.syspath();
+            if syspath.contains("uhid") {
+                log::info!("Detected UHID XPAD");
+                return DriverType::XpadUhid;
+            }
         }
 
         // Unknown

--- a/src/udev/device.rs
+++ b/src/udev/device.rs
@@ -520,6 +520,11 @@ impl UdevDevice {
         self.sysname.clone()
     }
 
+    /// Returns the syspath of the device.
+    ///
+    /// The path is an absolute path and includes the sys mount point. For example, the syspath for
+    /// `tty0` could be `/sys/devices/virtual/tty/tty0`, which includes the sys mount point,
+    /// `/sys`.
     pub fn syspath(&self) -> String {
         self.syspath.clone()
     }


### PR DESCRIPTION
This change adds the ability to match source devices in composite device configs based on udev properties. This new matching method is the most powerful and flexible way to match input devices and could completely replace the existing `evdev`, `hidraw`, and `iio` match configs, but those methods will still exist to maintain backwards compatibility.

Here are some examples:

### Old Method

```yaml
source_devices:
  - group: gamepad
    hidraw:
      vendor_id: 0x054c
      product_id: 0x0ce6

  - group: gamepad
    blocked: true
    evdev:
      name: "{Sony Interactive Entertainment DualSense Wireless Controller,DualSense Wireless Controller}"
      vendor_id: 054c
      product_id: 0ce6
      handler: event*
```

### New Method

```yaml
source_devices:
  - group: gamepad
    udev:
      attributes:
        - name: "idVendor"
          value: "054c"
        - name: "idProduct"
          value: "0ce6"
      subsystem: "hidraw"
      
  - group: gamepad
    blocked: true
    udev:
      attributes:
        - name: "name"
          value: "{Sony Interactive Entertainment DualSense Wireless Controller,DualSense Wireless Controller}"
        - name: "id/vendor"
          value: "054c"
        - name: "id/product"
          value: "0ce6"
      sys_name: event*
      subsystem: "input"
```

While slightly more complex, this new method will allow us to glob match on any udev data, including attributes from  `udevadm info --attribute-walk /path/to/device` or udev properties from `udevadm info -q property /path/to/device`.