### PR TITLE
fix(TargetDevice): add method for target devices to query composite device config

### DIFF
--- a/src/input/composite_device/command.rs
+++ b/src/input/composite_device/command.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use tokio::sync::mpsc;
 
 use crate::{
+    config::CompositeDeviceConfig,
     input::{
         capability::Capability,
         event::{native::NativeEvent, Event},
@@ -20,6 +21,7 @@ use super::InterceptMode;
 #[derive(Debug, Clone)]
 pub enum CompositeCommand {
     AttachTargetDevices(HashMap<String, TargetDeviceClient>),
+    GetConfig(mpsc::Sender<CompositeDeviceConfig>),
     GetCapabilities(mpsc::Sender<HashSet<Capability>>),
     GetDBusDevicePaths(mpsc::Sender<Vec<String>>),
     GetInterceptMode(mpsc::Sender<InterceptMode>),


### PR DESCRIPTION
This change adds new methods to allow target devices to query the composite device it's attached to for its configuration and source devices. This can allow us to modify the behavior of target devices based on the composite device config and/or source devices.