### PR TITLE
feat(CLI): add command line client interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,12 +42,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi-str"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf4578926a981ab0ca955dc023541d19de37112bc24c1a197bd806d3d86ad1d"
+dependencies = [
+ "ansitok",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "ansitok"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "220044e6a1bb31ddee4e3db724d29767f352de47445a6cd75e1a173142136c83"
+dependencies = [
+ "nom",
+ "vte",
 ]
 
 [[package]]
@@ -67,9 +86,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
@@ -98,6 +117,12 @@ dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "async-broadcast"
@@ -331,6 +356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytecount"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
+
+[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,11 +425,60 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags 1.3.2",
- "strsim",
+ "strsim 0.8.0",
  "textwrap",
- "unicode-width",
+ "unicode-width 0.1.12",
  "vec_map",
 ]
+
+[[package]]
+name = "clap"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.1",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.5.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33a7e468e750fa4b6be660e8b5651ad47372e8fb114030b594c2d75d48c5ffd0"
+dependencies = [
+ "clap 4.5.27",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -627,6 +707,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +815,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -807,7 +905,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3948a8818efcd4e0e189df60d79b58a9f4ae20b87437b2fde4dc4ca5b520c4ed"
 dependencies = [
- "clap",
+ "clap 2.34.0",
  "libiio-sys",
  "nix 0.23.2",
  "thiserror",
@@ -839,6 +937,8 @@ dependencies = [
 name = "inputplumber"
 version = "0.42.2"
 dependencies = [
+ "clap 4.5.27",
+ "clap_complete",
  "env_logger",
  "evdev",
  "glob-match",
@@ -853,6 +953,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_yaml",
+ "tabled",
  "thiserror",
  "tokio",
  "udev",
@@ -934,9 +1035,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libiio-sys"
@@ -1177,6 +1278,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b0f8def1f117e13c895f3eda65a7b5650688da29d6ad04635f61bc7b92eebd"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "bytecount",
+ "fnv",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1271,10 +1385,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.83"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b33eb56c327dec362a9e55b3ad14f9d2f0904fb5a5b03b513ab5465399e9f43"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -1558,6 +1694,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1577,6 +1719,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tabled"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6709222f3973137427ce50559cd564dc187a95b9cfe01613d2f4e93610e510a"
+dependencies = [
+ "ansi-str",
+ "ansitok",
+ "papergrid",
+ "tabled_derive",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "931be476627d4c54070a1f3a9739ccbfec9b36b39815106a20cce2243bbcefe1"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1603,7 +1770,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.12",
 ]
 
 [[package]]
@@ -1801,6 +1968,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
 
 [[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1842,6 +2015,27 @@ dependencies = [
  "packed_struct",
  "simple_logger",
  "socketpair",
+]
+
+[[package]]
+name = "vte"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cbce692ab4ca2f1f3047fcf732430249c0e971bfdd2b234cf2c47ad93af5983"
+dependencies = [
+ "arrayvec",
+ "utf8parse",
+ "vte_generate_state_changes",
+]
+
+[[package]]
+name = "vte_generate_state_changes"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e369bee1b05d510a7b4ed645f5faa90619e05437111783ea5848f28d97d3c2e"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ libiio = "*"
 libevdev = "*"
 
 [dependencies]
+clap = { version = "4.5.27", features = ["derive"] }
+clap_complete = "4.5.42"
 env_logger = "0.11.3"
 evdev = { git = "https://github.com/emberian/evdev.git", features = [
   "tokio",
@@ -45,6 +47,7 @@ procfs = "0.16.0"
 rand = "0.8.5"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_yaml = "0.9.34"
+tabled = { version = "0.17.0", features = ["ansi"] }
 thiserror = "1.0.61"
 tokio = { version = "*", features = ["full"] }
 udev = { version = "^0.8", features = ["mio"] }

--- a/src/cli/device.rs
+++ b/src/cli/device.rs
@@ -1,0 +1,229 @@
+use std::error::Error;
+use std::fmt::Display;
+use std::path::PathBuf;
+
+use clap::{Subcommand, ValueEnum};
+use tabled::settings::{Panel, Style};
+use tabled::{Table, Tabled};
+use zbus::Connection;
+
+use crate::cli::get_managed_objects;
+use crate::dbus::interface::composite_device::CompositeDeviceInterfaceProxy;
+use crate::dbus::interface::manager::ManagerInterfaceProxy;
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum DeviceCommand {
+    /// Display information about the composite device
+    Info,
+    /// Get the capabilities of the composite device
+    Capabilities,
+    /// Load the input profile from the given path
+    LoadProfile { path: String },
+    /// Stop InputPlumber from managing the device
+    Stop,
+    /// Manage the intercept mode of the composite device.
+    InterceptMode { mode: Option<InterceptMode> },
+}
+
+#[derive(ValueEnum, Debug, Clone)]
+pub enum InterceptMode {
+    /// No inputs are intercepted and re-routed
+    None,
+    /// No inputs are intercepted and re-routed except for gamepad Guide events. Upon receiving a gamepad Guide event, the device is automatically switched to intercept mode ALL.
+    Pass,
+    /// All inputs are intercepted and re-routed over DBus
+    All,
+    /// All gamepad inputs are intercepted and re-routed over DBus
+    GamepadOnly,
+}
+
+impl From<u32> for InterceptMode {
+    fn from(value: u32) -> Self {
+        match value {
+            0 => Self::None,
+            1 => Self::Pass,
+            2 => Self::All,
+            3 => Self::GamepadOnly,
+            _ => Self::None,
+        }
+    }
+}
+
+impl From<InterceptMode> for u32 {
+    fn from(value: InterceptMode) -> Self {
+        match value {
+            InterceptMode::None => 0,
+            InterceptMode::Pass => 1,
+            InterceptMode::All => 2,
+            InterceptMode::GamepadOnly => 3,
+        }
+    }
+}
+
+impl Display for InterceptMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            InterceptMode::None => "none",
+            InterceptMode::Pass => "pass",
+            InterceptMode::All => "all",
+            InterceptMode::GamepadOnly => "gamepad-only",
+        };
+        write!(f, "{}", value)
+    }
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum DevicesCommand {
+    /// List all running composite devices
+    List,
+    /// Enable/disable managing all supported input devices
+    ManageAll {
+        #[arg(long, action)]
+        enable: bool,
+    },
+}
+
+#[derive(Tabled)]
+struct DeviceRow {
+    #[tabled(rename = "Id")]
+    id: String,
+    #[tabled(rename = "Name")]
+    name: String,
+}
+
+#[derive(Tabled)]
+struct DeviceInfo {
+    #[tabled(rename = "Id")]
+    id: String,
+    #[tabled(rename = "Name")]
+    name: String,
+    #[tabled(rename = "Profile Name")]
+    profile_name: String,
+    #[tabled(rename = "Source Devices")]
+    sources: String,
+}
+
+pub async fn handle_device(
+    conn: Connection,
+    cmd: DeviceCommand,
+    num: u32,
+) -> Result<(), Box<dyn Error>> {
+    // Build the path to the composite device
+    let path = format!("/org/shadowblip/InputPlumber/CompositeDevice{num}");
+    let paths = get_managed_objects(conn.clone()).await?;
+    if !paths.contains(&path) {
+        return Err(format!("Composite device does not exist with number: {num}").into());
+    }
+
+    let device = CompositeDeviceInterfaceProxy::builder(&conn)
+        .path(path.clone())
+        .unwrap()
+        .build()
+        .await;
+    let Some(device) = device.ok() else {
+        return Ok(());
+    };
+
+    match cmd {
+        DeviceCommand::Info => {
+            // Get the source devices for this device
+            let name = device.name().await.unwrap_or_default();
+            let sources = device.source_device_paths().await.unwrap_or_default();
+            let profile_name = device.profile_name().await.unwrap_or_default();
+
+            let entry = DeviceInfo {
+                id: format!("{num}"),
+                name,
+                profile_name,
+                sources: format!("{sources:?}"),
+            };
+            let mut table = Table::new(vec![entry]);
+            table
+                .with(Style::modern_rounded())
+                .with(Panel::header("Composite Device"));
+            println!("{table}");
+        }
+        DeviceCommand::Capabilities => {
+            let caps = device.capabilities().await.unwrap_or_default();
+            println!("{caps:?}");
+        }
+        DeviceCommand::LoadProfile { path } => {
+            let path_buf = PathBuf::from(path.clone());
+            if !path_buf.exists() {
+                return Err(format!("No input profile exists at path: {path}").into());
+            }
+            let abs_path = std::fs::canonicalize(&path_buf)
+                .unwrap_or_default()
+                .to_string_lossy()
+                .to_string();
+            if let Err(e) = device.load_profile_path(abs_path).await {
+                return Err(format!("Failed to load input profile {path}: {e:?}").into());
+            }
+            println!("Successfully loaded profile: {path}");
+        }
+        DeviceCommand::Stop => {
+            device.stop().await?;
+            println!("Stopped device {num}");
+        }
+        DeviceCommand::InterceptMode { mode } => {
+            if let Some(mode) = mode {
+                device.set_intercept_mode(mode.clone().into()).await?;
+                println!("Set intercept mode to: {mode}");
+                return Ok(());
+            }
+            let mode: InterceptMode = device.intercept_mode().await.unwrap_or_default().into();
+            println!("Current intercept mode: {mode}");
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn handle_devices(conn: Connection, cmd: DevicesCommand) -> Result<(), Box<dyn Error>> {
+    match cmd {
+        DevicesCommand::List => {
+            let paths = get_managed_objects(conn.clone()).await?;
+            let mut device_paths: Vec<String> = paths
+                .into_iter()
+                .filter(|obj| obj.contains("/CompositeDevice"))
+                .collect();
+            device_paths.sort();
+            let count = device_paths.len();
+
+            // Query information about each device
+            let mut devices = Vec::with_capacity(device_paths.len());
+            for path in device_paths {
+                let device = CompositeDeviceInterfaceProxy::builder(&conn)
+                    .path(path.clone())
+                    .unwrap()
+                    .build()
+                    .await;
+                let Some(device) = device.ok() else {
+                    continue;
+                };
+
+                let number = path.replace("/org/shadowblip/InputPlumber/CompositeDevice", "");
+                let name = device.name().await.unwrap_or_default();
+
+                let row = DeviceRow { id: number, name };
+
+                devices.push(row);
+            }
+
+            let mut table = Table::new(devices);
+            table
+                .with(Style::modern_rounded())
+                .with(Panel::header("Composite Devices"));
+            println!("{table}");
+            println!("Found {count} composite device(s)");
+        }
+        DevicesCommand::ManageAll { enable } => {
+            let manager = ManagerInterfaceProxy::builder(&conn).build().await?;
+            manager.set_manage_all_devices(enable).await?;
+            let verb = if enable { "Enabled" } else { "Disabled" };
+            println!("{verb} management of all supported devices");
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,100 @@
+pub mod device;
+pub mod source;
+pub mod target;
+
+use std::error::Error;
+
+use clap::{Parser, Subcommand};
+use device::{handle_device, handle_devices, DeviceCommand, DevicesCommand};
+use source::{handle_sources, SourcesCommand};
+use target::{handle_targets, TargetsCommand};
+use zbus::fdo::ObjectManagerProxy;
+use zbus::{names::BusName, Connection};
+
+use crate::constants::{BUS_NAME, BUS_PREFIX};
+
+#[derive(Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct Args {
+    #[command(subcommand)]
+    pub cmd: Option<Commands>,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum Commands {
+    /// Start the InputPlumber daemon (default)
+    Run,
+    /// Manage source input devices
+    Sources {
+        #[command(subcommand)]
+        cmd: SourcesCommand,
+    },
+    /// Manage a composite device
+    Device {
+        /// Composite device id
+        id: u32,
+        #[command(subcommand)]
+        cmd: DeviceCommand,
+    },
+    /// Manage composite devices
+    Devices {
+        #[command(subcommand)]
+        cmd: DevicesCommand,
+    },
+    /// Manage target input devices
+    Targets {
+        #[command(subcommand)]
+        cmd: TargetsCommand,
+    },
+}
+
+pub async fn main_cli(args: Args) -> Result<(), Box<dyn Error>> {
+    let Some(cmd) = args.cmd else {
+        return Ok(());
+    };
+
+    // Connect to DBus
+    let connection = Connection::system().await?;
+    if !is_running(&connection).await {
+        return Err("InputPlumber daemon is not currently running".into());
+    }
+
+    match cmd {
+        Commands::Run => (),
+        Commands::Sources { cmd } => handle_sources(connection, cmd).await?,
+        Commands::Device { id: number, cmd } => handle_device(connection, cmd, number).await?,
+        Commands::Devices { cmd } => handle_devices(connection, cmd).await?,
+        Commands::Targets { cmd } => handle_targets(connection, cmd).await?,
+    }
+
+    Ok(())
+}
+
+/// Returns true if InputPlumber is currently running
+async fn is_running(conn: &Connection) -> bool {
+    let bus = BusName::from_static_str(BUS_NAME).unwrap();
+    let dbus = zbus::fdo::DBusProxy::new(conn).await.ok();
+    let Some(dbus) = dbus else {
+        return false;
+    };
+    dbus.name_has_owner(bus.clone()).await.unwrap_or_default()
+}
+
+/// Returns a list of dbus paths of all objects
+pub async fn get_managed_objects(conn: Connection) -> Result<Vec<String>, Box<dyn Error>> {
+    let bus = BusName::from_static_str(BUS_NAME).unwrap();
+    let object_manager: ObjectManagerProxy = ObjectManagerProxy::builder(&conn)
+        .destination(bus)?
+        .path(BUS_PREFIX)?
+        .build()
+        .await?;
+
+    let objects: Vec<String> = object_manager
+        .get_managed_objects()
+        .await?
+        .keys()
+        .map(|v| v.to_string())
+        .collect();
+
+    Ok(objects)
+}

--- a/src/cli/source.rs
+++ b/src/cli/source.rs
@@ -1,0 +1,70 @@
+use std::error::Error;
+
+use clap::Subcommand;
+use tabled::settings::{Panel, Style};
+use tabled::{Table, Tabled};
+use zbus::Connection;
+
+use crate::cli::get_managed_objects;
+use crate::dbus::interface::source::udev::SourceUdevDeviceInterfaceProxy;
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum SourcesCommand {
+    /// List all discovered source devices
+    List,
+}
+
+#[derive(Tabled)]
+struct SourceDeviceRow {
+    path: String,
+    name: String,
+    subsystem: String,
+}
+
+pub async fn handle_sources(conn: Connection, cmd: SourcesCommand) -> Result<(), Box<dyn Error>> {
+    match cmd {
+        SourcesCommand::List => {
+            let objects = get_managed_objects(conn.clone()).await?;
+            let mut paths: Vec<String> = objects
+                .into_iter()
+                .filter(|obj| obj.contains("/devices/source/"))
+                .collect();
+            paths.sort();
+            let count = paths.len();
+
+            // Query information about each device
+            let mut source_devices = Vec::with_capacity(paths.len());
+            for path in paths {
+                let device = SourceUdevDeviceInterfaceProxy::builder(&conn)
+                    .path(path.clone())
+                    .unwrap()
+                    .build()
+                    .await;
+                let Some(device) = device.ok() else {
+                    continue;
+                };
+
+                let name = device.name().await.unwrap_or_default();
+                let subsystem = device.subsystem().await.unwrap_or_default();
+                let path = device.device_path().await.unwrap_or_default();
+
+                let row = SourceDeviceRow {
+                    path,
+                    name,
+                    subsystem,
+                };
+
+                source_devices.push(row);
+            }
+
+            let mut table = Table::new(source_devices);
+            table
+                .with(Style::modern_rounded())
+                .with(Panel::header("Source Devices"));
+            println!("{table}");
+            println!("Found {count} source device(s)");
+        }
+    }
+
+    Ok(())
+}

--- a/src/cli/target.rs
+++ b/src/cli/target.rs
@@ -1,0 +1,80 @@
+use std::error::Error;
+
+use clap::Subcommand;
+use tabled::settings::{Panel, Style};
+use tabled::{Table, Tabled};
+use zbus::Connection;
+
+use crate::cli::get_managed_objects;
+use crate::input::target::TargetDeviceTypeId;
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum TargetsCommand {
+    /// List all discovered target devices
+    List,
+    /// List all supported target devices
+    SupportedDevices,
+}
+
+#[derive(Tabled)]
+struct TargetDeviceRow {
+    #[tabled(rename = "DBus Path")]
+    path: String,
+}
+
+#[derive(Tabled)]
+struct SupportedTargetRow {
+    #[tabled(rename = "Id")]
+    id: String,
+    #[tabled(rename = "Name")]
+    name: String,
+}
+
+pub async fn handle_targets(conn: Connection, cmd: TargetsCommand) -> Result<(), Box<dyn Error>> {
+    match cmd {
+        TargetsCommand::List => {
+            let objects = get_managed_objects(conn).await?;
+            let mut target_devices: Vec<String> = objects
+                .into_iter()
+                .filter(|obj| obj.contains("/devices/target/"))
+                .collect();
+            target_devices.sort();
+            let count = target_devices.len();
+
+            let target_devices: Vec<TargetDeviceRow> = target_devices
+                .into_iter()
+                .map(|path| {
+                    let dbus_path = path;
+                    TargetDeviceRow { path: dbus_path }
+                })
+                .collect();
+
+            let mut table = Table::new(target_devices);
+            table
+                .with(Style::modern_rounded())
+                .with(Panel::header("Target Devices"));
+            println!("{table}");
+            println!("Found {count} target device(s)");
+        }
+        TargetsCommand::SupportedDevices => {
+            let supported = TargetDeviceTypeId::supported_types();
+            let supported: Vec<SupportedTargetRow> = supported
+                .into_iter()
+                .map(|id| SupportedTargetRow {
+                    name: id.name().to_string(),
+                    id: id.to_string(),
+                })
+                .collect();
+            let count = supported.len();
+
+            let mut table = Table::new(supported);
+            table
+                .with(Style::modern_rounded())
+                .with(Panel::header("Supported Target Devices"));
+            println!("{table}");
+            println!("Found {count} supported target devices");
+        }
+    }
+
+    Ok(())
+}

--- a/src/dbus/interface/composite_device.rs
+++ b/src/dbus/interface/composite_device.rs
@@ -25,7 +25,13 @@ impl CompositeDeviceInterface {
     }
 }
 
-#[interface(name = "org.shadowblip.Input.CompositeDevice")]
+#[interface(
+    name = "org.shadowblip.Input.CompositeDevice",
+    proxy(
+        default_service = "org.shadowblip.InputPlumber",
+        default_path = "/org/shadowblip/InputPlumber/Manager"
+    )
+)]
 impl CompositeDeviceInterface {
     /// Name of the composite device
     #[zbus(property)]
@@ -81,7 +87,7 @@ impl CompositeDeviceInterface {
     }
 
     /// Directly write to the composite device's target devices with the given event
-    fn send_event(&self, event: String, value: zvariant::Value) -> fdo::Result<()> {
+    fn send_event(&self, event: String, value: zvariant::Value<'_>) -> fdo::Result<()> {
         let cap = Capability::from_str(event.as_str()).map_err(|_| {
             fdo::Error::Failed(format!(
                 "Failed to parse event string {event} into capability."

--- a/src/dbus/interface/manager.rs
+++ b/src/dbus/interface/manager.rs
@@ -22,7 +22,13 @@ impl ManagerInterface {
     }
 }
 
-#[interface(name = "org.shadowblip.InputManager")]
+#[interface(
+    name = "org.shadowblip.InputManager",
+    proxy(
+        default_service = "org.shadowblip.InputPlumber",
+        default_path = "/org/shadowblip/InputPlumber/Manager"
+    )
+)]
 impl ManagerInterface {
     #[zbus(property)]
     async fn version(&self) -> fdo::Result<String> {

--- a/src/dbus/interface/source/udev.rs
+++ b/src/dbus/interface/source/udev.rs
@@ -43,7 +43,10 @@ impl SourceUdevDeviceInterface {
     }
 }
 
-#[interface(name = "org.shadowblip.Input.Source.UdevDevice")]
+#[interface(
+    name = "org.shadowblip.Input.Source.UdevDevice",
+    proxy(default_service = "org.shadowblip.InputPlumber",)
+)]
 impl SourceUdevDeviceInterface {
     /// Returns the full device node path to the device (e.g. /dev/input/event3)
     #[zbus(property)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod bluetooth;
+pub mod cli;
 pub mod config;
 pub mod constants;
 pub mod dbus;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use std::env;
 use std::error::Error;
 use std::process;
@@ -10,6 +11,7 @@ use crate::input::manager::Manager;
 use crate::udev::unhide_all;
 
 mod bluetooth;
+mod cli;
 mod config;
 mod constants;
 mod dbus;
@@ -29,6 +31,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
     env::set_var("RUST_LOG", log_level);
     env_logger::init();
     const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+    // If there are any subcommands, run as a CLI client instead.
+    let args = cli::Args::parse();
+    if let Some(cmd) = args.cmd.as_ref() {
+        if !matches!(cmd, cli::Commands::Run) {
+            cli::main_cli(args).await?;
+            return Ok(());
+        }
+    }
+
     log::info!("Starting InputPlumber v{}", VERSION);
 
     // Configure the DBus connection


### PR DESCRIPTION
This change adds a simple command-line interface to InputPlumber to expose some basic functionality that we can expand on in the future. The new interface allows inputplumber to run as a client to execute dbus methods to provide a more user-friendly way to interact with the InputPlumber service.

## Examples

```bash
$ ./inputplumber help
Open source input manager for Linux

Usage: inputplumber [COMMAND]

Commands:
  run      Start the InputPlumber daemon (default)
  sources  Manage source input devices
  device   Manage a composite device
  devices  Manage composite devices
  targets  Manage target input devices
  help     Print this message or the help of the given subcommand(s)

Options:
  -h, --help     Print help
  -V, --version  Print version
```

```bash
$ ./inputplumber devices list
╭────┬─────────────────────────╮
│ Composite Devices            │
├────┼─────────────────────────┤
│ Id │ Name                    │
├────┼─────────────────────────┤
│ 0  │ Microsoft X-Box 360 pad │
╰────┴─────────────────────────╯
Found 1 composite device(s)
```

```bash
$ ./inputplumber device 0 load-profile ~/Projects/InputPlumber/rootfs/usr/share/inputplumber/profiles/default.yaml
Successfully loaded profile: ~/Projects/InputPlumber/rootfs/usr/share/inputplumber/profiles/default.yaml
```