### PR TITLE
feat(Manager): add gamepad reordering

### DIFF
--- a/src/input/composite_device/client.rs
+++ b/src/input/composite_device/client.rs
@@ -360,4 +360,15 @@ impl CompositeDeviceClient {
         }
         Err(ClientError::ChannelClosed)
     }
+
+    /// Returns true if the target devices are suspended
+    pub async fn is_suspended(&self) -> Result<bool, ClientError> {
+        let (tx, mut rx) = channel(1);
+        self.tx.send(CompositeCommand::IsSuspended(tx)).await?;
+
+        if let Some(result) = rx.recv().await {
+            return Ok(result);
+        }
+        Err(ClientError::ChannelClosed)
+    }
 }

--- a/src/input/composite_device/command.rs
+++ b/src/input/composite_device/command.rs
@@ -48,4 +48,5 @@ pub enum CompositeCommand {
     Stop,
     Suspend(mpsc::Sender<()>),
     Resume(mpsc::Sender<()>),
+    IsSuspended(mpsc::Sender<bool>),
 }

--- a/src/input/manager.rs
+++ b/src/input/manager.rs
@@ -346,6 +346,13 @@ impl Manager {
                         continue;
                     };
 
+                    self.composite_device_targets
+                        .entry(device_path.clone())
+                        .and_modify(|paths| {
+                            paths.remove(&path);
+                        });
+                    log::debug!("Used target devices: {:?}", self.composite_device_targets);
+
                     let is_suspended = match device.is_suspended().await {
                         Ok(suspended) => suspended,
                         Err(e) => {
@@ -366,12 +373,6 @@ impl Manager {
                         .filter(|paf| paf.as_str() != device_path.as_str())
                         .collect();
                     log::info!("Gamepad order: {:?}", self.target_gamepad_order);
-
-                    self.composite_device_targets
-                        .entry(device_path)
-                        .and_modify(|paths| {
-                            paths.remove(&path);
-                        });
                 }
                 ManagerCommand::DeviceAdded { device } => {
                     let dev_name = device.name();
@@ -686,7 +687,7 @@ impl Manager {
                 paths.insert(target_path.to_string());
                 paths
             });
-        log::trace!("Used target devices: {:?}", self.composite_device_targets);
+        log::debug!("Used target devices: {:?}", self.composite_device_targets);
 
         log::debug!("Finished handling attach request for: {target_path}");
 

--- a/src/input/target/mod.rs
+++ b/src/input/target/mod.rs
@@ -216,6 +216,14 @@ impl TargetDeviceTypeId {
     pub fn name(&self) -> &str {
         self.name
     }
+
+    /// Returns true if the target type is a gamepad
+    pub fn is_gamepad(&self) -> bool {
+        !matches!(
+            self.id,
+            "dbus" | "null" | "touchscreen" | "touchpad" | "mouse" | "keyboard"
+        )
+    }
 }
 
 impl Display for TargetDeviceTypeId {


### PR DESCRIPTION
This change adds the `GamepadOrder` property to the `Manager` interface to allow users to re-order gamepads.