### PR TITLE
feat(CompositeDevice): Add persist option

### DIFF
--- a/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+++ b/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
@@ -90,6 +90,11 @@
           "description": "If true, InputPlumber will automatically try to manage the input device. If this is false, InputPlumber will not try to manage the device unless an external service enables management of the device. Defaults to 'false'",
           "type": "boolean",
           "default": false
+        },
+        "persist": {
+          "description": "If true, InputPlumber will not stop the CompositeDevice if all the SourceDevices have stopped. This will persist the virtual TargetDevice to allow reconnecting a SourceDevice and resuming input. Defaults to 'false'",
+          "type": "boolean",
+          "default": false
         }
       },
       "title": "Options"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -276,6 +276,7 @@ pub struct CompositeDeviceConfigOptions {
     /// If this is false, InputPlumber will not try to manage the device unless
     /// an external service enables management of all devices.
     pub auto_manage: Option<bool>,
+    pub persist: Option<bool>,
 }
 
 /// Defines a platform match for loading a [CompositeDeviceConfig]

--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -312,6 +312,16 @@ impl CompositeDevice {
         }
         self.target_devices = targets;
 
+        // Set persist value from config if set, used to determine
+        // if CompositeDevice self-closes after all SourceDevices have
+        // been removed.
+        let persist = self
+            .config
+            .options
+            .as_ref()
+            .map(|options| options.persist.unwrap_or(false))
+            .unwrap_or(false);
+
         // Loop and listen for command events
         log::debug!("CompositeDevice started");
         let mut buffer = Vec::with_capacity(BUFFER_SIZE);
@@ -393,12 +403,6 @@ impl CompositeDevice {
                         log::debug!("Detected source device stopped: {}", device.devnode());
                         if let Err(e) = self.on_source_device_removed(device).await {
                             log::error!("Failed to remove source device: {:?}", e);
-                        }
-                        if self.source_devices_used.is_empty() {
-                            log::debug!(
-                                "No source devices remain. Stopping CompositeDevice {dbus_path}"
-                            );
-                            break 'main;
                         }
                     }
                     CompositeCommand::SourceDeviceRemoved(device) => {
@@ -523,10 +527,20 @@ impl CompositeDevice {
             }
 
             // If no source devices remain after processing the queue, stop
-            // the device.
+            // the device unless configured to persist.
             if devices_removed && self.source_devices_used.is_empty() {
-                log::debug!("No source devices remain. Stopping CompositeDevice {dbus_path}");
-                break 'main;
+                if persist {
+                    log::debug!("No source devices remain, but CompositeDevice {dbus_path} has persist enabled. Clearing target devices states.");
+                    for (path, target) in &self.target_devices {
+                        log::debug!("Clearing target device: {path}");
+                        if let Err(e) = target.clear_state().await {
+                            log::error!("Failed to clear target device state {path}: {e:?}");
+                        }
+                    }
+                } else {
+                    log::debug!("No source devices remain. Stopping CompositeDevice {dbus_path}");
+                    break 'main;
+                }
             }
         }
         log::info!("CompositeDevice stopping: {dbus_path}");

--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -979,6 +979,19 @@ impl TargetInputDevice for DualSenseDevice {
         let _ = self.device.destroy();
         Ok(())
     }
+
+    /// Clear any local state on the target device.
+    fn clear_state(&mut self) {
+        let caps = self.get_capabilities().unwrap_or_else(|_| {
+            log::error!("No target device capabilities found while clearing state.");
+            Vec::new()
+        });
+        for cap in caps {
+            let ev = NativeEvent::new(cap, InputValue::Bool(false));
+            self.queued_events
+                .push(ScheduledNativeEvent::new(ev, Duration::from_millis(0)));
+        }
+    }
 }
 
 impl TargetOutputDevice for DualSenseDevice {

--- a/src/input/target/mod.rs
+++ b/src/input/target/mod.rs
@@ -317,7 +317,9 @@ pub trait TargetInputDevice {
     /// Clear any local state on the target device. This is typically called
     /// whenever the composite device has entered intercept mode to indicate
     /// that the target device should stop sending input.
-    fn clear_state(&mut self) {}
+    fn clear_state(&mut self) {
+        log::debug!("Generic clear state called. Do nothing.");
+    }
 
     /// Called when the target device has been attached to a composite device.
     fn on_composite_device_attached(

--- a/src/input/target/steam_deck.rs
+++ b/src/input/target/steam_deck.rs
@@ -831,6 +831,19 @@ impl TargetInputDevice for SteamDeckDevice {
         log::debug!("Finished stopping");
         Ok(())
     }
+
+    /// Clear any local state on the target device.
+    fn clear_state(&mut self) {
+        let caps = self.get_capabilities().unwrap_or_else(|_| {
+            log::error!("No target device capabilities found while clearing state.");
+            Vec::new()
+        });
+        for cap in caps {
+            let ev = NativeEvent::new(cap, InputValue::Bool(false));
+            self.queued_events
+                .push(ScheduledNativeEvent::new(ev, Duration::from_millis(0)));
+        }
+    }
 }
 
 impl TargetOutputDevice for SteamDeckDevice {

--- a/src/input/target/xb360.rs
+++ b/src/input/target/xb360.rs
@@ -14,6 +14,7 @@ use crate::input::capability::{Capability, Gamepad, GamepadAxis, GamepadButton, 
 use crate::input::composite_device::client::CompositeDeviceClient;
 use crate::input::event::evdev::EvdevEvent;
 use crate::input::event::native::{NativeEvent, ScheduledNativeEvent};
+use crate::input::event::value::InputValue;
 use crate::input::output_capability::OutputCapability;
 use crate::input::output_event::{OutputEvent, UinputOutputEvent};
 
@@ -217,6 +218,19 @@ impl TargetInputDevice for XBox360Controller {
             return None;
         }
         Some(self.queued_events.drain(..).collect())
+    }
+
+    /// Clear any local state on the target device.
+    fn clear_state(&mut self) {
+        let caps = self.get_capabilities().unwrap_or_else(|_| {
+            log::error!("No target device capabilities found while clearing state.");
+            Vec::new()
+        });
+        for cap in caps {
+            let ev = NativeEvent::new(cap, InputValue::Bool(false));
+            self.queued_events
+                .push(ScheduledNativeEvent::new(ev, Duration::from_millis(0)));
+        }
     }
 }
 

--- a/src/input/target/xbox_elite.rs
+++ b/src/input/target/xbox_elite.rs
@@ -14,6 +14,7 @@ use crate::input::capability::{Capability, Gamepad, GamepadAxis, GamepadButton, 
 use crate::input::composite_device::client::CompositeDeviceClient;
 use crate::input::event::evdev::EvdevEvent;
 use crate::input::event::native::{NativeEvent, ScheduledNativeEvent};
+use crate::input::event::value::InputValue;
 use crate::input::output_capability::OutputCapability;
 use crate::input::output_event::{OutputEvent, UinputOutputEvent};
 
@@ -228,6 +229,19 @@ impl TargetInputDevice for XboxEliteController {
             return None;
         }
         Some(self.queued_events.drain(..).collect())
+    }
+
+    /// Clear any local state on the target device.
+    fn clear_state(&mut self) {
+        let caps = self.get_capabilities().unwrap_or_else(|_| {
+            log::error!("No target device capabilities found while clearing state.");
+            Vec::new()
+        });
+        for cap in caps {
+            let ev = NativeEvent::new(cap, InputValue::Bool(false));
+            self.queued_events
+                .push(ScheduledNativeEvent::new(ev, Duration::from_millis(0)));
+        }
     }
 }
 

--- a/src/input/target/xbox_series.rs
+++ b/src/input/target/xbox_series.rs
@@ -14,6 +14,7 @@ use crate::input::capability::{Capability, Gamepad, GamepadAxis, GamepadButton, 
 use crate::input::composite_device::client::CompositeDeviceClient;
 use crate::input::event::evdev::EvdevEvent;
 use crate::input::event::native::{NativeEvent, ScheduledNativeEvent};
+use crate::input::event::value::InputValue;
 use crate::input::output_capability::OutputCapability;
 use crate::input::output_event::{OutputEvent, UinputOutputEvent};
 
@@ -219,6 +220,19 @@ impl TargetInputDevice for XboxSeriesController {
             return None;
         }
         Some(self.queued_events.drain(..).collect())
+    }
+
+    /// Clear any local state on the target device.
+    fn clear_state(&mut self) {
+        let caps = self.get_capabilities().unwrap_or_else(|_| {
+            log::error!("No target device capabilities found while clearing state.");
+            Vec::new()
+        });
+        for cap in caps {
+            let ev = NativeEvent::new(cap, InputValue::Bool(false));
+            self.queued_events
+                .push(ScheduledNativeEvent::new(ev, Duration::from_millis(0)));
+        }
     }
 }
 


### PR DESCRIPTION
* Add CompositeDevice config bool option 'persist' 
* If persist is true then continue running CompositeDevice when all SourceDevices have been removed
* Update clear_state for Gamepad targets to default all inputs to stop all input from continuing

This improvement is to handle cases where a SourceDevice is disconnected to maintain the existing TargetDevice 