### PR TITLE
Fix inverted MSI-Claw menu buttons

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/msiclaw_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/msiclaw_type1.yaml
@@ -15,13 +15,13 @@ id: claw1
 mapping:
   - name: Guide
     source_events:
-      - keyboard: KeyF16
+      - keyboard: KeyF15
     target_event:
       gamepad:
         button: Guide
   - name: QuickAccess
     source_events:
-      - keyboard: KeyF15
+      - keyboard: KeyF16
     target_event:
       gamepad:
         button: QuickAccess


### PR DESCRIPTION
System/Menu buttons are inverted.
More info: https://github.com/ShadowBlip/InputPlumber/issues/250