### PR TITLE
fix(External Gamepads): use maximum_sources instead of single_source to allow multiple gamepads

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/60-ps4_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-ps4_gamepad.yaml
@@ -8,8 +8,8 @@ kind: CompositeDevice
 # Name of the composite device mapping
 name: Sony Interactive Entertainment Wireless Controller
 
-# Only allow a single source device per composite device of this type.
-single_source: false
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 2
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty then the source devices will *always* be checked.

--- a/rootfs/usr/share/inputplumber/devices/60-ps5_ds-edge_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-ps5_ds-edge_gamepad.yaml
@@ -8,8 +8,8 @@ kind: CompositeDevice
 # Name of the composite device mapping
 name: Sony Interactive Entertainment DualSense Edge Wireless Controller
 
-# Only allow a single source device per composite device of this type.
-single_source: false
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 4
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty then the source devices will *always* be checked.

--- a/rootfs/usr/share/inputplumber/devices/60-ps5_ds_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-ps5_ds_gamepad.yaml
@@ -8,8 +8,8 @@ kind: CompositeDevice
 # Name of the composite device mapping
 name: Sony Interactive Entertainment DualSense Wireless Controller
 
-# Only allow a single source device per composite device of this type.
-single_source: false
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 4
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty then the source devices will *always* be checked.

--- a/rootfs/usr/share/inputplumber/devices/60-switch_pro.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-switch_pro.yaml
@@ -8,8 +8,8 @@ kind: CompositeDevice
 # Name of the composite device mapping
 name: Nintendo Co., Ltd. Pro Controller
 
-# Only allow a single source device per composite device of this type.
-single_source: true
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 1
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty, then the source devices will *always* be checked.

--- a/rootfs/usr/share/inputplumber/devices/60-xbox_360_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-xbox_360_gamepad.yaml
@@ -13,8 +13,8 @@ name: Microsoft X-Box 360 pad
 # /sys/class/dmi/id/product_name
 matches: []
 
-# Only allow a single source device per composite device of this type.
-single_source: true
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 1
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.

--- a/rootfs/usr/share/inputplumber/devices/60-xbox_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-xbox_gamepad.yaml
@@ -13,8 +13,8 @@ name: Microsoft X-Box pad
 # /sys/class/dmi/id/product_name
 matches: []
 
-# Only allow a single source device per composite device of this type.
-single_source: true
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 1
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.

--- a/rootfs/usr/share/inputplumber/devices/60-xbox_one_elite_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-xbox_one_elite_gamepad.yaml
@@ -13,8 +13,8 @@ name: Microsoft X-Box One Elite pad
 # /sys/class/dmi/id/product_name
 matches: []
 
-# Only allow a single source device per composite device of this type.
-single_source: true
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 1
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.

--- a/rootfs/usr/share/inputplumber/devices/60-xbox_one_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-xbox_one_gamepad.yaml
@@ -13,8 +13,8 @@ name: Microsoft X-Box One pad
 # /sys/class/dmi/id/product_name
 matches: []
 
-# Only allow a single source device per composite device of this type.
-single_source: true
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 1
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.

--- a/rootfs/usr/share/inputplumber/devices/69-ignore_generic.yaml
+++ b/rootfs/usr/share/inputplumber/devices/69-ignore_generic.yaml
@@ -8,8 +8,8 @@ kind: CompositeDevice
 # Name of the composite device mapping
 name: Ignore Gamepads
 
-# Only allow a single source device per composite device of this type.
-single_source: true
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 1
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty, then the source devices will *always* be checked.

--- a/rootfs/usr/share/inputplumber/devices/70-generic_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/70-generic_gamepad.yaml
@@ -8,8 +8,8 @@ kind: CompositeDevice
 # Name of the composite device mapping
 name: Gamepads
 
-# Only allow a single source device per composite device of this type.
-single_source: true
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 1
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty, then the source devices will *always* be checked.


### PR DESCRIPTION
This change updates all external gamepad configs to use the new `maximum_sources` config option instead of `single_source`. This fixes an issue for some gamepads (like the DualSense controller) where a single CompositeDevice would capture all detected controllers of the same type instead of creating a new CompositeDevice.