### PR TITLE
feat(Touchscreen): add support for generic touchscreen devices

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2.yaml
@@ -47,6 +47,16 @@ source_devices:
         x: [0, -1, 0]
         y: [-1, 0, 0]
         z: [0, 0, -1]
+  #- group: touchscreen
+  #  udev:
+  #    properties:
+  #      - name: ID_INPUT_TOUCHSCREEN
+  #        value: "1"
+  #    sys_name: "event*"
+  #    subsystem: input
+  #  config:
+  #    touchscreen:
+  #      orientation: "right"
 
 # Optional configuration for the composite device
 options:
@@ -60,6 +70,7 @@ target_devices:
   - xbox-elite
   - mouse
   - keyboard
+  #- touchscreen
 
 # The ID of a device event mapping in the 'event_maps' folder
 capability_map_id: aya4

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
@@ -47,6 +47,16 @@ source_devices:
         x: [0, -1, 0]
         y: [-1, 0, 0]
         z: [0, 0, -1]
+  #- group: touchscreen
+  #  udev:
+  #    properties:
+  #      - name: ID_INPUT_TOUCHSCREEN
+  #        value: "1"
+  #    sys_name: "event*"
+  #    subsystem: input
+  #  config:
+  #    touchscreen:
+  #      orientation: "right"
 
 # Optional configuration for the composite device
 options:
@@ -60,6 +70,7 @@ target_devices:
   - xbox-elite
   - mouse
   - keyboard
+  #- touchscreen
 
 # The ID of a device event mapping in the 'event_maps' folder
 capability_map_id: aya4

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip.yaml
@@ -47,6 +47,24 @@ source_devices:
         x: [0, -1, 0]
         y: [-1, 0, 0]
         z: [0, 0, -1]
+  - group: touchscreen
+    udev:
+      properties:
+        - name: ID_INPUT_TOUCHSCREEN
+          value: "1"
+      attributes:
+        - name: id/vendor
+          value: "0416"
+        - name: id/product
+          value: "1001"
+      sys_name: "event*"
+      subsystem: input
+    config:
+      touchscreen:
+        orientation: "normal"
+        override_source_size: true
+        width: 1200
+        height: 1920
 
 # Optional configuration for the composite device
 options:
@@ -60,6 +78,7 @@ target_devices:
   - xbox-elite
   - mouse
   - keyboard
+  - touchscreen
 
 # The ID of a device event mapping in the 'event_maps' folder
 capability_map_id: aya4

--- a/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
@@ -138,6 +138,18 @@ source_devices:
         y: [-1, 0, 0]
         z: [0, 0, -1]
 
+  # Touchscreen
+  #- group: touchscreen
+  #  udev:
+  #    properties:
+  #      - name: ID_INPUT_TOUCHSCREEN
+  #        value: "1"
+  #    sys_name: "event*"
+  #    subsystem: input
+  #  config:
+  #    touchscreen:
+  #      orientation: "left"
+
   # Block all evdev devices; mouse, touchpad, gamepad, keyboard
   - group: gamepad
     blocked: true
@@ -160,3 +172,4 @@ target_devices:
   - mouse
   - keyboard
   - touchpad
+  #- touchscreen

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw.yaml
@@ -53,6 +53,15 @@ source_devices:
         y: [-1, 0, 0]
         z: [0, 0, -1]
 
+  # Touchscreen
+  #- group: touchscreen
+  #  udev:
+  #    properties:
+  #      - name: ID_INPUT_TOUCHSCREEN
+  #        value: "1"
+  #    sys_name: "event*"
+  #    subsystem: input
+
 # Optional configuration for the composite device
 options:
   # If true, InputPlumber will automatically try to manage the input device. If
@@ -65,6 +74,7 @@ target_devices:
   - xbox-elite
   - mouse
   - keyboard
+  #- touchscreen
 
 # The ID of a device event mapping in the 'event_maps' folder
 capability_map_id: claw1

--- a/rootfs/usr/share/inputplumber/devices/50-rog_ally.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-rog_ally.yaml
@@ -53,6 +53,13 @@ source_devices:
         x: [1, 0, 0]
         y: [0, -1, 0]
         z: [0, 0, -1]
+  #- group: touchscreen
+  #  udev:
+  #    properties:
+  #      - name: ID_INPUT_TOUCHSCREEN
+  #        value: "1"
+  #    sys_name: "event*"
+  #    subsystem: input
 
 # Optional configuration for the composite device
 options:
@@ -66,6 +73,7 @@ target_devices:
   - xbox-elite
   - mouse
   - keyboard
+  #- touchscreen
 
 # The ID of a device event mapping in the 'event_maps' folder
 capability_map_id: aly1

--- a/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml
@@ -52,6 +52,13 @@ source_devices:
         x: [1, 0, 0]
         y: [0, -1, 0]
         z: [0, 0, -1]
+  #- group: touchscreen
+  #  udev:
+  #    properties:
+  #      - name: ID_INPUT_TOUCHSCREEN
+  #        value: "1"
+  #    sys_name: "event*"
+  #    subsystem: input
 
 # Optional configuration for the composite device
 options:
@@ -65,6 +72,7 @@ target_devices:
   - xbox-elite
   - mouse
   - keyboard
+  #- touchscreen
 
 # The ID of a device event mapping in the 'event_maps' folder
 capability_map_id: aly1

--- a/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
@@ -34,16 +34,17 @@ source_devices:
       product_id: 0x1205
       interface_num: 2
   # Touchscreen
-  - group: mouse
-    hidraw:
-      vendor_id: 0x2808
-      product_id: 0x1015
-  - group: mouse
+  - group: touchscreen
     unique: false
-    blocked: true
-    evdev:
-      name: "FTS3528:00 2808:1015*"
-      handler: event*
+    udev:
+      properties:
+        - name: ID_INPUT_TOUCHSCREEN
+          value: "1"
+      sys_name: "event*"
+      subsystem: input
+    config:
+      touchscreen:
+        orientation: "right"
   # Keyboard
   - group: keyboard
     evdev:

--- a/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+++ b/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
@@ -161,6 +161,7 @@
             "keyboard",
             "mouse",
             "gamepad",
+            "touchscreen",
             "imu"
           ]
         },
@@ -186,6 +187,9 @@
         "iio": {
           "$ref": "#/definitions/IIO"
         },
+        "config": {
+          "$ref": "#/definitions/SourceDeviceConfig"
+        },
         "unique": {
           "description": "If false, any devices matching this description will be added to the existing composite device. Defaults to true.",
           "type": "boolean"
@@ -195,6 +199,55 @@
         "group"
       ],
       "title": "SourceDevice"
+    },
+    "SourceDeviceConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "touchscreen": {
+          "$ref": "#/definitions/TouchscreenConfig"
+        },
+        "imu": {
+          "$ref": "#/definitions/ImuConfig"
+        }
+      }
+    },
+    "TouchscreenConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "orientation": {
+          "description": "Orientation of the touchscreen device. Defaults to normal.",
+          "type": "string",
+          "enum": [
+            "normal",
+            "left",
+            "right",
+            "upsidedown"
+          ]
+        },
+        "width": {
+          "description": "Width of the touchscreen in pixels. If set, any virtual touchscreens will use this width instead of querying the source device for its size.",
+          "type": "integer"
+        },
+        "height": {
+          "description": "Height of the touchscreen in pixels. If set, any virtual touchscreens will use this height instead of querying the source device for its size.",
+          "type": "integer"
+        },
+        "override_source_size": {
+          "description": "If true, the source device will use the width/height defined in this configuration instead of the size advertised by the device itself. Defaults to false.",
+          "type": "boolean"
+        }
+      }
+    },
+    "ImuConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "mount_matrix": {
+          "$ref": "#/definitions/MountMatrix"
+        }
+      }
     },
     "Udev": {
       "description": "Source device to manage. Properties support globbing patterns.",

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -308,9 +308,39 @@ pub struct SourceDevice {
     pub hidraw: Option<Hidraw>,
     pub iio: Option<IIO>,
     pub udev: Option<Udev>,
+    pub config: Option<SourceDeviceConfig>,
     pub unique: Option<bool>,
     pub blocked: Option<bool>,
     pub ignore: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct SourceDeviceConfig {
+    pub touchscreen: Option<TouchscreenConfig>,
+    pub imu: Option<ImuConfig>,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct TouchscreenConfig {
+    /// Orientation of the touchscreen. Can be one of: ["normal", "left", "right", "upsidedown"]
+    pub orientation: Option<String>,
+    /// Width of the touchscreen. If set, any virtual touchscreens will use this width
+    /// instead of querying the source device for its size.
+    pub width: Option<u32>,
+    /// Height of the touchscreen. If set, any virtual touchscreens will use this height
+    /// instead of querying the source device for its size.
+    pub height: Option<u32>,
+    /// If true, the source device will use the width/height defined in this configuration
+    /// instead of the size advertised by the device itself.
+    pub override_source_size: Option<bool>,
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct ImuConfig {
+    pub mount_matrix: Option<MountMatrix>,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
@@ -359,6 +389,10 @@ pub struct UdevAttribute {
 pub struct IIO {
     pub id: Option<String>,
     pub name: Option<String>,
+    #[deprecated(
+        since = "0.43.0",
+        note = "please use `<SourceDevice>.config.imu.mount_matrix` instead"
+    )]
     pub mount_matrix: Option<MountMatrix>,
 }
 

--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -1454,11 +1454,14 @@ impl CompositeDevice {
 
         let source_device = match subsystem.as_str() {
             "input" => {
+                // Get any defined config for the event device
+                let config = self.config.get_matching_device(&device);
+
                 log::debug!("Adding source device: {:?}", device.name());
                 if is_blocked {
                     is_blocked_evdev = true;
                 }
-                let device = EventDevice::new(device, self.client(), is_blocked)?;
+                let device = EventDevice::new(device, self.client(), config, is_blocked)?;
                 SourceDevice::Event(device)
             }
             "hidraw" => {

--- a/src/input/source/evdev/touchscreen.rs
+++ b/src/input/source/evdev/touchscreen.rs
@@ -1,0 +1,351 @@
+use std::collections::HashSet;
+use std::fmt::Debug;
+use std::{collections::HashMap, error::Error, os::fd::AsRawFd};
+
+use evdev::{
+    AbsInfo, AbsoluteAxisCode, Device, EventSummary, InputEvent, KeyCode, MiscCode,
+    SynchronizationCode,
+};
+use nix::fcntl::{FcntlArg, OFlag};
+
+use crate::config::TouchscreenConfig;
+use crate::input::capability::Touch;
+use crate::input::event::value::InputValue;
+use crate::{
+    input::{
+        capability::Capability,
+        event::native::NativeEvent,
+        source::{InputError, SourceInputDevice, SourceOutputDevice},
+    },
+    udev::device::UdevDevice,
+};
+
+/// Orientation of the touchscreen used to translate touch
+#[derive(Debug, Clone, Copy, Default)]
+enum Orientation {
+    #[default]
+    Normal,
+    RotateLeft,
+    RotateRight,
+    UpsideDown,
+}
+
+impl From<&str> for Orientation {
+    fn from(value: &str) -> Self {
+        match value {
+            "normal" => Self::Normal,
+            "left" => Self::RotateLeft,
+            "right" => Self::RotateRight,
+            "upsidedown" => Self::UpsideDown,
+            _ => Self::Normal,
+        }
+    }
+}
+
+/// TouchState represents the state of a single touch
+#[derive(Debug, Clone)]
+struct TouchState {
+    is_touching: bool,
+    pressure: f64,
+    x: f64,
+    y: f64,
+}
+
+impl Default for TouchState {
+    fn default() -> Self {
+        Self {
+            is_touching: Default::default(),
+            pressure: 1.0,
+            x: Default::default(),
+            y: Default::default(),
+        }
+    }
+}
+
+impl TouchState {
+    /// Rotates the touch input to the given orientation
+    fn rotate(&self, orientation: Orientation) -> Self {
+        let mut value = self.clone();
+        let (x, y) = match orientation {
+            Orientation::Normal => (self.x, self.y),
+            Orientation::UpsideDown => (1.0 - self.x, 1.0 - self.y),
+            Orientation::RotateLeft => (1.0 - self.y, self.x),
+            Orientation::RotateRight => (self.y, 1.0 - self.x),
+        };
+        value.x = x;
+        value.y = y;
+
+        value
+    }
+
+    /// Convert the touch into an InputPlumber value with the given touch index
+    fn to_value(&self, idx: u8) -> InputValue {
+        InputValue::Touch {
+            index: idx,
+            is_touching: self.is_touching,
+            pressure: Some(self.pressure),
+            x: Some(self.x),
+            y: Some(self.y),
+        }
+    }
+
+    /// Convert the touch into an InputPlumber event with the given touch index
+    fn to_native_event(&self, idx: u8) -> NativeEvent {
+        NativeEvent::new(Capability::Touchscreen(Touch::Motion), self.to_value(idx))
+    }
+}
+
+/// Source device implementation for evdev touchscreens
+/// https://www.kernel.org/doc/Documentation/input/multi-touch-protocol.txt
+pub struct TouchscreenEventDevice {
+    device: Device,
+    orientation: Orientation,
+    axes_info: HashMap<AbsoluteAxisCode, AbsInfo>,
+    touch_state: [TouchState; 10], // NOTE: Max of 10 touch inputs
+    dirty_states: HashSet<usize>,
+    last_touch_idx: usize,
+}
+
+impl TouchscreenEventDevice {
+    /// Create a new Touchscreen source device from the given udev info
+    pub fn new(
+        device_info: UdevDevice,
+        config: Option<TouchscreenConfig>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let path = device_info.devnode();
+        log::debug!("Opening device at: {}", path);
+        let mut device = Device::open(path.clone())?;
+        device.grab()?;
+
+        // Set the device to do non-blocking reads
+        // TODO: use epoll to wake up when data is available
+        // https://github.com/emberian/evdev/blob/main/examples/evtest_nonblocking.rs
+        let raw_fd = device.as_raw_fd();
+        nix::fcntl::fcntl(raw_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))?;
+
+        // Check to see if the user wants to override the screen width/height.
+        let override_size = {
+            let override_opt = config.as_ref().and_then(|c| c.override_source_size);
+            override_opt.unwrap_or_default()
+        };
+
+        // Query information about the device to get the absolute ranges
+        let mut axes_info = HashMap::new();
+        for (axis, info) in device.get_absinfo()? {
+            log::trace!("Found axis: {:?}", axis);
+            log::trace!("Found info: {:?}", info);
+
+            // If the user isn't overriding the size or this axis doesn't contain
+            // size information, then use the original limits advertised by the device.
+            let is_size_info = axis == AbsoluteAxisCode::ABS_MT_POSITION_X
+                || axis == AbsoluteAxisCode::ABS_MT_POSITION_Y;
+            if !override_size || !is_size_info {
+                axes_info.insert(axis, info);
+                continue;
+            }
+
+            // Override the axis maximum if the user has that defined.
+            let mut maximum = info.maximum();
+
+            let width = config.as_ref().and_then(|c| c.width);
+            if axis == AbsoluteAxisCode::ABS_MT_POSITION_X && width.is_some() {
+                maximum = width.unwrap_or_default() as i32;
+            }
+
+            let height = config.as_ref().and_then(|c| c.height);
+            if axis == AbsoluteAxisCode::ABS_MT_POSITION_Y && height.is_some() {
+                maximum = height.unwrap_or_default() as i32;
+            }
+
+            let modified_info = AbsInfo::new(
+                info.value(),
+                info.minimum(),
+                maximum,
+                info.fuzz(),
+                info.flat(),
+                info.resolution(),
+            );
+            axes_info.insert(axis, modified_info);
+        }
+
+        // Configure the orientation of the touchscreen
+        let orientation =
+            if let Some(orientation) = config.as_ref().and_then(|c| c.orientation.as_ref()) {
+                Orientation::from(orientation.as_str())
+            } else {
+                Orientation::default()
+            };
+        log::debug!("Configured touchscreen orientation: {orientation:?}");
+
+        Ok(Self {
+            device,
+            orientation,
+            axes_info,
+            touch_state: Default::default(),
+            dirty_states: HashSet::with_capacity(10),
+            last_touch_idx: 0,
+        })
+    }
+
+    /// Translate the given evdev event into a native event
+    fn translate(&mut self, event: InputEvent) -> Vec<NativeEvent> {
+        log::trace!("Received event: {:?}", event);
+
+        // Update internal touch state until a synchronization event occurs. Each
+        // event that comes in will update the touch state and update 'dirty_states'
+        // to indicate that events should be sent for that touch index when a
+        // SYN_REPORT event occurs.
+        match event.destructure() {
+            // Synchronization events indicate that touch events can be emitted
+            EventSummary::Synchronization(_, SynchronizationCode::SYN_REPORT, _) => {
+                let mut events = Vec::with_capacity(self.dirty_states.len());
+
+                // Send events for any dirty touch states
+                for idx in self.dirty_states.drain() {
+                    let Some(touch) = self.touch_state.get_mut(idx) else {
+                        continue;
+                    };
+
+                    // Rotate values based on config
+                    let rotated_touch = touch.rotate(self.orientation);
+                    let event = rotated_touch.to_native_event(idx as u8);
+                    events.push(event);
+                }
+
+                return events;
+            }
+            // The BTN_TOUCH event occurs whenever touches have started or stopped.
+            // This can be used to reset the last touch index when no touches are
+            // detected.
+            EventSummary::Key(_, KeyCode::BTN_TOUCH, value) => {
+                if value == 0 {
+                    // Reset last touch index when all touches stop
+                    self.last_touch_idx = 0;
+                } else {
+                    self.dirty_states.insert(0);
+                }
+            }
+            // The ABS_MT_SLOT event defines the index of the touch. E.g. "0" would
+            // be the first touch, "1", the second, etc. Upon receiving this event,
+            // any following ABS_X/Y events are associated with this touch index.
+            EventSummary::AbsoluteAxis(_, AbsoluteAxisCode::ABS_MT_SLOT, value) => {
+                // Select the current slot to update
+                let slot = value as usize;
+                self.last_touch_idx = slot;
+                self.dirty_states.insert(slot);
+            }
+            // Whenever a touch is lifted, an ABS_MT_TRACKING_ID event with a value of
+            // -1 event will occur.
+            EventSummary::AbsoluteAxis(_, AbsoluteAxisCode::ABS_MT_TRACKING_ID, -1) => {
+                if let Some(touch) = self.touch_state.get_mut(self.last_touch_idx) {
+                    touch.is_touching = false;
+                    self.dirty_states.insert(self.last_touch_idx);
+                }
+            }
+            // Emitted whenever touch motion is detected for the X axis
+            EventSummary::AbsoluteAxis(_, AbsoluteAxisCode::ABS_MT_POSITION_X, value) => {
+                // Get the axis information so the value can be normalized
+                let Some(info) = self.axes_info.get(&AbsoluteAxisCode::ABS_MT_POSITION_X) else {
+                    return vec![];
+                };
+                let normal_value = normalize_unsigned_value(value, info.maximum());
+
+                // Select the current slot to update
+                if let Some(touch) = self.touch_state.get_mut(self.last_touch_idx) {
+                    touch.is_touching = true;
+                    touch.x = normal_value;
+                    self.dirty_states.insert(self.last_touch_idx);
+                }
+            }
+            // Emitted whenever touch motion is detected for the Y axis
+            EventSummary::AbsoluteAxis(_, AbsoluteAxisCode::ABS_MT_POSITION_Y, value) => {
+                // Get the axis information so the value can be normalized
+                let Some(info) = self.axes_info.get(&AbsoluteAxisCode::ABS_MT_POSITION_Y) else {
+                    return vec![];
+                };
+                let normal_value = normalize_unsigned_value(value, info.maximum());
+
+                // Select the current slot to update
+                if let Some(touch) = self.touch_state.get_mut(self.last_touch_idx) {
+                    touch.is_touching = true;
+                    touch.y = normal_value;
+                    self.dirty_states.insert(self.last_touch_idx);
+                }
+            }
+            // Some touchscreens support touch pressure and emit this event.
+            EventSummary::AbsoluteAxis(_, AbsoluteAxisCode::ABS_PRESSURE, value) => {
+                // Get the axis information so the value can be normalized
+                let Some(info) = self.axes_info.get(&AbsoluteAxisCode::ABS_PRESSURE) else {
+                    return vec![];
+                };
+                let normal_value = normalize_unsigned_value(value, info.maximum());
+
+                // Select the current slot to update
+                if let Some(touch) = self.touch_state.get_mut(self.last_touch_idx) {
+                    touch.pressure = normal_value;
+                    self.dirty_states.insert(self.last_touch_idx);
+                }
+            }
+            EventSummary::Misc(_, MiscCode::MSC_TIMESTAMP, _) => (),
+            _ => (),
+        }
+
+        vec![]
+    }
+}
+
+impl SourceInputDevice for TouchscreenEventDevice {
+    /// Poll the given input device for input events
+    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        // Read events from the device
+        let events = {
+            let result = self.device.fetch_events();
+            let events = match result {
+                Ok(events) => events,
+                Err(err) => match err.kind() {
+                    // Do nothing if this would block
+                    std::io::ErrorKind::WouldBlock => return Ok(vec![]),
+                    _ => {
+                        log::trace!("Failed to fetch events: {:?}", err);
+                        let msg = format!("Failed to fetch events: {:?}", err);
+                        return Err(msg.into());
+                    }
+                },
+            };
+
+            let events: Vec<InputEvent> = events.into_iter().collect();
+            events
+        };
+
+        // Convert the events into native events
+        let native_events = events
+            .into_iter()
+            .map(|e| self.translate(e))
+            .filter(|events| !events.is_empty())
+            .flatten()
+            .collect();
+
+        Ok(native_events)
+    }
+
+    /// Returns the possible input events this device is capable of emitting
+    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
+        Ok(vec![Capability::Touchscreen(Touch::Motion)])
+    }
+}
+
+impl SourceOutputDevice for TouchscreenEventDevice {}
+
+impl Debug for TouchscreenEventDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TouchscreenEventDevice")
+            .field("axes_info", &self.axes_info)
+            .finish()
+    }
+}
+
+// Returns a value between 0.0 and 1.0 based on the given value with its
+// maximum.
+fn normalize_unsigned_value(raw_value: i32, max: i32) -> f64 {
+    raw_value as f64 / max as f64
+}


### PR DESCRIPTION
This change adds support for generic touchscreen source devices. This change also adds the `config` section of a source device to allow defining arbitrary configuration of that captured source device. i.e. in the case of touchscreens, it can allow the source driver to translate touches based on the orientation of the touchscreen.