### PR TITLE
feat(SourceDevice): add source device event filtering and configurable device hiding

### DIFF
--- a/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+++ b/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
@@ -175,6 +175,11 @@
           "type": "boolean",
           "default": false
         },
+        "passthrough": {
+          "description": "If true, events will be read from this device, but the source device will not be hidden or grabbed. Defaults to false.",
+          "type": "boolean",
+          "default": false
+        },
         "udev": {
           "$ref": "#/definitions/Udev"
         },
@@ -189,6 +194,9 @@
         },
         "config": {
           "$ref": "#/definitions/SourceDeviceConfig"
+        },
+        "events": {
+          "$ref": "#/definitions/EventsConfig"
         },
         "unique": {
           "description": "If false, any devices matching this description will be added to the existing composite device. Defaults to true.",
@@ -422,6 +430,27 @@
         "y",
         "z"
       ]
+    },
+    "EventsConfig": {
+      "type": "object",
+      "description": "Defines which events are included or excluded from input processing by the source device",
+      "additionalProperties": false,
+      "properties": {
+        "exclude": {
+          "description": "Events to exclude from being processed by a source device",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "include": {
+          "description": "Events to include and be processed by a source device",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
     }
   }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -303,15 +303,33 @@ pub struct DMIMatch {
 #[derive(Debug, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct SourceDevice {
+    /// Custom group identifier for the source device.
     pub group: String,
+    /// Devices that match the given evdev properties will be captured by InputPlumber
     pub evdev: Option<Evdev>,
+    /// Devices that match the given hidraw properties will be captured by InputPlumber
     pub hidraw: Option<Hidraw>,
+    /// Devices that match the given iio properties will be captured by InputPlumber
     pub iio: Option<IIO>,
+    /// Devices that match the given udev properties will be captured by InputPlumber
     pub udev: Option<Udev>,
+    /// Device configuration options are used to alter how the source device is managed
     pub config: Option<SourceDeviceConfig>,
+    /// If false, any devices matching this description will be added to the
+    /// existing composite device. Defaults to true.
     pub unique: Option<bool>,
+    /// If true, device will be grabbed but no events from this device will
+    /// reach target devices. Defaults to false.
     pub blocked: Option<bool>,
+    /// If true, this source device will be ignored and not managed by
+    /// InputPlumber. Defaults to false.
     pub ignore: Option<bool>,
+    /// If true, events will be read from this device, but the source device
+    /// will not be hidden or grabbed. Defaults to false.
+    pub passthrough: Option<bool>,
+    /// Defines which events are included or excluded from input processing by
+    /// the source device.
+    pub events: Option<EventsConfig>,
 }
 
 #[derive(Debug, Deserialize, Clone, PartialEq)]
@@ -403,6 +421,15 @@ pub struct MountMatrix {
     pub x: [f64; 3],
     pub y: [f64; 3],
     pub z: [f64; 3],
+}
+
+#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub struct EventsConfig {
+    /// Events to exclude from being processed by a source device
+    pub exclude: Option<Vec<String>>,
+    /// Events to include and be processed by a source device
+    pub include: Option<Vec<String>>,
 }
 
 /// Defines a combined device

--- a/src/input/manager.rs
+++ b/src/input/manager.rs
@@ -470,7 +470,8 @@ impl Manager {
             device,
             self.next_composite_dbus_path()?,
             capability_map,
-        )?;
+        )
+        .await?;
 
         // Check to see if there's already a CompositeDevice for
         // these source devices.

--- a/src/input/source/evdev/keyboard.rs
+++ b/src/input/source/evdev/keyboard.rs
@@ -1,0 +1,144 @@
+use std::error::Error;
+use std::fmt::Debug;
+use std::os::fd::AsRawFd;
+
+use evdev::{Device, EventType, InputEvent};
+use nix::fcntl::{FcntlArg, OFlag};
+
+use crate::{
+    config::SourceDevice,
+    input::{
+        capability::Capability,
+        event::{evdev::EvdevEvent, native::NativeEvent},
+        source::{InputError, SourceInputDevice, SourceOutputDevice},
+    },
+    udev::device::UdevDevice,
+};
+
+/// Source device implementation for evdev gamepads
+pub struct KeyboardEventDevice {
+    device: Device,
+}
+
+impl KeyboardEventDevice {
+    /// Create a new [KeyboardEventDevice] source device from the given udev info
+    pub fn new(
+        device_info: UdevDevice,
+        config: &Option<SourceDevice>,
+    ) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let path = device_info.devnode();
+        log::debug!("Opening device at: {}", path);
+        let mut device = Device::open(path.clone())?;
+
+        // Grab exclusive access to the device
+        let should_passthru = config.as_ref().and_then(|c| c.passthrough).unwrap_or(false);
+        if !should_passthru {
+            device.grab()?;
+        }
+
+        // Set the device to do non-blocking reads
+        // TODO: use epoll to wake up when data is available
+        // https://github.com/emberian/evdev/blob/main/examples/evtest_nonblocking.rs
+        let raw_fd = device.as_raw_fd();
+        nix::fcntl::fcntl(raw_fd, FcntlArg::F_SETFL(OFlag::O_NONBLOCK))?;
+
+        Ok(Self { device })
+    }
+
+    /// Translate the given evdev event into a native event
+    fn translate(&mut self, event: InputEvent) -> Option<NativeEvent> {
+        log::trace!("Received event: {:?}", event);
+
+        // Block Sync events, we create these at the target anyway and they waste processing.
+        if event.event_type() == EventType::SYNCHRONIZATION {
+            log::trace!("Holding Sync event from propagating through the processing stack.");
+            return None;
+        }
+
+        // Convert the event into a [NativeEvent]
+        let native_event = NativeEvent::from_evdev_raw(event.into(), None);
+
+        Some(native_event)
+    }
+}
+
+impl SourceInputDevice for KeyboardEventDevice {
+    /// Poll the given input device for input events
+    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        // Read events from the device
+        let events = {
+            let result = self.device.fetch_events();
+            let events = match result {
+                Ok(events) => events,
+                Err(err) => match err.kind() {
+                    // Do nothing if this would block
+                    std::io::ErrorKind::WouldBlock => return Ok(vec![]),
+                    _ => {
+                        log::trace!("Failed to fetch events: {:?}", err);
+                        let msg = format!("Failed to fetch events: {:?}", err);
+                        return Err(msg.into());
+                    }
+                },
+            };
+
+            let events: Vec<InputEvent> = events.into_iter().collect();
+            events
+        };
+
+        // Convert the events into native events
+        let native_events = events
+            .into_iter()
+            .filter_map(|e| self.translate(e))
+            .collect();
+
+        Ok(native_events)
+    }
+
+    /// Returns the possible input events this device is capable of emitting
+    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
+        let mut capabilities = vec![];
+
+        // Loop through all support events
+        let events = self.device.supported_events();
+        for event in events.iter() {
+            match event {
+                EventType::SYNCHRONIZATION => {
+                    capabilities.push(Capability::Sync);
+                }
+                EventType::KEY => {
+                    let Some(keys) = self.device.supported_keys() else {
+                        continue;
+                    };
+                    for key in keys.iter() {
+                        let input_event = InputEvent::new(event.0, key.0, 0);
+                        let evdev_event = EvdevEvent::from(input_event);
+                        let cap = evdev_event.as_capability();
+                        capabilities.push(cap);
+                    }
+                }
+                EventType::RELATIVE => (),
+                EventType::ABSOLUTE => (),
+                EventType::MISC => (),
+                EventType::SWITCH => (),
+                EventType::LED => (),
+                EventType::SOUND => (),
+                EventType::REPEAT => (),
+                EventType::FORCEFEEDBACK => (),
+                EventType::POWER => (),
+                EventType::FORCEFEEDBACKSTATUS => (),
+                EventType::UINPUT => (),
+                _ => (),
+            }
+        }
+
+        Ok(capabilities)
+    }
+}
+
+impl SourceOutputDevice for KeyboardEventDevice {}
+
+impl Debug for KeyboardEventDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KeyboardEventDevice").finish()
+    }
+}

--- a/src/input/source/iio.rs
+++ b/src/input/source/iio.rs
@@ -83,20 +83,21 @@ impl IioDevice {
     pub fn new(
         device_info: UdevDevice,
         composite_device: CompositeDeviceClient,
-        config: Option<config::IIO>,
+        conf: Option<config::SourceDevice>,
     ) -> Result<Self, Box<dyn Error + Send + Sync>> {
         let driver_type = IioDevice::get_driver_type(&device_info);
+        let iio_config = conf.as_ref().and_then(|c| c.iio.clone());
 
         match driver_type {
             DriverType::Unknown => Err("No driver for iio interface found".into()),
             DriverType::BmiImu => {
-                let device = BmiImu::new(device_info.clone(), config)?;
-                let source_device = SourceDriver::new(composite_device, device, device_info);
+                let device = BmiImu::new(device_info.clone(), iio_config)?;
+                let source_device = SourceDriver::new(composite_device, device, device_info, conf);
                 Ok(Self::BmiImu(source_device))
             }
             DriverType::AccelGryo3D => {
-                let device = AccelGyro3dImu::new(device_info.clone(), config)?;
-                let source_device = SourceDriver::new(composite_device, device, device_info);
+                let device = AccelGyro3dImu::new(device_info.clone(), iio_config)?;
+                let source_device = SourceDriver::new(composite_device, device, device_info, conf);
                 Ok(Self::AccelGryo3D(source_device))
             }
         }

--- a/src/udev/mod.rs
+++ b/src/udev/mod.rs
@@ -16,9 +16,9 @@ use self::device::Device;
 const RULES_PREFIX: &str = "/run/udev/rules.d";
 
 /// Hide the given input device from regular users.
-pub async fn hide_device(path: String) -> Result<(), Box<dyn Error>> {
+pub async fn hide_device(path: &str) -> Result<(), Box<dyn Error>> {
     // Get the device to hide
-    let device = get_device(path.clone()).await?;
+    let device = get_device(path.to_string()).await?;
     let name = device.name.clone();
     let Some(parent) = device.get_parent() else {
         return Err("Unable to determine parent for device".into());


### PR DESCRIPTION
This change adds two new configurable features:

- Source device event filtering - exclude processing certain events from a source device
- Source device passthrough - InputPlumber won't hide or grab exclusive access to a source device