### PR TITLE
fix: avoid inputs cancelling each other

### DIFF
--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -156,8 +156,11 @@ pub struct CompositeDevice {
     /// List of currently active buttons and keys. Used to block "up" events for
     /// keys that have already been handled.
     active_inputs: Vec<Capability>,
-    /// Mapping of target and source capabilities preventing input release events
-    /// coming from capabilities that didn't start the event
+    /// Mapping preventing input release events to come from capability that
+    /// didn't start the input in the first place.
+    /// The key value pairs are:
+    ///  - KEY   - Target capability
+    ///  - VALUE - Source capability
     exclusive_inputs: HashMap<Capability, Capability>,
 }
 

--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -848,6 +848,15 @@ impl CompositeDevice {
                 // capability as the initiator
                 .filter_map(|event| {
                     let target_cap = event.as_capability();
+                    // Handle only button presses
+                    if !matches!(
+                        target_cap,
+                        Capability::Gamepad(Gamepad::Button(_))
+                            | Capability::Keyboard(_)
+                            | Capability::Mouse(Mouse::Button(_))
+                    ) {
+                        return Some(event);
+                    }
                     let pressed = event.pressed();
                     match self.exclusive_inputs.entry(target_cap) {
                         Entry::Vacant(e) => {


### PR DESCRIPTION
Closes #258

This is a proposition of a solution that addresses said issue. 
By mapping target_capability -> source_capability we can reference "ownership" of an input to given source event within the CompositeDevice. I think this change should be considered potentially breaking.

At the moment this prevents input cancellation for buttons on Gamepad, Keyboard and Mouse capabilities