### PR TITLE
feat(Flip DS): Add SSI button as OSK

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type4.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type4.yaml
@@ -44,6 +44,14 @@ mapping:
     target_event:
       gamepad:
         button: RightTop
+  - name: Secondary Screen Interaction
+    source_events:
+      - keyboard: KeyRightCtrl
+      - keyboard: KeyLeftMeta
+      - keyboard: KeyF18
+    target_event:
+      gamepad:
+        button: Keyboard
 
 # List of events to filter from the source devices
 filtered_events: []


### PR DESCRIPTION
Add support for Secondary Screen Interaction button on Flip DS.  Currently mapped to Keyboard.