### PR TITLE
fix(Udev): cache device properties so they are not lost during rule evaluation

### DIFF
--- a/src/input/source/evdev.rs
+++ b/src/input/source/evdev.rs
@@ -160,7 +160,9 @@ impl EventDevice {
             return DriverType::Keyboard;
         }
 
-        log::debug!("Unknown input device, falling back to gamepad implementation");
+        let devnode = device.devnode();
+        log::debug!("Unknown input device '{devnode}', falling back to gamepad implementation. Device had udev properties: {properties:?}");
+
         DriverType::Gamepad
     }
 }


### PR DESCRIPTION
This change fixes an issue where the evdev source would not identify the correct driver to use because the udev properties to identify the driver are no longer present at the time of source device initialization. I suspect this could be from udev hiding that triggers reloading the rules.

This change caches udev properties, so they will be queryable at the time of source device initialization. 