### PR TITLE
fix(CompositeDevice): clear state for target devices on profile change

### DIFF
--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -1528,6 +1528,17 @@ impl CompositeDevice {
             });
         }
 
+        // Clear the state from all target devices
+        let target_devices = self.target_devices.clone();
+        tokio::task::spawn(async move {
+            for (path, device) in target_devices.iter() {
+                log::debug!("Clearing state on device: {path}");
+                if let Err(e) = device.clear_state().await {
+                    log::error!("Failed to clear state on target device {path}: {e:?}");
+                }
+            }
+        });
+
         log::debug!("Successfully loaded device profile: {}", profile.name);
         Ok(())
     }


### PR DESCRIPTION
This change will clear the state of all target devices whenever the input profile changes on a composite device. This fixes an issue where if a user had an input profile with joystick -> mouse translation and the profile changed to one without that translation, the virtual mouse would continue to send input.