### PR TITLE
feat: expose generic target interface on every target interface

### DIFF
--- a/src/dbus/interface/target/mod.rs
+++ b/src/dbus/interface/target/mod.rs
@@ -11,17 +11,21 @@ use zbus_macros::interface;
 /// a target input device.
 pub struct TargetInterface {
     dev_name: String,
+    device_type: String,
 }
 
 impl TargetInterface {
-    pub fn new(dev_name: String) -> TargetInterface {
-        TargetInterface { dev_name }
+    pub fn new(dev_name: String, device_type: String) -> TargetInterface {
+        TargetInterface {
+            dev_name,
+            device_type,
+        }
     }
 }
 
 impl Default for TargetInterface {
     fn default() -> Self {
-        Self::new("Gamepad".to_string())
+        Self::new("Gamepad".to_string(), "gamepad".to_string())
     }
 }
 
@@ -31,5 +35,10 @@ impl TargetInterface {
     #[zbus(property)]
     async fn name(&self) -> fdo::Result<String> {
         Ok(self.dev_name.clone())
+    }
+
+    #[zbus(property)]
+    async fn device_type(&self) -> fdo::Result<String> {
+        Ok(self.device_type.clone())
     }
 }


### PR DESCRIPTION
Finally got the use for `TargetInterface`. This will allow overlays to iterate over target devices to get their type - this is especially useful in cases like controller reordering or anything that relies on target device types