### PR TITLE
fix(CompositeDevice): move device hiding logic back to device start instead of device add

### DIFF
--- a/rootfs/usr/lib/systemd/system/inputplumber.service
+++ b/rootfs/usr/lib/systemd/system/inputplumber.service
@@ -2,6 +2,7 @@
 Description=InputPlumber Service
 
 [Service]
+Environment=LOG_LEVEL=info
 ExecStart=/usr/bin/inputplumber
 
 [Install]

--- a/src/input/manager.rs
+++ b/src/input/manager.rs
@@ -213,7 +213,9 @@ impl Manager {
     pub async fn run(&mut self) -> Result<(), Box<dyn Error + Send + Sync>> {
         // Delay initial discovery by a short amount of time to allow udev
         // rules to process for the first time.
-        tokio::time::sleep(Duration::from_millis(1000)).await;
+        // TODO: Figure out a better way to prevent udev from not running hiding
+        // rules too early in boot.
+        tokio::time::sleep(Duration::from_millis(4000)).await;
 
         let dbus_for_listen_on_dbus = self.dbus.clone();
 
@@ -793,8 +795,7 @@ impl Manager {
         let composite_path_clone = composite_path.clone();
         let tx = self.tx.clone();
         let task = tokio::spawn(async move {
-            let targets = HashMap::new();
-            if let Err(e) = device.run(targets).await {
+            if let Err(e) = device.run().await {
                 log::error!("Error running {composite_path}: {}", e.to_string());
             }
             log::debug!("Composite device stopped running: {composite_path}");

--- a/src/udev/device.rs
+++ b/src/udev/device.rs
@@ -746,7 +746,9 @@ impl Device {
         let match_rule = match subsystem.as_str() {
             "hidraw" => {
                 let name = self.name.clone();
-                Some(format!(r#"SUBSYSTEMS=="{subsystem}", KERNEL=="{name}""#))
+                Some(format!(
+                    r#"ACTION=="add|change", SUBSYSTEMS=="{subsystem}", KERNEL=="{name}""#
+                ))
             }
             "input" => {
                 let rule_fn = || {
@@ -755,7 +757,7 @@ impl Device {
                     let pid = self.get_product_id()?;
 
                     Some(format!(
-                        r#"SUBSYSTEMS=="{subsystem}", KERNELS=="{device_name}", ATTRS{{id/vendor}}=="{vid}", ATTRS{{id/product}}=="{pid}""#
+                        r#"ACTION=="add|change", SUBSYSTEMS=="{subsystem}", KERNELS=="{device_name}", ATTRS{{id/vendor}}=="{vid}", ATTRS{{id/product}}=="{pid}""#
                     ))
                 };
                 rule_fn()

--- a/src/udev/mod.rs
+++ b/src/udev/mod.rs
@@ -43,7 +43,8 @@ pub async fn hide_device(path: &str) -> Result<(), Box<dyn Error>> {
 {match_rule}, GOTO="inputplumber_valid"
 GOTO="inputplumber_end"
 LABEL="inputplumber_valid"
-KERNEL=="hidraw[0-9]*|js[0-9]*|event[0-9]*", SUBSYSTEM=="{subsystem}", MODE="000", GROUP="root", RUN:="{chmod_cmd} 000 {path}", SYMLINK+="inputplumber/by-hidden/%k"
+KERNEL=="js[0-9]*|event[0-9]*", SUBSYSTEM=="{subsystem}", MODE:="0000", GROUP:="root", RUN:="{chmod_cmd} 000 /dev/input/%k", SYMLINK+="inputplumber/by-hidden/%k"
+KERNEL=="hidraw[0-9]*", SUBSYSTEM=="{subsystem}", MODE:="0000", GROUP:="root", RUN:="{chmod_cmd} 000 /dev/%k", SYMLINK+="inputplumber/by-hidden/%k"
 LABEL="inputplumber_end"
 "#
     );

--- a/src/udev/mod.rs
+++ b/src/udev/mod.rs
@@ -43,7 +43,7 @@ pub async fn hide_device(path: &str) -> Result<(), Box<dyn Error>> {
 {match_rule}, GOTO="inputplumber_valid"
 GOTO="inputplumber_end"
 LABEL="inputplumber_valid"
-ACTION=="add|change", KERNEL=="hidraw[0-9]*|js[0-9]*|event[0-9]*", SUBSYSTEM=="{subsystem}", MODE:="0000", GROUP:="root", RUN:="{chmod_cmd} 000 {path}", SYMLINK+="inputplumber/by-hidden/%k"
+KERNEL=="hidraw[0-9]*|js[0-9]*|event[0-9]*", SUBSYSTEM=="{subsystem}", MODE="000", GROUP="root", RUN:="{chmod_cmd} 000 {path}", SYMLINK+="inputplumber/by-hidden/%k"
 LABEL="inputplumber_end"
 "#
     );
@@ -102,12 +102,14 @@ pub async fn unhide_all() -> Result<(), Box<dyn Error>> {
 
 /// Trigger udev to evaluate rules on the children of the given parent device path
 async fn reload_children(parent: String) -> Result<(), Box<dyn Error>> {
+    log::debug!("Reloading udev rules: udevadm control --reload-rules");
     let _ = Command::new("udevadm")
         .args(["control", "--reload-rules"])
         .output()
         .await?;
 
     for action in ["remove", "add"] {
+        log::debug!("Retriggering udev rules: udevadm trigger --action {action} -b {parent}");
         let _ = Command::new("udevadm")
             .args(["trigger", "--action", action, "-b", parent.as_str()])
             .output()
@@ -119,11 +121,13 @@ async fn reload_children(parent: String) -> Result<(), Box<dyn Error>> {
 
 /// Trigger udev to evaluate rules on the children of the given parent device path
 async fn reload_all() -> Result<(), Box<dyn Error>> {
+    log::debug!("Reloading udev rules: udevadm control --reload-rules");
     let _ = Command::new("udevadm")
         .args(["control", "--reload-rules"])
         .output()
         .await?;
 
+    log::debug!("Retriggering udev rules: udevadm trigger");
     let _ = Command::new("udevadm").arg("trigger").output().await?;
 
     Ok(())


### PR DESCRIPTION
This change also includes fixes for a deadlock that can occur with `SetTargetDevices` introduced by an earlier version.