### PR TITLE
Fix(udev::Device): number is defined as an u64 in udev

### DIFF
--- a/src/udev/device.rs
+++ b/src/udev/device.rs
@@ -629,7 +629,7 @@ pub struct Device {
     /// M: Device name in /sys (i.e. the last component of "P:")
     pub name: String,
     /// R: Device number in /sys (i.e. the numeric suffix of the last component of "P:")
-    pub number: u32,
+    pub number: u64,
     /// U: Kernel subsystem
     pub subsystem: String,
     /// T: Device type within subsystem


### PR DESCRIPTION
The device number is defined as an u64 in udev: fix a possible bug by using the correct data type