### PR TITLE
feat(Unified Controller): add unified controller driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,10 @@ setup: /usr/share/dbus-1/system.d/$(DBUS_NAME).conf ## Install dbus policies
 		/usr/share/dbus-1/system.d/$(DBUS_NAME).conf
 	sudo systemctl reload dbus
 
+.PHONY: example
+example:
+	CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUNNER='sudo -E' cargo run --example unified_gamepad
+
 ##@ Distribution
 
 .PHONY: dist

--- a/examples/unified_gamepad/main.rs
+++ b/examples/unified_gamepad/main.rs
@@ -1,0 +1,47 @@
+use std::{fs, thread::sleep, time::Duration};
+
+use inputplumber::drivers::unified_gamepad::driver::Driver;
+
+const SEARCH_PATH: &str = "/sys/bus/hid/devices";
+
+fn main() {
+    // Look for a Unified Controller
+    let paths = fs::read_dir(SEARCH_PATH).expect("Unable to read HID devices");
+
+    println!("Searching for Unified Controller");
+    let mut device_sys_path = None;
+    for path in paths {
+        let path = path.unwrap();
+        let mut file_path = path.path().into_os_string();
+        file_path.push("/uevent");
+        println!("{file_path:?}");
+
+        let data = fs::read_to_string(file_path).unwrap();
+        println!("{data}");
+        if data.contains("InputPlumber Unified Gamepad") {
+            device_sys_path = Some(path);
+            break;
+        }
+    }
+
+    // Get the hidraw name of the device
+    let device_sys_path = device_sys_path.expect("Unable to find Unified Controller");
+    let mut hid_sys_path = device_sys_path.path().into_os_string();
+    hid_sys_path.push("/hidraw");
+    let paths = fs::read_dir(hid_sys_path).expect("Unable to read HID device info");
+    let device_name = paths.into_iter().next().unwrap().unwrap().file_name();
+
+    println!("Found Unified Controller device: {device_name:?}");
+    println!("Starting Unified Controller driver!");
+
+    let path = format!("/dev/{}", device_name.to_string_lossy());
+    let mut driver = Driver::new(path).expect("Failed to create driver instance");
+
+    loop {
+        let events = driver.poll().expect("Failed to poll device");
+        for event in events.into_iter() {
+            println!("Event: {event:?}");
+        }
+        sleep(Duration::from_millis(1));
+    }
+}

--- a/rootfs/usr/lib/udev/hwdb.d/59-inputplumber.hwdb
+++ b/rootfs/usr/lib/udev/hwdb.d/59-inputplumber.hwdb
@@ -10,3 +10,6 @@ evdev:name:AT Translated Set 2 keyboard:dmi:*:svnOrangePi:pnNEO-01:*
   KEYBOARD_KEY_66=f15
   KEYBOARD_KEY_67=f16
 
+# Unified Gamepad
+hid:b0003g0001v00001D50p0000616A
+ ID_INPUT_UNIFIED=1

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -7,4 +7,5 @@ pub mod legos;
 pub mod opineo;
 pub mod rog_ally;
 pub mod steam_deck;
+pub mod unified_gamepad;
 pub mod xpad_uhid;

--- a/src/drivers/unified_gamepad/capability.rs
+++ b/src/drivers/unified_gamepad/capability.rs
@@ -1,0 +1,707 @@
+use packed_struct::prelude::*;
+
+#[derive(PrimitiveEnum_u16, Clone, Copy, PartialEq, Debug, Default)]
+pub enum InputCapability {
+    #[default]
+    None = 0,
+    KeyboardKeyEsc = 1,
+    KeyboardKey1 = 2,
+    KeyboardKey2 = 3,
+    KeyboardKey3 = 4,
+    KeyboardKey4 = 5,
+    KeyboardKey5 = 6,
+    KeyboardKey6 = 7,
+    KeyboardKey7 = 8,
+    KeyboardKey8 = 9,
+    KeyboardKey9 = 10,
+    KeyboardKey0 = 11,
+    KeyboardKeyMinus = 12,
+    KeyboardKeyEqual = 13,
+    KeyboardKeyBackspace = 14,
+    KeyboardKeyTab = 15,
+    KeyboardKeyQ = 16,
+    KeyboardKeyW = 17,
+    KeyboardKeyE = 18,
+    KeyboardKeyR = 19,
+    KeyboardKeyT = 20,
+    KeyboardKeyY = 21,
+    KeyboardKeyU = 22,
+    KeyboardKeyI = 23,
+    KeyboardKeyO = 24,
+    KeyboardKeyP = 25,
+    KeyboardKeyLeftBrace = 26,
+    KeyboardKeyRightBrace = 27,
+    KeyboardKeyEnter = 28,
+    KeyboardKeyLeftCtrl = 29,
+    KeyboardKeyA = 30,
+    KeyboardKeyS = 31,
+    KeyboardKeyD = 32,
+    KeyboardKeyF = 33,
+    KeyboardKeyG = 34,
+    KeyboardKeyH = 35,
+    KeyboardKeyJ = 36,
+    KeyboardKeyK = 37,
+    KeyboardKeyL = 38,
+    KeyboardKeySemicolon = 39,
+    KeyboardKeyApostrophe = 40,
+    KeyboardKeyGrave = 41,
+    KeyboardKeyLeftShift = 42,
+    KeyboardKeyBackslash = 43,
+    KeyboardKeyZ = 44,
+    KeyboardKeyX = 45,
+    KeyboardKeyC = 46,
+    KeyboardKeyV = 47,
+    KeyboardKeyB = 48,
+    KeyboardKeyN = 49,
+    KeyboardKeyM = 50,
+    KeyboardKeyComma = 51,
+    KeyboardKeyDot = 52,
+    KeyboardKeySlash = 53,
+    KeyboardKeyRightShift = 54,
+    KeyboardKeyKpAsterisk = 55,
+    KeyboardKeyLeftAlt = 56,
+    KeyboardKeySpace = 57,
+    KeyboardKeyCapsLock = 58,
+    KeyboardKeyF1 = 59,
+    KeyboardKeyF2 = 60,
+    KeyboardKeyF3 = 61,
+    KeyboardKeyF4 = 62,
+    KeyboardKeyF5 = 63,
+    KeyboardKeyF6 = 64,
+    KeyboardKeyF7 = 65,
+    KeyboardKeyF8 = 66,
+    KeyboardKeyF9 = 67,
+    KeyboardKeyF10 = 68,
+    KeyboardKeyNumLock = 69,
+    KeyboardKeyScrollLock = 70,
+    KeyboardKeyKP7 = 71,
+    KeyboardKeyKP8 = 72,
+    KeyboardKeyKP9 = 73,
+    KeyboardKeyKPMinus = 74,
+    KeyboardKeyKP4 = 75,
+    KeyboardKeyKP5 = 76,
+    KeyboardKeyKP6 = 77,
+    KeyboardKeyKPPlus = 78,
+    KeyboardKeyKP1 = 79,
+    KeyboardKeyKP2 = 80,
+    KeyboardKeyKP3 = 81,
+    KeyboardKeyKP0 = 82,
+    KeyboardKeyKPDot = 83,
+
+    KeyboardKeyZenkakuhankaku = 85,
+    KeyboardKey102nd = 86,
+    KeyboardKeyF11 = 87,
+    KeyboardKeyF12 = 88,
+    KeyboardKeyRo = 89,
+    KeyboardKeyKatakana = 90,
+    KeyboardKeyHiragana = 91,
+    KeyboardKeyHenkan = 92,
+    KeyboardKeyKatakanaHiragana = 93,
+    KeyboardKeyMuhenkan = 94,
+    KeyboardKeyKPJpComma = 95,
+    KeyboardKeyKPEnter = 96,
+    KeyboardKeyRightCtrl = 97,
+    KeyboardKeyKPSlash = 98,
+    KeyboardKeySysRq = 99,
+    KeyboardKeyRightAlt = 100,
+    KeyboardKeyLineFeed = 101,
+    KeyboardKeyHome = 102,
+    KeyboardKeyUp = 103,
+    KeyboardKeyPageUp = 104,
+    KeyboardKeyLeft = 105,
+    KeyboardKeyRight = 106,
+    KeyboardKeyEnd = 107,
+    KeyboardKeyDown = 108,
+    KeyboardKeyPageDown = 109,
+    KeyboardKeyInsert = 110,
+    KeyboardKeyDelete = 111,
+    KeyboardKeyMacro = 112,
+    KeyboardKeyMute = 113,
+    KeyboardKeyVolumeDown = 114,
+    KeyboardKeyVolumeUp = 115,
+    KeyboardKeyPower = 116,
+    KeyboardKeyKPEqual = 117,
+    KeyboardKeyKPPlusMinus = 118,
+    KeyboardKeyPause = 119,
+    KeyboardKeyScale = 120,
+
+    KeyboardKeyKPComma = 121,
+    KeyboardKeyHangeul = 122,
+    KeyboardKeyHanja = 123,
+    KeyboardKeyYen = 124,
+    KeyboardKeyLeftMeta = 125,
+    KeyboardKeyRightMeta = 126,
+    KeyboardKeyCompose = 127,
+
+    KeyboardKeyStop = 128,
+    KeyboardKeyAgain = 129,
+    KeyboardKeyProps = 130,
+    KeyboardKeyUndo = 131,
+    KeyboardKeyFront = 132,
+    KeyboardKeyCopy = 133,
+    KeyboardKeyOpen = 134,
+    KeyboardKeyPaste = 135,
+    KeyboardKeyFind = 136,
+    KeyboardKeyCut = 137,
+    KeyboardKeyHelp = 138,
+    KeyboardKeyMenu = 139,
+    KeyboardKeyCalc = 140,
+    KeyboardKeySetup = 141,
+    KeyboardKeySleep = 142,
+    KeyboardKeyWakeup = 143,
+    KeyboardKeyFile = 144,
+    KeyboardKeySendFile = 145,
+    KeyboardKeyDeleteFile = 146,
+    KeyboardKeyXfer = 147,
+    KeyboardKeyProg1 = 148,
+    KeyboardKeyProg2 = 149,
+    KeyboardKeyWww = 150,
+    KeyboardKeyMsdos = 151,
+    KeyboardKeyScreenLock = 152,
+    KeyboardKeyRotateDisplay = 153,
+    KeyboardKeyCycleWindows = 154,
+    KeyboardKeyMail = 155,
+    KeyboardKeyBookmarks = 156,
+    KeyboardKeyComputer = 157,
+    KeyboardKeyBack = 158,
+    KeyboardKeyForward = 159,
+    KeyboardKeyCloseCd = 160,
+    KeyboardKeyEjectCd = 161,
+    KeyboardKeyEjectCloseCd = 162,
+    KeyboardKeyNextSong = 163,
+    KeyboardKeyPlayPause = 164,
+    KeyboardKeyPreviousSong = 165,
+    KeyboardKeyStopCd = 166,
+    KeyboardKeyRecord = 167,
+    KeyboardKeyRewind = 168,
+    KeyboardKeyPhone = 169,
+    KeyboardKeyIso = 170,
+    KeyboardKeyConfig = 171,
+    KeyboardKeyHomepage = 172,
+    KeyboardKeyRefresh = 173,
+    KeyboardKeyExit = 174,
+    KeyboardKeyMove = 175,
+    KeyboardKeyEdit = 176,
+    KeyboardKeyScrollUp = 177,
+    KeyboardKeyScrollDown = 178,
+    KeyboardKeyKPLeftParen = 179,
+    KeyboardKeyKPRightParen = 180,
+    KeyboardKeyNew = 181,
+    KeyboardKeyRedo = 182,
+
+    KeyboardKeyF13 = 183,
+    KeyboardKeyF14 = 184,
+    KeyboardKeyF15 = 185,
+    KeyboardKeyF16 = 186,
+    KeyboardKeyF17 = 187,
+    KeyboardKeyF18 = 188,
+    KeyboardKeyF19 = 189,
+    KeyboardKeyF20 = 190,
+    KeyboardKeyF21 = 191,
+    KeyboardKeyF22 = 192,
+    KeyboardKeyF23 = 193,
+    KeyboardKeyF24 = 194,
+
+    KeyboardKeyPlayCd = 200,
+    KeyboardKeyPauseCd = 201,
+    KeyboardKeyProg3 = 202,
+    KeyboardKeyProg4 = 203,
+    KeyboardKeyDashboard = 204,
+    KeyboardKeySuspend = 205,
+    KeyboardKeyClose = 206,
+    KeyboardKeyPlay = 207,
+    KeyboardKeyFastForward = 208,
+    KeyboardKeyBassBoost = 209,
+    KeyboardKeyPrint = 210,
+    KeyboardKeyHp = 211,
+    KeyboardKeyCamera = 212,
+    KeyboardKeySound = 213,
+    KeyboardKeyQuestion = 214,
+    KeyboardKeyEmail = 215,
+    KeyboardKeyChat = 216,
+    KeyboardKeySearch = 217,
+    KeyboardKeyConnect = 218,
+    KeyboardKeyFinance = 219,
+    KeyboardKeySport = 220,
+    KeyboardKeyShop = 221,
+    KeyboardKeyAltErase = 222,
+    KeyboardKeyCancel = 223,
+    KeyboardKeyBrightnessDown = 224,
+    KeyboardKeyBrightnessUp = 225,
+    KeyboardKeyMedia = 226,
+
+    KeyboardKeySwitchVideoMode = 227,
+    KeyboardKeyKBDillumToggle = 228,
+    KeyboardKeyKBDillumDown = 229,
+    KeyboardKeyKBDillumUp = 230,
+
+    KeyboardKeySend = 231,
+    KeyboardKeyReply = 232,
+    KeyboardKeyForwardMail = 233,
+    KeyboardKeySave = 234,
+    KeyboardKeyDocuments = 235,
+
+    KeyboardKeyBattery = 236,
+
+    KeyboardKeyBluetooth = 237,
+    KeyboardKeyWlan = 238,
+    KeyboardKeyUwb = 239,
+
+    KeyboardKeyUnknown = 240,
+
+    KeyboardKeyVideoNext = 241,
+    KeyboardKeyVideoPrev = 242,
+    KeyboardKeyBrightnessCycle = 243,
+    KeyboardKeyBrightnessAuto = 244,
+    KeyboardKeyDisplayOff = 245,
+
+    KeyboardKeyWwan = 246,
+    KeyboardKeyRfKill = 247,
+
+    KeyboardKeyMicMute = 248,
+    KeyboardKeyOk = 0x160,
+    KeyboardKeySelect = 0x161,
+    KeyboardKeyGoto = 0x162,
+    KeyboardKeyClear = 0x163,
+    KeyboardKeyPower2 = 0x164,
+    KeyboardKeyOption = 0x165,
+    KeyboardKeyInfo = 0x166,
+    KeyboardKeyTime = 0x167,
+    KeyboardKeyVendor = 0x168,
+    KeyboardKeyArchive = 0x169,
+    KeyboardKeyProgram = 0x16A,
+    KeyboardKeyChannel = 0x16B,
+    KeyboardKeyFavorites = 0x16C,
+    KeyboardKeyEpg = 0x16D,
+    KeyboardKeyPvr = 0x16E,
+    KeyboardKeyMhp = 0x16F,
+    KeyboardKeyLanguage = 0x170,
+    KeyboardKeyTitle = 0x171,
+    KeyboardKeySubtitle = 0x172,
+    KeyboardKeyAngle = 0x173,
+    KeyboardKeyFullScreen = 0x174,
+    KeyboardKeyMode = 0x175,
+    KeyboardKeyKeyboard = 0x176,
+    KeyboardKeyAspectRatio = 0x177,
+    KeyboardKeyPc = 0x178,
+    KeyboardKeyTv = 0x179,
+    KeyboardKeyTv2 = 0x17A,
+    KeyboardKeyVcr = 0x17B,
+    KeyboardKeyVcr2 = 0x17C,
+    KeyboardKeySat = 0x17D,
+    KeyboardKeySat2 = 0x17E,
+    KeyboardKeyCd = 0x17F,
+    KeyboardKeyTape = 0x180,
+    KeyboardKeyRadio = 0x181,
+    KeyboardKeyTuner = 0x182,
+    KeyboardKeyPlayer = 0x183,
+    KeyboardKeyText = 0x184,
+    KeyboardKeyDvd = 0x185,
+    KeyboardKeyAux = 0x186,
+    KeyboardKeyMp3 = 0x187,
+    KeyboardKeyAudio = 0x188,
+    KeyboardKeyVideo = 0x189,
+    KeyboardKeyDirectory = 0x18A,
+    KeyboardKeyList = 0x18B,
+    KeyboardKeyMemo = 0x18C,
+    KeyboardKeyCalendar = 0x18D,
+    KeyboardKeyRed = 0x18E,
+    KeyboardKeyGreen = 0x18F,
+    KeyboardKeyYellow = 0x190,
+    KeyboardKeyBlue = 0x191,
+    KeyboardKeyChannelUp = 0x192,
+    KeyboardKeyChannelDown = 0x193,
+    KeyboardKeyFirst = 0x194,
+    KeyboardKeyLast = 0x195,
+    KeyboardKeyAb = 0x196,
+    KeyboardKeyNext = 0x197,
+    KeyboardKeyRestart = 0x198,
+    KeyboardKeySlow = 0x199,
+    KeyboardKeyShuffle = 0x19A,
+    KeyboardKeyBreak = 0x19B,
+    KeyboardKeyPrevious = 0x19C,
+    KeyboardKeyDigits = 0x19D,
+    KeyboardKeyTeen = 0x19E,
+    KeyboardKeyTwen = 0x19F,
+    KeyboardKeyVideoPhone = 0x1A0,
+    KeyboardKeyGames = 0x1A1,
+    KeyboardKeyZoomIn = 0x1A2,
+    KeyboardKeyZoomOut = 0x1A3,
+    KeyboardKeyZoomReset = 0x1A4,
+    KeyboardKeyWordProcessor = 0x1A5,
+    KeyboardKeyEditor = 0x1A6,
+    KeyboardKeySpreadsheet = 0x1A7,
+    KeyboardKeyGraphicsEditor = 0x1A8,
+    KeyboardKeyPresentation = 0x1A9,
+    KeyboardKeyDatabase = 0x1AA,
+    KeyboardKeyNews = 0x1AB,
+    KeyboardKeyVoicemail = 0x1AC,
+    KeyboardKeyAddressbook = 0x1AD,
+    KeyboardKeyMessenger = 0x1AE,
+    KeyboardKeyDisplayToggle = 0x1AF,
+    KeyboardKeySpellcheck = 0x1B0,
+    KeyboardKeyLogoff = 0x1B1,
+
+    KeyboardKeyDollar = 0x1B2,
+    KeyboardKeyEuro = 0x1B3,
+
+    KeyboardKeyFrameBack = 0x1B4,
+    KeyboardKeyFrameForward = 0x1B5,
+    KeyboardKeyContextMenu = 0x1B6,
+    KeyboardKeyMediaRepeat = 0x1B7,
+    KeyboardKey10ChannelsUp = 0x1B8,
+    KeyboardKey10ChannelsDown = 0x1B9,
+    KeyboardKeyImages = 0x1BA,
+    KeyboardKeyNotificationCenter = 0x1BC,
+    KeyboardKeyPickupPhone = 0x1BD,
+    KeyboardKeyHangupPhone = 0x1BE,
+
+    KeyboardKeyDelEol = 0x1C0,
+    KeyboardKeyDelEos = 0x1c1,
+    KeyboardKeyInsLine = 0x1c2,
+    KeyboardKeyDelLine = 0x1c3,
+
+    KeyboardKeyFn = 0x1d0,
+    KeyboardKeyFnEsc = 0x1d1,
+    KeyboardKeyFnF1 = 0x1d2,
+    KeyboardKeyFnF2 = 0x1d3,
+    KeyboardKeyFnF3 = 0x1d4,
+    KeyboardKeyFnF4 = 0x1d5,
+    KeyboardKeyFnF5 = 0x1d6,
+    KeyboardKeyFnF6 = 0x1d7,
+    KeyboardKeyFnF7 = 0x1d8,
+    KeyboardKeyFnF8 = 0x1d9,
+    KeyboardKeyFnF9 = 0x1da,
+    KeyboardKeyFnF10 = 0x1db,
+    KeyboardKeyFnF11 = 0x1dc,
+    KeyboardKeyFnF12 = 0x1dd,
+    KeyboardKeyFn1 = 0x1de,
+    KeyboardKeyFn2 = 0x1df,
+    KeyboardKeyFnD = 0x1e0,
+    KeyboardKeyFnE = 0x1e1,
+    KeyboardKeyFnF = 0x1e2,
+    KeyboardKeyFnS = 0x1e3,
+    KeyboardKeyFnB = 0x1e4,
+    KeyboardKeyFnRightShift = 0x1e5,
+
+    KeyboardKeyBrlDot1 = 0x1f1,
+    KeyboardKeyBrlDot2 = 0x1f2,
+    KeyboardKeyBrlDot3 = 0x1f3,
+    KeyboardKeyBrlDot4 = 0x1f4,
+    KeyboardKeyBrlDot5 = 0x1f5,
+    KeyboardKeyBrlDot6 = 0x1f6,
+    KeyboardKeyBrlDot7 = 0x1f7,
+    KeyboardKeyBrlDot8 = 0x1f8,
+    KeyboardKeyBrlDot9 = 0x1f9,
+    KeyboardKeyBrlDot10 = 0x1fa,
+
+    KeyboardKeyNumeric0 = 0x200,
+    KeyboardKeyNumeric1 = 0x201,
+    KeyboardKeyNumeric2 = 0x202,
+    KeyboardKeyNumeric3 = 0x203,
+    KeyboardKeyNumeric4 = 0x204,
+    KeyboardKeyNumeric5 = 0x205,
+    KeyboardKeyNumeric6 = 0x206,
+    KeyboardKeyNumeric7 = 0x207,
+    KeyboardKeyNumeric8 = 0x208,
+    KeyboardKeyNumeric9 = 0x209,
+    KeyboardKeyNumericStar = 0x20a,
+    KeyboardKeyNumericPound = 0x20b,
+    KeyboardKeyNumericA = 0x20c,
+    KeyboardKeyNumericB = 0x20d,
+    KeyboardKeyNumericC = 0x20e,
+    KeyboardKeyNumericD = 0x20f,
+
+    KeyboardKeyCameraFocus = 0x210,
+    KeyboardKeyWpsButton = 0x211,
+
+    KeyboardKeyTouchpadToggle = 0x212,
+    KeyboardKeyTouchpadOn = 0x213,
+    KeyboardKeyTouchpadOff = 0x214,
+
+    KeyboardKeyCameraZoomIn = 0x215,
+    KeyboardKeyCameraZoomOut = 0x216,
+    KeyboardKeyCameraUp = 0x217,
+    KeyboardKeyCameraDown = 0x218,
+    KeyboardKeyCameraLeft = 0x219,
+    KeyboardKeyCameraRight = 0x21a,
+
+    KeyboardKeyAttendantOn = 0x21b,
+    KeyboardKeyAttendantOff = 0x21c,
+    KeyboardKeyAttendantToggle = 0x21d,
+    KeyboardKeyLightsToggle = 0x21e,
+
+    KeyboardKeyAlsToggle = 0x230,
+    KeyboardKeyRotateLockToggle = 0x231,
+    KeyboardKeyRefreshRateToggle = 0x232,
+
+    KeyboardKeyButtonConfig = 0x240,
+    KeyboardKeyTaskManager = 0x241,
+    KeyboardKeyJournal = 0x242,
+    KeyboardKeyControlPanel = 0x243,
+    KeyboardKeyAppSelect = 0x244,
+    KeyboardKeyScreensaver = 0x245,
+    KeyboardKeyVoiceCommand = 0x246,
+    KeyboardKeyAssistant = 0x247,
+    KeyboardKeyKbdLayoutNext = 0x248,
+    KeyboardKeyEmojiPicker = 0x249,
+    KeyboardKeyDictate = 0x24a,
+    KeyboardKeyCameraAccessEnable = 0x24b,
+    KeyboardKeyCameraAccessDisable = 0x24c,
+    KeyboardKeyCameraAccessToggle = 0x24d,
+    KeyboardKeyAccessibility = 0x24e,
+    KeyboardKeyDoNotDisturb = 0x24f,
+
+    KeyboardKeyBrightnessMin = 0x250,
+    KeyboardKeyBrightnessMax = 0x251,
+
+    KeyboardKeyKbdInputAssistPrev = 0x260,
+    KeyboardKeyKbdInputAssistNext = 0x261,
+    KeyboardKeyKbdInputAssistPrevGroup = 0x262,
+    KeyboardKeyKbdInputAssistNextGroup = 0x263,
+    KeyboardKeyKbdInputAssistAccept = 0x264,
+    KeyboardKeyKbdInputAssistCancel = 0x265,
+
+    /* Diagonal movement keys */
+    KeyboardKeyRightUp = 0x266,
+    KeyboardKeyRightDown = 0x267,
+    KeyboardKeyLeftUp = 0x268,
+    KeyboardKeyLeftDown = 0x269,
+
+    KeyboardKeyRootMenu = 0x26a,
+    KeyboardKeyMediaTopMenu = 0x26b,
+    KeyboardKeyNumeric11 = 0x26c,
+    KeyboardKeyNumeric12 = 0x26d,
+    /*
+     * Toggle Audio Description: refers to an audio service that helps blind and
+     * visually impaired consumers understand the action in a program. Note: in
+     * some countries this is referred to as "Video Description".
+     */
+    KeyboardKeyAudioDesc = 0x26e,
+    KeyboardKey3dMode = 0x26f,
+    KeyboardKeyNextFavorite = 0x270,
+    KeyboardKeyStopRecord = 0x271,
+    KeyboardKeyPauseRecord = 0x272,
+    KeyboardKeyVod = 0x273,
+    KeyboardKeyUnmute = 0x274,
+    KeyboardKeyFastReverse = 0x275,
+    KeyboardKeySlowReverse = 0x276,
+    /*
+     * Control a data application associated with the currently viewed channel,
+     * e.g. teletext or data broadcast application (MHEG, MHP, HbbTV, etc.)
+     */
+    KeyboardKeyData = 0x277,
+    KeyboardKeyOnscreenKeyboard = 0x278,
+    /* Electronic privacy screen control */
+    KeyboardKeyPrivacyScreenToggle = 0x279,
+
+    /* Select an area of screen to be copied */
+    KeyboardKeySelectiveScreenshot = 0x27a,
+
+    /* Move the focus to the next or previous user controllable element within a UI container */
+    KeyboardKeyNextElement = 0x27b,
+    KeyboardKeyPreviousElement = 0x27c,
+
+    /* Toggle Autopilot engagement */
+    KeyboardKeyAutopilotEngageToggle = 0x27D,
+
+    /* Shortcut Keys */
+    KeyboardKeyMarkWaypoint = 0x27E,
+    KeyboardKeySos = 0x27F,
+    KeyboardKeyNavChart = 0x280,
+    KeyboardKeyFishingChart = 0x281,
+    KeyboardKeySingleRangeRadar = 0x282,
+    KeyboardKeyDualRangeRadar = 0x283,
+    KeyboardKeyRadarOverlay = 0x284,
+    KeyboardKeyTraditionalSonar = 0x285,
+    KeyboardKeyClearvuSonar = 0x286,
+    KeyboardKeySidevuSonar = 0x287,
+    KeyboardKeyNavInfo = 0x288,
+    KeyboardKeyBrightnessMenu = 0x289,
+
+    /*
+     * Some keyboards have keys which do not have a defined meaning, these keys
+     * are intended to be programmed / bound to macros by the user. For most
+     * keyboards with these macro-keys the key-sequence to inject, or action to
+     * take, is all handled by software on the host side. So from the kernel's
+     * point of view these are just normal keys.
+     *
+     * The KEY_MACRO# codes below are intended for such keys, which may be labeled
+     * e.g. G1-G18, or S1 - S30. The KEY_MACRO# codes MUST NOT be used for keys
+     * where the marking on the key does indicate a defined meaning / purpose.
+     *
+     * The KEY_MACRO# codes MUST also NOT be used as fallback for when no existing
+     * KEY_FOO define matches the marking / purpose. In this case a new KEY_FOO
+     * define MUST be added.
+     */
+    KeyboardKeyMacro1 = 0x290,
+    KeyboardKeyMacro2 = 0x291,
+    KeyboardKeyMacro3 = 0x292,
+    KeyboardKeyMacro4 = 0x293,
+    KeyboardKeyMacro5 = 0x294,
+    KeyboardKeyMacro6 = 0x295,
+    KeyboardKeyMacro7 = 0x296,
+    KeyboardKeyMacro8 = 0x297,
+    KeyboardKeyMacro9 = 0x298,
+    KeyboardKeyMacro10 = 0x299,
+    KeyboardKeyMacro11 = 0x29a,
+    KeyboardKeyMacro12 = 0x29b,
+    KeyboardKeyMacro13 = 0x29c,
+    KeyboardKeyMacro14 = 0x29d,
+    KeyboardKeyMacro15 = 0x29e,
+    KeyboardKeyMacro16 = 0x29f,
+    KeyboardKeyMacro17 = 0x2a0,
+    KeyboardKeyMacro18 = 0x2a1,
+    KeyboardKeyMacro19 = 0x2a2,
+    KeyboardKeyMacro20 = 0x2a3,
+    KeyboardKeyMacro21 = 0x2a4,
+    KeyboardKeyMacro22 = 0x2a5,
+    KeyboardKeyMacro23 = 0x2a6,
+    KeyboardKeyMacro24 = 0x2a7,
+    KeyboardKeyMacro25 = 0x2a8,
+    KeyboardKeyMacro26 = 0x2a9,
+    KeyboardKeyMacro27 = 0x2aa,
+    KeyboardKeyMacro28 = 0x2ab,
+    KeyboardKeyMacro29 = 0x2ac,
+    KeyboardKeyMacro30 = 0x2ad,
+
+    /*
+     * Some keyboards with the macro-keys described above have some extra keys
+     * for controlling the host-side software responsible for the macro handling:
+     * -A macro recording start/stop key. Note that not all keyboards which emit
+     *  KEY_MACRO_RECORD_START will also emit KEY_MACRO_RECORD_STOP if
+     *  KEY_MACRO_RECORD_STOP is not advertised, then KEY_MACRO_RECORD_START
+     *  should be interpreted as a recording start/stop toggle;
+     * -Keys for switching between different macro (pre)sets, either a key for
+     *  cycling through the configured presets or keys to directly select a preset.
+     */
+    KeyboardKeyMacroRecordStart = 0x2b0,
+    KeyboardKeyMacroRecordStop = 0x2b1,
+    KeyboardKeyMacroPresetCycle = 0x2b2,
+    KeyboardKeyMacroPreset1 = 0x2b3,
+    KeyboardKeyMacroPreset2 = 0x2b4,
+    KeyboardKeyMacroPreset3 = 0x2b5,
+
+    /*
+     * Some keyboards have a buildin LCD panel where the contents are controlled
+     * by the host. Often these have a number of keys directly below the LCD
+     * intended for controlling a menu shown on the LCD. These keys often don't
+     * have any labeling so we just name them KEY_KBD_LCD_MENU#
+     */
+    KeyboardKeyKbdLcdMenu1 = 0x2b8,
+    KeyboardKeyKbdLcdMenu2 = 0x2b9,
+    KeyboardKeyKbdLcdMenu3 = 0x2ba,
+    KeyboardKeyKbdLcdMenu4 = 0x2bb,
+    KeyboardKeyKbdLcdMenu5 = 0x2bc,
+
+    MouseButtonLeft = 0x110,
+    MouseButtonRight = 0x111,
+    MouseButtonMiddle = 0x112,
+    MouseButtonSide = 0x113,
+    MouseButtonExtra = 0x114,
+
+    /// Base button, usually on the bottom right, Steam Quick Access Button (...)
+    GamepadButtonQuick = 0x126,
+    GamepadButtonQuick2 = 0x127,
+
+    /// South action, Sony Cross x, Xbox A, Nintendo B
+    GamepadButtonSouth = 0x130,
+    /// East action, Sony Circle ◯, Xbox B, Nintendo A
+    GamepadButtonEast = 0x131,
+    /// North action, Sony Square □, Xbox X, Nintendo Y
+    GamepadButtonNorth = 0x133,
+    /// West action, Sony Triangle ∆, XBox Y, Nintendo X
+    GamepadButtonWest = 0x134,
+    /// Select, Sony Select, Xbox Back, Nintendo -, Steam Deck ⧉
+    GamepadButtonSelect = 0x13a,
+    /// Start, Xbox Menu, Nintendo +, Steam Deck Hamburger Menu (☰)
+    GamepadButtonStart = 0x13b,
+    /// Guide button, Sony PS, Xbox Home, Steam Button
+    GamepadButtonGuide = 0x13c,
+    /// Directional pad up
+    GamepadButtonDpadUp = 0x220,
+    /// Directional pad down
+    GamepadButtonDpadDown = 0x221,
+    /// Directional pad left
+    GamepadButtonDpadLeft = 0x222,
+    /// Directional pad right
+    GamepadButtonDpadRight = 0x223,
+
+    /// Left shoulder button, Xbox LB, Sony L1
+    GamepadButtonLeftBumper = 0x136,
+    /// Right shoulder button, Xbox RB, Sony R1
+    GamepadButtonRightBumper = 0x137,
+    GamepadButtonLeftTrigger = 0x138,
+    GamepadButtonRightTrigger = 0x139,
+
+    /// Z-axis button on the left stick, Sony L3, Xbox LS
+    GamepadButtonLeftStick = 0x13d,
+    /// Z-axis button on the right stick, Sony R3, Xbox RS
+    GamepadButtonRightStick = 0x13e,
+
+    /* Non-standard gamepad codes */
+    /// Left back paddle button, Xbox P3, Steam Deck L4
+    GamepadButtonLeftPaddle1 = 0x307,
+    /// Left back paddle button, Xbox P4, Steam Deck L5
+    GamepadButtonLeftPaddle2 = 0x308,
+    GamepadButtonLeftPaddle3 = 0x309,
+    /// Right back paddle button, Xbox P1, Steam Deck R4
+    GamepadButtonRightPaddle1 = 0x30a,
+    /// Right back paddle button, Xbox P2, Steam Deck R5
+    GamepadButtonRightPaddle2 = 0x30b,
+    /// Right "side" paddle button, Legion Go M2
+    GamepadButtonRightPaddle3 = 0x30c,
+
+    /// Touch binary sensor for left stick
+    GamepadButtonLeftStickTouch = 0x30d,
+    /// Touch binary sensor for right stick
+    GamepadButtonRightStickTouch = 0x30e,
+
+    /// Dedicated button to open an on-screen keyboard
+    GamepadButtonKeyboard = 0x304,
+    /// Dedicated button to take screenshots
+    GamepadButtonScreenshot = 0x305,
+    /// Dedicated mute button, Sony DualSense Mute
+    GamepadButtonMute = 0x306,
+
+    /// Left analog stick
+    GamepadAxisLeftStick = 0x400,
+    /// Right analog stick
+    GamepadAxisRightStick = 0x401,
+
+    /// Left trigger, Xbox Left Trigger, Sony L2, Nintendo ZL
+    GamepadTriggerLeft = 0x500,
+    /// Right trigger, Xbox Right Trigger, Sony R2, Nintendo ZR
+    GamepadTriggerRight = 0x501,
+    /// Left touchpad force sensor, Steam Deck left touchpad force
+    GamepadTriggerLeftTouchpadForce = 0x502,
+    /// Left analog stick force sensor, Steam Deck left stick force
+    GamepadTriggerLeftStickForce = 0x503,
+    /// Right touchpad force sensor, Steam Deck right touchpad force
+    GamepadTriggerRightTouchpadForce = 0x504,
+    /// Right analog stick force sensor, Steam Deck right stick force
+    GamepadTriggerRightStickForce = 0x505,
+
+    /// Center or main gyro sensor
+    GamepadGyroCenter = 0x600,
+    /// Left side gamepad gyro
+    GamepadGyroLeft = 0x601,
+    /// Right side gamepad gyro
+    GamepadGyroRight = 0x602,
+    GamepadAccelerometerCenter = 0x603,
+    GamepadAccelerometerLeft = 0x604,
+    GamepadAccelerometerRight = 0x605,
+
+    /// Left touchpad touch motion
+    TouchpadLeftMotion = 0x700,
+    /// Center touchpad touch motion, DualSense Touchpad motion
+    TouchpadCenterMotion = 0x701,
+    /// Right touchpad touch motion
+    TouchpadRightMotion = 0x702,
+    /// Left touchpad button press
+    TouchpadLeftButton = 0x703,
+    /// Center touchpad button press, DualSense Touchpad button press
+    TouchpadCenterButton = 0x704,
+    /// Right touchpad button press
+    TouchpadRightButton = 0x705,
+}

--- a/src/drivers/unified_gamepad/driver.rs
+++ b/src/drivers/unified_gamepad/driver.rs
@@ -1,0 +1,154 @@
+use packed_struct::prelude::*;
+use std::{error::Error, ffi::CString};
+
+use hidapi::HidDevice;
+
+use crate::drivers::unified_gamepad::reports::{
+    input_capability_report::INPUT_CAPABILITY_REPORT_SIZE, ReportType,
+};
+
+use super::{
+    event::Event,
+    reports::{
+        input_capability_report::InputCapabilityReport,
+        input_data_report::{InputDataReport, INPUT_DATA_REPORT_SIZE},
+        UNIFIED_SPEC_VERSION_MAJOR, UNIFIED_SPEC_VERSION_MINOR,
+    },
+};
+
+// TODO: Find an appropriate VID/PID to use. For the time being, this
+// is using the OpenInput VID/PID. We may be able to ask for a VID/PID
+// from OpenMoko: https://github.com/openmoko/openmoko-usb-oui/tree/master
+pub const UNIFIED_CONTROLLER_VID: u16 = 0x1d50;
+pub const UNIFIED_CONTROLLER_PID: u16 = 0x616a;
+
+/// Unified Controller driver for reading gamepad input
+pub struct Driver {
+    device: HidDevice,
+    capabilities: Option<InputCapabilityReport>,
+    state: Option<InputDataReport>,
+}
+
+impl Driver {
+    #[allow(dead_code)]
+    pub fn new(path: String) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let c_path = CString::new(path.clone())?;
+        let api = hidapi::HidApi::new()?;
+        let device = api.open_path(&c_path)?;
+        let info = device.get_device_info()?;
+        let vid = info.vendor_id();
+        let pid = info.product_id();
+        if vid != UNIFIED_CONTROLLER_VID || pid != UNIFIED_CONTROLLER_PID {
+            return Err(format!("Device '{path}' is not a Unified Controller: {vid}:{pid}").into());
+        }
+
+        Ok(Self {
+            device,
+            capabilities: None,
+            state: None,
+        })
+    }
+
+    /// Poll the device and read input reports
+    #[allow(dead_code)]
+    pub fn poll(&mut self) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
+        // Check the device for its capabilities
+        if self.capabilities.is_none() {
+            let mut buf = [0; INPUT_CAPABILITY_REPORT_SIZE];
+            buf[0] = ReportType::InputCapabilityReport as u8;
+            let _bytes_read = self.device.get_feature_report(&mut buf)?;
+            let report = InputCapabilityReport::unpack(&buf)?;
+            self.capabilities = Some(report);
+        }
+
+        // Read data from the device into a buffer
+        let mut buf = [0; INPUT_DATA_REPORT_SIZE];
+        let bytes_read = self.device.read(&mut buf[..])?;
+        let slice = &buf[..bytes_read];
+
+        // Handle the incoming input report
+        let events = self.handle_report(slice, bytes_read)?;
+
+        Ok(events)
+    }
+
+    #[allow(dead_code)]
+    fn handle_report(
+        &mut self,
+        buf: &[u8],
+        _bytes_read: usize,
+    ) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
+        // The first and second bytes contain the specification version
+        let major_ver = buf[0];
+        let minor_ver = buf[1];
+
+        // The major version indicates there are breaking changes.
+        if major_ver != UNIFIED_SPEC_VERSION_MAJOR {
+            return Err(format!("Device major version (v{major_ver}) is not compatible with this implementation (v{UNIFIED_SPEC_VERSION_MAJOR})").into());
+        }
+        // Minor versions are backwards compatible
+        if minor_ver > UNIFIED_SPEC_VERSION_MINOR {
+            return Err(format!("Device minor version (v{minor_ver}) is newer than this implementation supports (v{UNIFIED_SPEC_VERSION_MINOR})").into());
+        }
+
+        let report_type = ReportType::from(buf[2]);
+        match report_type {
+            ReportType::Unknown => (),
+            ReportType::InputCapabilityReport => {
+                let report = InputCapabilityReport::unpack(buf)?;
+                self.capabilities = Some(report);
+                // If the capabilities change, zero out the old state
+                self.state = None;
+            }
+            ReportType::InputDataReport => {
+                return self.handle_input_report(buf);
+            }
+            ReportType::OutputCapabilityReport => (),
+            ReportType::OutputDataReport => (),
+        }
+
+        Ok(vec![])
+    }
+
+    fn handle_input_report(
+        &mut self,
+        buf: &[u8],
+    ) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
+        let buffer = buf.try_into()?;
+        let report = InputDataReport::unpack(buffer)?;
+        let old_state = self.state.take();
+        self.state = Some(report);
+
+        let Some(old_state) = old_state.as_ref() else {
+            return Ok(vec![]);
+        };
+        let Some(state) = self.state.as_ref() else {
+            return Ok(vec![]);
+        };
+        if state.state_version == old_state.state_version {
+            return Ok(vec![]);
+        }
+        let Some(capabilities) = self.capabilities.as_ref() else {
+            return Ok(vec![]);
+        };
+
+        let old_values = capabilities.decode_data_report(old_state)?;
+        let values = capabilities.decode_data_report(state)?;
+        let values_iter = old_values.iter().zip(values.iter());
+
+        let mut events = Vec::new();
+        for (info, (old_value, value)) in capabilities.get_capabilities().iter().zip(values_iter) {
+            if old_value == value {
+                continue;
+            }
+            let capability = info.capability;
+            let event = Event {
+                capability,
+                value: value.to_owned(),
+            };
+            events.push(event);
+        }
+
+        Ok(events)
+    }
+}

--- a/src/drivers/unified_gamepad/event.rs
+++ b/src/drivers/unified_gamepad/event.rs
@@ -1,0 +1,10 @@
+use super::{capability::InputCapability, value::Value};
+
+/// Events that can be emitted by the Unified Controller
+#[derive(Clone, Debug, Default)]
+pub struct Event {
+    #[allow(dead_code)]
+    pub capability: InputCapability,
+    #[allow(dead_code)]
+    pub value: Value,
+}

--- a/src/drivers/unified_gamepad/mod.rs
+++ b/src/drivers/unified_gamepad/mod.rs
@@ -1,0 +1,5 @@
+pub mod capability;
+pub mod driver;
+pub mod event;
+pub mod reports;
+pub mod value;

--- a/src/drivers/unified_gamepad/reports.rs
+++ b/src/drivers/unified_gamepad/reports.rs
@@ -1,0 +1,154 @@
+use packed_struct::{prelude::*, PackedStructInfo};
+
+use super::value::{
+    BoolValue, Int16Vector3Value, TouchValue, UInt16Value, UInt16Vector2Value, UInt8Value,
+};
+
+pub mod input_capability_report;
+#[cfg(test)]
+pub mod input_capability_report_test;
+pub mod input_data_report;
+#[cfg(test)]
+pub mod input_data_report_test;
+
+/// Major version of the Unified Controller Input Specification that this
+/// implementation supports.
+pub const UNIFIED_SPEC_VERSION_MAJOR: u8 = 1;
+/// Minor version of the Unified Controller Input Specification that this
+/// implementation supports.
+pub const UNIFIED_SPEC_VERSION_MINOR: u8 = 0;
+
+/// Report descriptor to advertise
+pub const REPORT_DESCRIPTOR: [u8; 24] = [
+    // report descriptor for general input/output
+    0x06, 0x00, 0xFF, // Usage Page (Vendor Defined 0xFF00)
+    0x09, 0x01, // Usage (0x01)
+    0xA1, 0x01, // Collection (Application)
+    0x09, 0x02, //   Usage (0x02)
+    0x15, 0x00, //   Logical Minimum (0)
+    0x25, 0xFF, //   Logical Maximum (255)
+    0x75, 0x08, //   Report Size (8)
+    0x95, 0x40, //   Report Count (64)
+    0x81, 0x02, //   Input (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position)
+    0x09, 0x03, //   Usage (0x03)
+    0x91,
+    0x02, //   Output (Data,Var,Abs,No Wrap,Linear,Preferred State,No Null Position,Non-volatile)
+    0xC0, // End Collection
+];
+
+/// ReportType contains an enumeration of all possible report types
+#[derive(PrimitiveEnum_u8, Clone, Copy, PartialEq, Debug)]
+pub enum ReportType {
+    Unknown = 0x00,
+    InputCapabilityReport = 0x01,
+    InputDataReport = 0x02,
+    OutputCapabilityReport = 0x03,
+    OutputDataReport = 0x04,
+}
+
+impl From<u8> for ReportType {
+    fn from(value: u8) -> Self {
+        match value {
+            0x01 => Self::InputCapabilityReport,
+            0x02 => Self::InputDataReport,
+            0x03 => Self::OutputCapabilityReport,
+            0x04 => Self::OutputDataReport,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Feature report types
+#[derive(PrimitiveEnum_u8, Clone, Copy, PartialEq, Debug)]
+pub enum FeatureReportType {
+    /// Instruct the driver to return a feature report with the available capabilities
+    GetInputCapabilities = 0x01,
+    GetOutputCapabilites = 0x02,
+    GetName = 0x03,
+    GetVendorId = 0x04,
+    GetProductId = 0x05,
+    GetGlobalProductId = 0x06,
+    GetSerial = 0x07,
+
+    // Examples
+    InputData = 0x09,
+    SetMappings = 0x80,
+    ClearMappings = 0x81,
+    GetMappings = 0x82,
+    GetAttrib = 0x83,
+    GetAttribLabel = 0x84,
+    DefaultMappings = 0x85,
+    FactoryReset = 0x86,
+    WriteRegister = 0x87,
+    ClearRegister = 0x88,
+    ReadRegister = 0x89,
+    GetRegisterLabel = 0x8a,
+    GetRegisterMax = 0x8b,
+    GetRegisterDefault = 0x8c,
+    SetMode = 0x8d,
+    DefaultMouse = 0x8e,
+    TriggerHapticPulse = 0x8f,
+    RequestCommStatus = 0xb4,
+    //GetSerial = 0xae,
+    TriggerHapticCommand = 0xea,
+    TriggerRumbleCommand = 0xeb,
+}
+
+// Describes how to decode a particular value
+#[derive(PrimitiveEnum_u8, Clone, Copy, PartialEq, Debug, Default, Ord, PartialOrd, Eq)]
+pub enum ValueType {
+    #[default]
+    None,
+    /// Bool values take up 1 bit in the input report
+    Bool,
+    /// Uint8 values take up 1 byte in the input report
+    UInt8,
+    /// Uint16 values take up 2 bytes in the input report
+    UInt16,
+    /// UInt16Vector2 vales take up 4 bytes in the input report
+    UInt16Vector2,
+    /// Int16Vector3 vales take up 6 bytes in the input report
+    Int16Vector3,
+    /// Touch values takes up 6 bytes in the input report
+    Touch,
+}
+
+impl ValueType {
+    /// Returns the size in bits the value type takes up in the input data report
+    pub fn size_bits(&self) -> usize {
+        match self {
+            ValueType::None => 0,
+            ValueType::Bool => BoolValue::packed_bits(),
+            ValueType::UInt8 => UInt8Value::packed_bits(),
+            ValueType::UInt16 => UInt16Value::packed_bits(),
+            ValueType::UInt16Vector2 => UInt16Vector2Value::packed_bits(),
+            ValueType::Int16Vector3 => Int16Vector3Value::packed_bits(),
+            ValueType::Touch => TouchValue::packed_bits(),
+        }
+    }
+
+    /// Returns the size in bytes the value type takes up in the input data report
+    /// rounded to the nearest byte
+    pub fn size_bytes(&self) -> usize {
+        let size_bits = self.size_bits();
+        if size_bits < 8 {
+            return 1;
+        }
+        size_bits / 8
+    }
+
+    /// Returns the sort priority of the value type to determine the order that these
+    /// value types will appear in the input data report. Lower numbers should
+    /// be ordered first.
+    pub fn order_priority(&self) -> u8 {
+        match self {
+            ValueType::None => 6,
+            ValueType::Bool => 5,
+            ValueType::UInt8 => 4,
+            ValueType::UInt16 => 3,
+            ValueType::UInt16Vector2 => 2,
+            ValueType::Int16Vector3 => 1,
+            ValueType::Touch => 0,
+        }
+    }
+}

--- a/src/drivers/unified_gamepad/reports/input_capability_report.rs
+++ b/src/drivers/unified_gamepad/reports/input_capability_report.rs
@@ -1,0 +1,338 @@
+use std::{array::TryFromSliceError, fmt::Display};
+
+use packed_struct::{prelude::*, PackedStructInfo};
+use thiserror::Error;
+
+use crate::drivers::unified_gamepad::{
+    capability::InputCapability,
+    value::{
+        BoolValue, Int16Vector3Value, TouchValue, UInt16Value, UInt16Vector2Value, UInt8Value,
+        Value,
+    },
+};
+
+use super::{
+    input_data_report::InputDataReport, ReportType, ValueType, UNIFIED_SPEC_VERSION_MAJOR,
+    UNIFIED_SPEC_VERSION_MINOR,
+};
+
+/// The maximum size of the [InputCapabilityReport]
+pub const INPUT_CAPABILITY_REPORT_SIZE: usize = 1274;
+/// Maximum number of capabilities supported by the [InputCapabilityReport]
+pub const INPUT_CAPABILITY_REPORT_MAX_CAPABILITIES: usize = u8::MAX as usize;
+
+/// The [InputCapabilityReportHeader] defines the header for the [InputCapabilityReport]
+/// that is used to describe the input capabilities of the device and how to decode
+/// the [InputDataReport].
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", size_bytes = "4")]
+pub struct InputCapabilityReportHeader {
+    /// Major version indicates whether or not compatibility-breaking changes
+    /// have occurred.
+    #[packed_field(bytes = "0")]
+    pub major_ver: u8,
+    /// The minor version indicates what capabilities are available
+    #[packed_field(bytes = "1")]
+    pub minor_ver: u8,
+    /// The report type
+    #[packed_field(bytes = "2", ty = "enum")]
+    pub report_type: ReportType,
+
+    /// The number of input capabilities the device supports
+    #[packed_field(bytes = "3")]
+    pub capabilities_count: u8,
+}
+
+impl Default for InputCapabilityReportHeader {
+    fn default() -> Self {
+        Self {
+            major_ver: UNIFIED_SPEC_VERSION_MAJOR,
+            minor_ver: UNIFIED_SPEC_VERSION_MINOR,
+            report_type: ReportType::InputCapabilityReport,
+            capabilities_count: Default::default(),
+        }
+    }
+}
+
+/// The [InputCapabilityReport] describes the input capabilities of the device
+/// and how to decode the [InputDataReport].
+#[derive(Debug, Clone, Default)]
+pub struct InputCapabilityReport {
+    header: InputCapabilityReportHeader,
+    capabilities: Vec<InputCapabilityInfo>,
+}
+
+impl Display for InputCapabilityReport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let header = format!("{}", self.header);
+        let caps: Vec<String> = self
+            .capabilities
+            .iter()
+            .map(|cap| format!("{cap}"))
+            .collect();
+        let body = caps.join("");
+
+        write!(f, "{header}{body}")
+    }
+}
+
+/// Result of adding a capability to an [InputCapabilityReport]
+type AddCapabilityResult = Result<(), AddCapabilityError>;
+
+/// Possible errors when adding a capability to an [InputCapabilityReport]
+#[derive(Error, Debug)]
+pub enum AddCapabilityError {
+    #[error(
+        "adding capability `{capability:?}` would exceed maximum number of capabilities `{size:?}`"
+    )]
+    MaxCapabilitiesExceeded {
+        capability: InputCapability,
+        size: usize,
+    },
+}
+
+impl InputCapabilityReport {
+    /// Add the given capability to the capability report
+    pub fn add_capability(&mut self, capability: InputCapabilityInfo) -> AddCapabilityResult {
+        // Don't add empty capabilities
+        if capability.value_type == ValueType::None {
+            return Ok(());
+        }
+        if capability.capability == InputCapability::None {
+            return Ok(());
+        }
+        if self.header.capabilities_count == INPUT_CAPABILITY_REPORT_MAX_CAPABILITIES as u8 {
+            return Err(AddCapabilityError::MaxCapabilitiesExceeded {
+                capability: capability.capability,
+                size: INPUT_CAPABILITY_REPORT_MAX_CAPABILITIES,
+            });
+        }
+
+        // Ensure that the capability doesn't already exist
+        let exists = self
+            .capabilities
+            .iter()
+            .any(|cap| cap.capability == capability.capability);
+        if exists {
+            return Ok(());
+        }
+
+        // Increment the capability count and add the capability
+        self.header.capabilities_count += 1;
+        self.capabilities.push(capability);
+
+        // Sort the capabilities based on their value type to pack values close
+        // to each other.
+        self.capabilities
+            .sort_by_key(|cap| cap.value_type.order_priority());
+        self.update_capability_offsets();
+
+        Ok(())
+    }
+
+    /// Removes the given capability from the capability report
+    pub fn remove_capability(&mut self, capability: InputCapability) {
+        self.capabilities = self
+            .capabilities
+            .drain(..)
+            .filter(|cap| cap.capability != capability)
+            .collect();
+        self.update_capability_offsets();
+    }
+
+    /// Get the capability information for the given capability
+    pub fn get_capability(&self, capability: InputCapability) -> Option<InputCapabilityInfo> {
+        self.capabilities
+            .iter()
+            .find(|info| info.capability == capability)
+            .map(|info| info.to_owned())
+    }
+
+    /// Return all capabilities in the [InputCapabilityReport]
+    pub fn get_capabilities(&self) -> &[InputCapabilityInfo] {
+        self.capabilities.as_slice()
+    }
+
+    /// Updates the `offset` bits of all capabilities
+    fn update_capability_offsets(&mut self) {
+        // Update the bit offset of all capabilities based on the value type
+        let mut offset = 0;
+        for cap in self.capabilities.iter_mut() {
+            if cap.value_type == ValueType::None {
+                continue;
+            }
+
+            // Non-bool values should be byte-aligned
+            let offset_remainder = offset % 8;
+            if cap.value_type != ValueType::Bool && offset_remainder != 0 {
+                offset += offset_remainder;
+            }
+
+            // Update the offset
+            cap.offset = offset;
+            let value_size = cap.value_type.size_bits() as u16;
+            offset += value_size;
+        }
+    }
+}
+
+/// Result of decoding an [InputDataReport]
+type InputDecodeResult = Result<Vec<Value>, InputDecodeError>;
+
+/// Possible errors when decoding an [InputDataReport] from an [InputCapabilityReport]
+#[derive(Error, Debug)]
+pub enum InputDecodeError {
+    #[error(
+        "failed to get an appropriately sized slice to decode value from input data report: {0}"
+    )]
+    BadOffset(#[from] TryFromSliceError),
+    #[error("failed to unpack bytes to the appropriate value: {0}")]
+    UnpackingFailure(#[from] PackingError),
+}
+
+impl InputCapabilityReport {
+    /// Decode the given [InputDataReport] according to the capability report
+    pub fn decode_data_report(&self, report: &InputDataReport) -> InputDecodeResult {
+        let mut values = Vec::with_capacity(self.capabilities.len());
+        for capability_info in self.capabilities.iter() {
+            // Get the value type and its size
+            let value_type = capability_info.value_type;
+            let value_size_bytes = value_type.size_bytes();
+
+            // Get the bit/byte offset
+            let offset_bits = capability_info.offset as usize;
+            let offset_remainder = offset_bits % 8;
+            let offset_bytes = (offset_bits - offset_remainder) / 8;
+
+            // Get the byte start and end
+            let byte_start = offset_bytes;
+            let byte_end = byte_start + value_size_bytes;
+
+            let value = match value_type {
+                ValueType::None => Value::None,
+                ValueType::Bool => {
+                    let byte = report.data[byte_start];
+                    // Check if the `offset_remainder` bit in the byte is set
+                    let value = byte & (1 << offset_remainder) > 0;
+                    Value::Bool(BoolValue { value })
+                }
+                ValueType::UInt8 => {
+                    let slice = &report.data[byte_start..byte_end];
+                    let buffer = slice.try_into()?;
+                    let value = UInt8Value::unpack(buffer)?;
+                    Value::UInt8(value)
+                }
+                ValueType::UInt16 => {
+                    let slice = &report.data[byte_start..byte_end];
+                    let buffer = slice.try_into()?;
+                    let value = UInt16Value::unpack(buffer)?;
+                    Value::UInt16(value)
+                }
+                ValueType::UInt16Vector2 => {
+                    let slice = &report.data[byte_start..byte_end];
+                    let buffer = slice.try_into()?;
+                    let value = UInt16Vector2Value::unpack(buffer)?;
+                    Value::UInt16Vector2(value)
+                }
+                ValueType::Int16Vector3 => {
+                    let slice = &report.data[byte_start..byte_end];
+                    let buffer = slice.try_into()?;
+                    let value = Int16Vector3Value::unpack(buffer)?;
+                    Value::Int16Vector3(value)
+                }
+                ValueType::Touch => {
+                    let slice = &report.data[byte_start..byte_end];
+                    let buffer = slice.try_into()?;
+                    let value = TouchValue::unpack(buffer)?;
+                    Value::Touch(value)
+                }
+            };
+            values.push(value);
+        }
+
+        Ok(values)
+    }
+}
+
+impl InputCapabilityReport {
+    /// Packs the structure into a byte array
+    pub fn pack_to_vec(&self) -> Result<Vec<u8>, PackingError> {
+        // Allocate the packed data based on the header and capabilities added
+        let header_size_bytes = InputCapabilityReportHeader::packed_bits() / 8;
+        let caps_size_bytes = self.capabilities.len() * (InputCapabilityInfo::packed_bits() / 8);
+        let capacity = header_size_bytes + caps_size_bytes;
+        let mut data = Vec::with_capacity(capacity);
+
+        // Pack the header bytes
+        let header = self.header.pack()?;
+        data.extend_from_slice(&header);
+
+        // Pack the body bytes
+        for capability in self.capabilities.iter() {
+            let packed = capability.pack()?;
+            data.extend_from_slice(&packed);
+        }
+
+        Ok(data)
+    }
+
+    /// Unpacks the structure from the byte array
+    pub fn unpack(src: &[u8]) -> Result<Self, PackingError> {
+        // Unpack the header
+        let header_size_bytes = InputCapabilityReportHeader::packed_bits() / 8;
+        let slice = &src[0..header_size_bytes];
+        let buffer = slice
+            .try_into()
+            .map_err(|_err| PackingError::BufferTooSmall)?;
+        let header = InputCapabilityReportHeader::unpack(buffer)?;
+
+        // Unpack the body based on the number of capabilities
+        let num_capabilities = header.capabilities_count as usize;
+        let capability_size_bytes = InputCapabilityInfo::packed_bits() / 8;
+        let mut capabilities = Vec::with_capacity(num_capabilities);
+        let mut byte_start = header_size_bytes;
+        for _ in 0..num_capabilities {
+            let byte_end = byte_start + capability_size_bytes;
+            let slice = &src[byte_start..byte_end];
+            let buffer = slice
+                .try_into()
+                .map_err(|_err| PackingError::BufferTooSmall)?;
+            let capability = InputCapabilityInfo::unpack(buffer)?;
+            capabilities.push(capability);
+            byte_start = byte_end;
+        }
+
+        Ok(Self {
+            header,
+            capabilities,
+        })
+    }
+}
+
+/// [InputCapabilityInfo] describes a single input capability that a device supports
+/// and how to decode the value in the input data report. A consuming driver can
+/// use the offset to look for the value at a specific bit offset and can use the
+/// value type to determine how to unpack the value.
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq, Default)]
+#[packed_struct(bit_numbering = "msb0", size_bytes = "5")]
+pub struct InputCapabilityInfo {
+    /// The capability
+    #[packed_field(bytes = "0..=1", endian = "lsb", ty = "enum")]
+    pub capability: InputCapability,
+    /// The type of value this capability emits
+    #[packed_field(bytes = "2", ty = "enum")]
+    pub value_type: ValueType,
+    /// The bit offset in the input report to read the value for this capability.
+    #[packed_field(bytes = "3..=4", endian = "lsb")]
+    pub offset: u16,
+}
+
+impl InputCapabilityInfo {
+    pub fn new(capability: InputCapability, value_type: ValueType) -> Self {
+        Self {
+            capability,
+            value_type,
+            offset: 0,
+        }
+    }
+}

--- a/src/drivers/unified_gamepad/reports/input_capability_report_test.rs
+++ b/src/drivers/unified_gamepad/reports/input_capability_report_test.rs
@@ -1,0 +1,47 @@
+use std::error::Error;
+
+use crate::drivers::unified_gamepad::{
+    capability::InputCapability,
+    reports::{
+        input_capability_report::{InputCapabilityInfo, InputCapabilityReport},
+        ValueType,
+    },
+};
+
+#[tokio::test]
+async fn test_packing() -> Result<(), Box<dyn Error>> {
+    let mut report = InputCapabilityReport::default();
+    report
+        .add_capability(InputCapabilityInfo::new(
+            InputCapability::GamepadButtonStart,
+            ValueType::Bool,
+        ))
+        .expect("should add capability");
+    report
+        .add_capability(InputCapabilityInfo::new(
+            InputCapability::GamepadButtonSelect,
+            ValueType::Bool,
+        ))
+        .expect("should add capability");
+    report
+        .get_capability(InputCapability::GamepadButtonSelect)
+        .expect("should have added the capability");
+
+    // Pack the report
+    let bytes = report.pack_to_vec().expect("should pack to bytes");
+    println!("Got bytes: {bytes:?}");
+
+    // Unpack the report
+    let unpacked_report =
+        InputCapabilityReport::unpack(bytes.as_slice()).expect("should have unpacked");
+
+    println!("Got unpacked report: {unpacked_report}");
+
+    assert_eq!(
+        format!("{report}"),
+        format!("{unpacked_report}"),
+        "unpacked report should match original"
+    );
+
+    Ok(())
+}

--- a/src/drivers/unified_gamepad/reports/input_data_report.rs
+++ b/src/drivers/unified_gamepad/reports/input_data_report.rs
@@ -1,0 +1,249 @@
+use packed_struct::prelude::*;
+use thiserror::Error;
+
+use crate::drivers::unified_gamepad::{capability::InputCapability, value::TouchValue};
+
+use super::{
+    input_capability_report::InputCapabilityReport, ReportType, ValueType,
+    UNIFIED_SPEC_VERSION_MAJOR, UNIFIED_SPEC_VERSION_MINOR,
+};
+
+/// The maximum size of the [InputDataReport]
+pub const INPUT_DATA_REPORT_SIZE: usize = 68;
+
+/// The [InputDataReport] contains input data based on the capabilities of the
+/// device according to the [super::input_capability_report::InputCapabilityReport].
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", size_bytes = "68")]
+pub struct InputDataReport {
+    // byte 0-3
+    #[packed_field(bytes = "0")]
+    pub major_ver: u8, // Major version? Always 0x01
+    #[packed_field(bytes = "1")]
+    pub minor_ver: u8, // Minor version? Always 0x00
+    #[packed_field(bytes = "2", ty = "enum")]
+    pub report_type: ReportType, // Report type? Always 0x09
+
+    /// The state version will increment whenever a state change has occurred.
+    /// If the version has not changed since the last report, there is no need
+    /// to further process the report.
+    #[packed_field(bytes = "4..=5", endian = "lsb")]
+    pub state_version: u16,
+
+    /// Input data can be decoded by reading capabilities in the [super::input_capability_report::InputCapabilityReport].
+    #[packed_field(bytes = "6..=67")]
+    pub data: [u8; 62],
+}
+
+impl Default for InputDataReport {
+    fn default() -> Self {
+        Self {
+            major_ver: UNIFIED_SPEC_VERSION_MAJOR,
+            minor_ver: UNIFIED_SPEC_VERSION_MINOR,
+            report_type: ReportType::InputDataReport,
+            state_version: Default::default(),
+            data: [0; 62],
+        }
+    }
+}
+
+/// Result of updating an [InputDataReport]
+type UpdateInputReportResult = Result<(), UpdateInputReportError>;
+
+/// Possible errors when updating a [InputDataReport]
+#[derive(Error, Debug)]
+pub enum UpdateInputReportError {
+    #[error("capability `{0:?}` was not found in the input capability report")]
+    CapabilityNotFound(InputCapability),
+    #[error("value type in capability report `{capability_type:?}` does not match the value type in the update `{update_type:?}`")]
+    ValueTypeMismatch {
+        capability_type: ValueType,
+        update_type: ValueType,
+    },
+    #[error("unable to pack update values: {0:?}")]
+    PackingError(#[from] PackingError),
+    #[error("update for capability `{capability:?}` would update report at byte `{offset:?}` which exceeds the max size of the input report `{size:?}`")]
+    ReportSizeExceeded {
+        capability: InputCapability,
+        offset: usize,
+        size: usize,
+    },
+}
+
+impl InputDataReport {
+    /// Update the [InputDataReport] with the given value based on the [InputCapabilityReport]
+    pub fn update(
+        &mut self,
+        capability_report: &InputCapabilityReport,
+        update: StateUpdate,
+    ) -> UpdateInputReportResult {
+        let Some(capability_info) = capability_report.get_capability(update.capability) else {
+            return Err(UpdateInputReportError::CapabilityNotFound(
+                update.capability,
+            ));
+        };
+
+        // Validate that the event value matches the value type
+        let capability_type = capability_info.value_type;
+        let update_type = update.value.value_type();
+        if capability_type != update_type {
+            return Err(UpdateInputReportError::ValueTypeMismatch {
+                capability_type,
+                update_type,
+            });
+        }
+
+        // Get the value type and its size
+        let value_type = capability_info.value_type;
+        let value_size_bytes = value_type.size_bytes();
+
+        // Get the bit/byte offset
+        let offset_bits = capability_info.offset as usize;
+        let offset_remainder = offset_bits % 8;
+        let offset_bytes = (offset_bits - offset_remainder) / 8;
+
+        // Get the byte start
+        let byte_start = offset_bytes;
+
+        // Ensure the data can fit in the report
+        if byte_start + value_size_bytes > self.data.len() {
+            return Err(UpdateInputReportError::ReportSizeExceeded {
+                capability: update.capability,
+                offset: byte_start + value_size_bytes,
+                size: self.data.len(),
+            });
+        }
+
+        match update.value {
+            ValueUpdate::None => (),
+            ValueUpdate::Bool(value) => {
+                // Shift the value to the appropriate bit offset
+                if value.value {
+                    // Toggle on the bit at the offset remainder
+                    self.data[byte_start] |= 1 << offset_remainder;
+                } else {
+                    // Toggle off the bit at the offset remainder
+                    self.data[byte_start] ^= 1 << offset_remainder;
+                }
+            }
+            ValueUpdate::UInt8(value) => {
+                self.data[byte_start] = value.value;
+            }
+            ValueUpdate::UInt16(value) => {
+                let data = value.value.to_le_bytes();
+                self.data[byte_start] = data[0];
+                self.data[byte_start + 1] = data[1];
+            }
+            ValueUpdate::UInt16Vector2(value) => {
+                let x_data = value.x.map(|x| x.to_le_bytes());
+                if let Some(data) = x_data {
+                    self.data[byte_start] = data[0];
+                    self.data[byte_start + 1] = data[1];
+                }
+
+                let y_data = value.y.map(|y| y.to_le_bytes());
+                if let Some(data) = y_data {
+                    self.data[byte_start + 2] = data[0];
+                    self.data[byte_start + 3] = data[1];
+                }
+            }
+            ValueUpdate::Int16Vector3(value) => {
+                let x_data = value.x.map(|x| x.to_le_bytes());
+                if let Some(data) = x_data {
+                    self.data[byte_start] = data[0];
+                    self.data[byte_start + 1] = data[1];
+                }
+
+                let y_data = value.y.map(|y| y.to_le_bytes());
+                if let Some(data) = y_data {
+                    self.data[byte_start + 2] = data[0];
+                    self.data[byte_start + 3] = data[1];
+                }
+
+                let z_data = value.z.map(|z| z.to_le_bytes());
+                if let Some(data) = z_data {
+                    self.data[byte_start + 4] = data[0];
+                    self.data[byte_start + 5] = data[1];
+                }
+            }
+            ValueUpdate::Touch(value) => {
+                let data = value.pack()?;
+                self.data[byte_start] = data[0];
+                self.data[byte_start + 1] = data[1];
+                self.data[byte_start + 2] = data[2];
+                self.data[byte_start + 3] = data[3];
+                self.data[byte_start + 4] = data[4];
+                self.data[byte_start + 5] = data[5];
+            }
+        };
+
+        self.state_version = self.state_version.wrapping_add(1);
+        log::trace!("Updated data: {:?}", self.data);
+
+        Ok(())
+    }
+}
+
+/// [StateUpdate] is used to provide information on how to update the state of
+/// a unified gamepad device.
+#[derive(Clone, Debug, Default)]
+pub struct StateUpdate {
+    pub capability: InputCapability,
+    pub value: ValueUpdate,
+}
+
+#[derive(Debug, Clone, Default)]
+pub enum ValueUpdate {
+    #[default]
+    None,
+    Bool(BoolUpdate),
+    UInt8(UInt8Update),
+    #[allow(dead_code)]
+    UInt16(UInt16Update),
+    UInt16Vector2(UInt16Vector2Update),
+    Int16Vector3(Int16Vector3Update),
+    Touch(TouchValue),
+}
+
+impl ValueUpdate {
+    /// Return the [ValueType] for this [Value]
+    pub fn value_type(&self) -> ValueType {
+        match self {
+            Self::None => ValueType::None,
+            Self::Bool(_) => ValueType::Bool,
+            Self::UInt8(_) => ValueType::UInt8,
+            Self::UInt16(_) => ValueType::UInt16,
+            Self::UInt16Vector2(_) => ValueType::UInt16Vector2,
+            Self::Int16Vector3(_) => ValueType::Int16Vector3,
+            Self::Touch(_) => ValueType::Touch,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct BoolUpdate {
+    pub value: bool,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct UInt8Update {
+    pub value: u8,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct UInt16Update {
+    pub value: u16,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct UInt16Vector2Update {
+    pub x: Option<u16>,
+    pub y: Option<u16>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct Int16Vector3Update {
+    pub x: Option<i16>,
+    pub y: Option<i16>,
+    pub z: Option<i16>,
+}

--- a/src/drivers/unified_gamepad/reports/input_data_report_test.rs
+++ b/src/drivers/unified_gamepad/reports/input_data_report_test.rs
@@ -1,0 +1,110 @@
+use std::error::Error;
+
+use crate::drivers::unified_gamepad::{
+    capability::InputCapability,
+    reports::{
+        input_capability_report::{InputCapabilityInfo, InputCapabilityReport},
+        input_data_report::{BoolUpdate, InputDataReport, StateUpdate, ValueUpdate},
+        ValueType,
+    },
+    value::Value,
+};
+
+#[tokio::test]
+async fn test_update() -> Result<(), Box<dyn Error>> {
+    // Create a capability report
+    let mut capability_report = InputCapabilityReport::default();
+    capability_report
+        .add_capability(InputCapabilityInfo::new(
+            InputCapability::GamepadButtonStart,
+            ValueType::Bool,
+        ))
+        .expect("should add capability");
+    capability_report
+        .add_capability(InputCapabilityInfo::new(
+            InputCapability::GamepadButtonSelect,
+            ValueType::Bool,
+        ))
+        .expect("should add capability");
+
+    // Create the input report
+    let mut input_report = InputDataReport::default();
+
+    // Test updates
+    let update = StateUpdate {
+        capability: InputCapability::GamepadButtonStart,
+        value: ValueUpdate::Bool(BoolUpdate { value: true }),
+    };
+    input_report
+        .update(&capability_report, update)
+        .expect("should update the input report");
+    println!("Input Report: {input_report}");
+    assert_eq!(
+        input_report.data[0], 1,
+        "should have set the data in the first byte"
+    );
+
+    let update = StateUpdate {
+        capability: InputCapability::GamepadButtonStart,
+        value: ValueUpdate::Bool(BoolUpdate { value: false }),
+    };
+    input_report
+        .update(&capability_report, update)
+        .expect("should update the input report");
+    println!("Input Report: {input_report}");
+    assert_eq!(
+        input_report.data[0], 0,
+        "should have unset the data in the first byte"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_decode() -> Result<(), Box<dyn Error>> {
+    // Create a capability report
+    let mut capability_report = InputCapabilityReport::default();
+    capability_report
+        .add_capability(InputCapabilityInfo::new(
+            InputCapability::GamepadButtonStart,
+            ValueType::Bool,
+        ))
+        .expect("should add capability");
+    capability_report
+        .add_capability(InputCapabilityInfo::new(
+            InputCapability::GamepadButtonSelect,
+            ValueType::Bool,
+        ))
+        .expect("should add capability");
+
+    // Create the input report
+    let mut input_report = InputDataReport::default();
+
+    // Update the state
+    let update = StateUpdate {
+        capability: InputCapability::GamepadButtonStart,
+        value: ValueUpdate::Bool(BoolUpdate { value: true }),
+    };
+    input_report
+        .update(&capability_report, update)
+        .expect("should update the input report");
+    println!("Input Report: {input_report}");
+    assert_eq!(
+        input_report.data[0], 1,
+        "should have set the data in the first byte"
+    );
+
+    // Test decoding the report using the capability report
+    let values = capability_report
+        .decode_data_report(&input_report)
+        .expect("should have decoded the input report");
+    println!("Decoded values: {values:?}");
+
+    let start_value = values.first().expect("should have at least one value");
+    let Value::Bool(value) = start_value else {
+        panic!("start value should be a boolean");
+    };
+    assert!(value.value, "decoded value should be true");
+
+    Ok(())
+}

--- a/src/drivers/unified_gamepad/value.rs
+++ b/src/drivers/unified_gamepad/value.rs
@@ -1,0 +1,107 @@
+use packed_struct::prelude::*;
+
+use super::reports::ValueType;
+
+/// [Value] defines all the possible values that a unified gamepad can send as
+/// part of its HID reports.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub enum Value {
+    #[default]
+    None,
+    Bool(BoolValue),
+    UInt8(UInt8Value),
+    UInt16(UInt16Value),
+    UInt16Vector2(UInt16Vector2Value),
+    Int16Vector3(Int16Vector3Value),
+    Touch(TouchValue),
+}
+
+impl Value {
+    /// Return the [ValueType] for this [Value]
+    pub fn value_type(&self) -> ValueType {
+        match self {
+            Value::None => ValueType::None,
+            Value::Bool(_) => ValueType::Bool,
+            Value::UInt8(_) => ValueType::UInt8,
+            Value::UInt16(_) => ValueType::UInt16,
+            Value::UInt16Vector2(_) => ValueType::UInt16Vector2,
+            Value::Int16Vector3(_) => ValueType::Int16Vector3,
+            Value::Touch(_) => ValueType::Touch,
+        }
+    }
+}
+
+/// [BoolValue] defines boolean values that can be sent in an HID report, typically
+/// used for inputs like buttons or switches.
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", size_bits = "1")]
+pub struct BoolValue {
+    #[packed_field(bits = "0")]
+    pub value: bool,
+}
+
+/// [UInt8Value] defines u8 values that can be sent in an HID report, typically
+/// used for low resolution trigger inputs.
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", size_bytes = "1")]
+pub struct UInt8Value {
+    #[packed_field(bytes = "0")]
+    pub value: u8,
+}
+
+/// [UInt16Value] defines u16 values that can be sent in an HID report, typically
+/// used for higher resolution trigger inputs.
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", size_bytes = "2")]
+pub struct UInt16Value {
+    #[packed_field(bytes = "0..=1", endian = "lsb")]
+    pub value: u16,
+}
+
+/// [UInt16Vector2Value] defines (x, y) values that can be sent in an HID report, typically
+/// used for inputs which require 2-axes of positive values.
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", size_bytes = "4")]
+pub struct UInt16Vector2Value {
+    #[packed_field(bytes = "0..=1", endian = "lsb")]
+    pub x: u16,
+    #[packed_field(bytes = "2..=3", endian = "lsb")]
+    pub y: u16,
+}
+
+/// [Int16Vector3Value] defines (x, y, z) values that can be sent in an HID report, typically
+/// used for accelerometer, gyroscope, or magnetometer input.
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", size_bytes = "6")]
+pub struct Int16Vector3Value {
+    #[packed_field(bytes = "0..=1", endian = "lsb")]
+    pub x: i16,
+    #[packed_field(bytes = "2..=3", endian = "lsb")]
+    pub y: i16,
+    #[packed_field(bytes = "4..=5", endian = "lsb")]
+    pub z: i16,
+}
+
+/// [TouchValue] defines touch values that can be sent in an HID report.
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", size_bytes = "6")]
+pub struct TouchValue {
+    /// The finger id of the touch input for multi-touch devices.
+    #[packed_field(bits = "0..=6")]
+    pub index: Integer<u8, packed_bits::Bits<7>>,
+    /// Whether or not the device is sensing touch.
+    #[packed_field(bits = "7")]
+    pub is_touching: bool,
+    /// Optionally the amount of pressure the touch is experiencing, normalized
+    /// between 0 and 255.
+    #[packed_field(bytes = "1")]
+    pub pressure: u8,
+    /// The X position of the touch, normalized between 0.0-1.0, where 0
+    /// is the left side of the input device and where 1.0 is the right side
+    #[packed_field(bytes = "2..=3", endian = "lsb")]
+    pub x: u16,
+    /// The Y position of the touch, normalized between 0.0-1.0, where 0
+    /// is the top side of the input device and where 1.0 is the bottom side
+    #[packed_field(bytes = "4..=5", endian = "lsb")]
+    pub y: u16,
+}

--- a/src/input/composite_device/command.rs
+++ b/src/input/composite_device/command.rs
@@ -42,6 +42,8 @@ pub enum CompositeCommand {
     SourceDeviceAdded(UdevDevice),
     SourceDeviceRemoved(UdevDevice),
     SourceDeviceStopped(UdevDevice),
+    UpdateSourceCapabilities(String, HashSet<Capability>),
+    UpdateTargetCapabilities(String, HashSet<Capability>),
     WriteChordEvent(Vec<NativeEvent>),
     WriteEvent(NativeEvent),
     WriteSendEvent(NativeEvent),

--- a/src/input/target/mod.rs
+++ b/src/input/target/mod.rs
@@ -9,6 +9,7 @@ use std::{
 use horipad_steam::HoripadSteamDevice;
 use thiserror::Error;
 use tokio::sync::mpsc::{self, error::TryRecvError};
+use unified_gamepad::UnifiedGamepadDevice;
 
 use crate::dbus::interface::target::{gamepad::TargetGamepadInterface, TargetInterface};
 
@@ -48,6 +49,7 @@ pub mod mouse;
 pub mod steam_deck;
 pub mod touchpad;
 pub mod touchscreen;
+pub mod unified_gamepad;
 pub mod xb360;
 pub mod xbox_elite;
 pub mod xbox_series;
@@ -203,6 +205,10 @@ impl TargetDeviceTypeId {
             TargetDeviceTypeId {
                 id: "xbox-series",
                 name: "Microsoft Xbox Series S|X Controller",
+            },
+            TargetDeviceTypeId {
+                id: "unified-gamepad",
+                name: "InputPlumber Unified Gamepad",
             },
         ]
     }
@@ -586,6 +592,7 @@ pub enum TargetDevice {
     XBox360(TargetDriver<XBox360Controller>),
     XBoxElite(TargetDriver<XboxEliteController>),
     XBoxSeries(TargetDriver<XboxSeriesController>),
+    UnifiedGamepad(TargetDriver<UnifiedGamepadDevice>),
 }
 
 impl TargetDevice {
@@ -689,6 +696,11 @@ impl TargetDevice {
                 let driver = TargetDriver::new(id, device, dbus);
                 Ok(Self::XBoxSeries(driver))
             }
+            "unified-gamepad" => {
+                let device = UnifiedGamepadDevice::new()?;
+                let driver = TargetDriver::new(id, device, dbus);
+                Ok(Self::UnifiedGamepad(driver))
+            }
             "null" => Ok(Self::Null),
             _ => Ok(Self::Null),
         }
@@ -720,6 +732,7 @@ impl TargetDevice {
             }
             TargetDevice::XBoxElite(_) => vec!["xbox-elite".try_into().unwrap()],
             TargetDevice::XBoxSeries(_) => vec!["xbox-series".try_into().unwrap()],
+            TargetDevice::UnifiedGamepad(_) => vec!["unified-gamepad".try_into().unwrap()],
         }
     }
 
@@ -740,6 +753,7 @@ impl TargetDevice {
             TargetDevice::XBox360(_) => "gamepad",
             TargetDevice::XBoxElite(_) => "gamepad",
             TargetDevice::XBoxSeries(_) => "gamepad",
+            TargetDevice::UnifiedGamepad(_) => "gamepad",
         }
     }
 
@@ -758,6 +772,7 @@ impl TargetDevice {
             TargetDevice::XBox360(device) => Some(device.client()),
             TargetDevice::XBoxElite(device) => Some(device.client()),
             TargetDevice::XBoxSeries(device) => Some(device.client()),
+            TargetDevice::UnifiedGamepad(device) => Some(device.client()),
         }
     }
 
@@ -776,6 +791,7 @@ impl TargetDevice {
             TargetDevice::XBox360(device) => device.run(dbus_path).await,
             TargetDevice::XBoxElite(device) => device.run(dbus_path).await,
             TargetDevice::XBoxSeries(device) => device.run(dbus_path).await,
+            TargetDevice::UnifiedGamepad(device) => device.run(dbus_path).await,
         }
     }
 }

--- a/src/input/target/unified_gamepad.rs
+++ b/src/input/target/unified_gamepad.rs
@@ -1,0 +1,771 @@
+use std::{collections::HashSet, error::Error, fmt::Debug, fs::File};
+
+use packed_struct::prelude::*;
+use tokio::sync::mpsc::{self, error::TryRecvError, Receiver};
+use uhid_virt::{Bus, CreateParams, StreamError, UHIDDevice};
+use zbus::Connection;
+
+use crate::{
+    dbus::interface::target::{gamepad::TargetGamepadInterface, TargetInterface},
+    drivers::unified_gamepad::{
+        capability::InputCapability,
+        driver::{UNIFIED_CONTROLLER_PID, UNIFIED_CONTROLLER_VID},
+        reports::{
+            input_capability_report::{InputCapabilityInfo, InputCapabilityReport},
+            input_data_report::{
+                BoolUpdate, InputDataReport, Int16Vector3Update, StateUpdate, UInt16Vector2Update,
+                UInt8Update, ValueUpdate,
+            },
+            ReportType, ValueType, REPORT_DESCRIPTOR,
+        },
+        value::TouchValue,
+    },
+    input::{
+        capability::{
+            Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger, Touch, Touchpad,
+        },
+        composite_device::client::CompositeDeviceClient,
+        event::{native::NativeEvent, value::InputValue},
+        output_capability::OutputCapability,
+        output_event::OutputEvent,
+    },
+};
+
+use super::{
+    client::TargetDeviceClient, InputError, OutputError, TargetDeviceTypeId, TargetInputDevice,
+    TargetOutputDevice,
+};
+
+/// A [UnifiedGamepadDevice] implements the Unified Controller Input Specification
+pub struct UnifiedGamepadDevice {
+    device: UHIDDevice<File>,
+    dbus_path: Option<String>,
+    composite_device: Option<CompositeDeviceClient>,
+    capabilities: HashSet<Capability>,
+    capabilities_rx: Option<Receiver<HashSet<Capability>>>,
+    capability_report: InputCapabilityReport,
+    state: InputDataReport,
+    clients_count: u16,
+}
+
+impl UnifiedGamepadDevice {
+    /// Create a new [UnifiedGamepadDevice]
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        // Create the virtual device
+        let uhid_device = UnifiedGamepadDevice::create_virtual_device()?;
+        let device = Self {
+            device: uhid_device,
+            dbus_path: None,
+            composite_device: None,
+            capabilities: HashSet::new(),
+            capabilities_rx: None,
+            capability_report: InputCapabilityReport::default(),
+            state: InputDataReport::default(),
+            clients_count: 0,
+        };
+
+        Ok(device)
+    }
+
+    /// Create the virtual device to emulate
+    fn create_virtual_device() -> Result<UHIDDevice<File>, Box<dyn Error>> {
+        let device = UHIDDevice::create(CreateParams {
+            name: "InputPlumber Unified Gamepad".to_string(),
+            phys: "".to_string(),
+            uniq: "".to_string(),
+            bus: Bus::USB,
+            // TODO: Find an appropriate VID/PID to use. For the time being, this
+            // is using the OpenInput VID/PID. We may be able to ask for a VID/PID
+            // from OpenMoko: https://github.com/openmoko/openmoko-usb-oui/tree/master
+            vendor: UNIFIED_CONTROLLER_VID as u32,
+            product: UNIFIED_CONTROLLER_PID as u32,
+            version: 1,
+            country: 0,
+            rd_data: REPORT_DESCRIPTOR.to_vec(),
+        })?;
+
+        Ok(device)
+    }
+
+    /// Checks to see if new capabilities are available in the capabilities channel
+    fn receive_new_capabilities(&mut self) -> Option<HashSet<Capability>> {
+        let rx = self.capabilities_rx.as_mut()?;
+
+        match rx.try_recv() {
+            Ok(capabilities) => Some(capabilities),
+            Err(e) => match e {
+                TryRecvError::Empty => None,
+                TryRecvError::Disconnected => {
+                    self.capabilities_rx = None;
+                    None
+                }
+            },
+        }
+    }
+
+    /// Update the device capabilities with the given capabilities
+    fn update_capabilities(&mut self, capabilities: HashSet<Capability>) {
+        log::debug!("Updating device capabilities with: {capabilities:?}");
+        let Some(composite_device) = self.composite_device.as_ref() else {
+            log::warn!("No composite device set to update capabilities");
+            return;
+        };
+
+        // Set the capabilities of the device
+        self.capabilities = capabilities.clone();
+
+        // Update the capability report with the source capabilities
+        let mut cap_info: Vec<InputCapabilityInfo> = capabilities
+            .clone()
+            .into_iter()
+            .map(|cap| cap.into())
+            .collect();
+        cap_info.sort_by_key(|cap| cap.value_type.order_priority());
+
+        // Update the capability report
+        self.capability_report = InputCapabilityReport::default();
+        for info in cap_info {
+            log::trace!("Updating report with info: {info}");
+            if let Err(e) = self.capability_report.add_capability(info) {
+                log::warn!("Failed to add input capability for gamepad: {e}");
+            }
+        }
+        log::debug!("Using capability report: {}", self.capability_report);
+
+        // Inform the composite device that the capabilities have changed
+        if let Some(dbus_path) = self.dbus_path.as_ref() {
+            log::debug!("Updating composite device with new capabilities");
+            if let Err(e) = composite_device
+                .blocking_update_target_capabilities(dbus_path.clone(), capabilities)
+            {
+                log::warn!("Failed to update target capabilities: {e:?}");
+            }
+        }
+
+        log::debug!("Updated capabilities");
+    }
+
+    /// Write the current device state to the virtual device
+    fn write_state(&mut self) -> Result<(), Box<dyn Error>> {
+        let data = self.state.pack()?;
+
+        // Write the state to the virtual HID
+        if let Err(e) = self.device.write(&data) {
+            let err = format!("Failed to write input data report: {:?}", e);
+            return Err(err.into());
+        }
+
+        Ok(())
+    }
+
+    /// Handle [OutputEvent::Output] events from the HIDRAW device. These are
+    /// output events which should be forwarded back to source devices.
+    fn handle_output(&mut self, _data: Vec<u8>) -> Result<Vec<OutputEvent>, Box<dyn Error>> {
+        // TODO: Implement output events
+        Ok(vec![])
+    }
+
+    /// Handle [OutputEvent::GetReport] events from the HIDRAW device
+    fn handle_get_report(
+        &mut self,
+        id: u32,
+        report_number: u8,
+        report_type: uhid_virt::ReportType,
+    ) -> Result<(), Box<dyn Error>> {
+        // We only support getting feature reports
+        if report_type != uhid_virt::ReportType::Feature {
+            return Ok(());
+        }
+
+        let report_type = ReportType::from(report_number);
+        match report_type {
+            ReportType::Unknown => (),
+            ReportType::InputCapabilityReport => {
+                log::debug!("GetFeatureReport: InputCapabilityReport");
+                // Write the input capabilities of the device
+                let response = self.capability_report.pack_to_vec()?;
+                self.device.write_get_report_reply(id, 0, response)?;
+                // NOTE: Feature reports only support a maximum of 64 bytes?
+            }
+            ReportType::InputDataReport => (),
+            ReportType::OutputCapabilityReport => (),
+            ReportType::OutputDataReport => (),
+        }
+
+        Ok(())
+    }
+}
+
+impl TargetInputDevice for UnifiedGamepadDevice {
+    /// Start the DBus interface for this target device
+    fn start_dbus_interface(
+        &mut self,
+        dbus: Connection,
+        path: String,
+        client: TargetDeviceClient,
+        type_id: TargetDeviceTypeId,
+    ) {
+        log::debug!("Starting dbus interface: {path}");
+        log::trace!("Using device client: {client:?}");
+        self.dbus_path = Some(path.clone());
+        tokio::task::spawn(async move {
+            let generic_interface = TargetInterface::new(&type_id);
+            let iface = TargetGamepadInterface::new(type_id.name().to_owned());
+
+            let object_server = dbus.object_server();
+            let (gen_result, result) = tokio::join!(
+                object_server.at(path.clone(), generic_interface),
+                object_server.at(path.clone(), iface)
+            );
+
+            if gen_result.is_err() || result.is_err() {
+                log::debug!("Failed to start dbus interface: {path} generic: {gen_result:?} type-specific: {result:?}");
+            } else {
+                log::debug!("Started dbus interface: {path}");
+            }
+        });
+    }
+
+    fn on_composite_device_attached(
+        &mut self,
+        composite_device: CompositeDeviceClient,
+    ) -> Result<(), InputError> {
+        self.composite_device = Some(composite_device.clone());
+
+        // Spawn a task to asyncronously fetch the source capabilities of
+        // the composite device.
+        let (tx, rx) = mpsc::channel(1);
+        tokio::task::spawn(async move {
+            log::debug!("Getting capabilities from the composite device!");
+            let capabilities = match composite_device.get_capabilities().await {
+                Ok(caps) => caps,
+                Err(e) => {
+                    log::warn!("Failed to fetch composite device capabilities: {e:?}");
+                    return;
+                }
+            };
+            if let Err(e) = tx.send(capabilities).await {
+                log::warn!("Failed to send composite device capabilities: {e:?}");
+            }
+        });
+
+        // Keep a reference to the receiver so it can be checked every poll iteration
+        self.capabilities_rx = Some(rx);
+
+        Ok(())
+    }
+
+    fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
+        log::trace!("Received event: {event:?}");
+
+        // Update the internal controller state when events are emitted.
+        if let Err(e) = self.state.update(&self.capability_report, event.into()) {
+            log::warn!("Failed to update gamepad state: {e}");
+            log::warn!("Current capability report: {}", self.capability_report);
+        }
+
+        Ok(())
+    }
+
+    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
+        // Get the input capabilities from the source device(s)
+        let capabilities = Vec::from_iter(self.capabilities.iter().cloned());
+        Ok(capabilities)
+    }
+
+    fn stop(&mut self) -> Result<(), InputError> {
+        let _ = self.device.destroy();
+        Ok(())
+    }
+}
+
+impl TargetOutputDevice for UnifiedGamepadDevice {
+    /// Handle reading from the device and processing input events from source
+    /// devices.
+    /// https://www.kernel.org/doc/html/latest/hid/uhid.html#read
+    fn poll(
+        &mut self,
+        _composite_device: &Option<CompositeDeviceClient>,
+    ) -> Result<Vec<OutputEvent>, OutputError> {
+        // Check to see if there are any capability updates
+        if let Some(new_capabilities) = self.receive_new_capabilities() {
+            self.update_capabilities(new_capabilities);
+        }
+
+        // Read output events
+        let event = match self.device.read() {
+            Ok(event) => event,
+            Err(err) => match err {
+                StreamError::Io(_e) => {
+                    //log::error!("Error reading from UHID device: {e:?}");
+                    // Write the current state
+                    self.write_state()?;
+                    return Ok(vec![]);
+                }
+                StreamError::UnknownEventType(e) => {
+                    log::debug!("Unknown event type: {:?}", e);
+                    // Write the current state
+                    self.write_state()?;
+                    return Ok(vec![]);
+                }
+            },
+        };
+
+        // Match the type of UHID output event
+        let output_events = match event {
+            // This is sent when the HID device is started. Consider this as an answer to
+            // UHID_CREATE. This is always the first event that is sent.
+            uhid_virt::OutputEvent::Start { dev_flags: _ } => {
+                log::debug!("Start event received");
+                Ok(vec![])
+            }
+            // This is sent when the HID device is stopped. Consider this as an answer to
+            // UHID_DESTROY.
+            uhid_virt::OutputEvent::Stop => {
+                log::debug!("Stop event received");
+                Ok(vec![])
+            }
+            // This is sent when the HID device is opened. That is, the data that the HID
+            // device provides is read by some other process. You may ignore this event but
+            // it is useful for power-management. As long as you haven't received this event
+            // there is actually no other process that reads your data so there is no need to
+            // send UHID_INPUT events to the kernel.
+            uhid_virt::OutputEvent::Open => {
+                self.clients_count = self.clients_count.wrapping_add(1);
+                log::debug!(
+                    "Open event received. Current clients: {}",
+                    self.clients_count
+                );
+                Ok(vec![])
+            }
+            // This is sent when there are no more processes which read the HID data. It is
+            // the counterpart of UHID_OPEN and you may as well ignore this event.
+            uhid_virt::OutputEvent::Close => {
+                if self.clients_count != 0 {
+                    self.clients_count = self.clients_count.wrapping_sub(1)
+                }
+                log::debug!(
+                    "Close event received. Current clients: {}",
+                    self.clients_count
+                );
+                Ok(vec![])
+            }
+            // This is sent if the HID device driver wants to send raw data to the I/O
+            // device. You should read the payload and forward it to the device.
+            uhid_virt::OutputEvent::Output { data } => {
+                log::trace!("Got output data: {:?}", data);
+                let result = self.handle_output(data);
+                match result {
+                    Ok(events) => Ok(events),
+                    Err(e) => {
+                        let err = format!("Failed process output event: {:?}", e);
+                        Err(err.into())
+                    }
+                }
+            }
+            // This event is sent if the kernel driver wants to perform a GET_REPORT request
+            // on the control channel as described in the HID specs. The report-type and
+            // report-number are available in the payload.
+            // The kernel serializes GET_REPORT requests so there will never be two in
+            // parallel. However, if you fail to respond with a UHID_GET_REPORT_REPLY, the
+            // request might silently time out.
+            // Once you read a GET_REPORT request, you shall forward it to the HID device and
+            // remember the "id" field in the payload. Once your HID device responds to the
+            // GET_REPORT (or if it fails), you must send a UHID_GET_REPORT_REPLY to the
+            // kernel with the exact same "id" as in the request. If the request already
+            // timed out, the kernel will ignore the response silently. The "id" field is
+            // never re-used, so conflicts cannot happen.
+            uhid_virt::OutputEvent::GetReport {
+                id,
+                report_number,
+                report_type,
+            } => {
+                log::trace!(
+                    "Received GetReport event: id: {id}, num: {report_number}, type: {report_type:?}"
+                );
+                let result = self.handle_get_report(id, report_number, report_type);
+                if let Err(e) = result {
+                    let err = format!("Failed to process GetReport event: {e:?}");
+                    return Err(err.into());
+                }
+                Ok(vec![])
+            }
+            // This is the SET_REPORT equivalent of UHID_GET_REPORT. On receipt, you shall
+            // send a SET_REPORT request to your HID device. Once it replies, you must tell
+            // the kernel about it via UHID_SET_REPORT_REPLY.
+            // The same restrictions as for UHID_GET_REPORT apply.
+            uhid_virt::OutputEvent::SetReport {
+                id,
+                report_number,
+                report_type,
+                data,
+            } => {
+                log::debug!("Received SetReport event: id: {id}, num: {report_number}, type: {:?}, data: {:?}", report_type, data);
+                Ok(vec![])
+            }
+        };
+
+        // Write the current state
+        if self.clients_count > 0 {
+            self.write_state()?;
+        }
+
+        output_events
+    }
+
+    fn get_output_capabilities(&self) -> Result<Vec<OutputCapability>, OutputError> {
+        // TODO: Get the output capabilities from the source device(s)
+        Ok(vec![])
+    }
+}
+
+impl Debug for UnifiedGamepadDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UnifiedGamepadDevice")
+            .field("state", &self.state)
+            .finish()
+    }
+}
+
+/// Implementation to convert an InputPlumber [NativeEvent] into a Unified Controller [StateUpdate]
+impl From<NativeEvent> for StateUpdate {
+    fn from(event: NativeEvent) -> Self {
+        let event_capability = event.as_capability();
+        let capability = event_capability.clone().into();
+        match event_capability {
+            Capability::None => Self::default(),
+            Capability::NotImplemented => Self::default(),
+            Capability::Sync => Self::default(),
+            Capability::DBus(_) => Self::default(),
+            Capability::Gamepad(gamepad) => match gamepad {
+                Gamepad::Button(_) => {
+                    let value = match event.get_value() {
+                        InputValue::Bool(value) => BoolUpdate { value },
+                        InputValue::Float(value) => BoolUpdate { value: value > 0.5 },
+                        _ => {
+                            // Cannot convert other values to bool
+                            return Self::default();
+                        }
+                    };
+                    let value = ValueUpdate::Bool(value);
+
+                    Self { capability, value }
+                }
+                Gamepad::Axis(_) => {
+                    let value = match event.get_value() {
+                        InputValue::Vector2 { x, y } => {
+                            // Normalize the x and y values from -1.0 -> 1.0 to a value between 0
+                            // and u16::MAX.
+                            let x = x.map(|x| (((x + 1.0) / 2.0) * u16::MAX as f64) as u16);
+                            let y = y.map(|y| (((y + 1.0) / 2.0) * u16::MAX as f64) as u16);
+                            UInt16Vector2Update { x, y }
+                        }
+                        _ => {
+                            // Cannot convert other values
+                            return Self::default();
+                        }
+                    };
+                    let value = ValueUpdate::UInt16Vector2(value);
+
+                    Self { capability, value }
+                }
+                Gamepad::Trigger(_) => {
+                    let value = match event.get_value() {
+                        InputValue::Float(value) => {
+                            // Normalize the value from 0.0 -> 1.0 to a value between 0 and
+                            // u8::MAX.
+                            let value = (value * u8::MAX as f64) as u8;
+                            UInt8Update { value }
+                        }
+                        _ => {
+                            return Self::default();
+                        }
+                    };
+                    let value = ValueUpdate::UInt8(value);
+
+                    Self { capability, value }
+                }
+                Gamepad::Accelerometer => {
+                    let value = match event.get_value() {
+                        InputValue::Vector3 { x, y, z } => Int16Vector3Update {
+                            x: x.map(|x| x as i16),
+                            y: y.map(|y| y as i16),
+                            z: z.map(|z| z as i16),
+                        },
+                        _ => {
+                            return Self::default();
+                        }
+                    };
+                    let value = ValueUpdate::Int16Vector3(value);
+
+                    Self { capability, value }
+                }
+                Gamepad::Gyro => {
+                    let value = match event.get_value() {
+                        InputValue::Vector3 { x, y, z } => Int16Vector3Update {
+                            x: x.map(|x| x as i16),
+                            y: y.map(|y| y as i16),
+                            z: z.map(|z| z as i16),
+                        },
+                        _ => {
+                            return Self::default();
+                        }
+                    };
+                    let value = ValueUpdate::Int16Vector3(value);
+
+                    Self { capability, value }
+                }
+            },
+            Capability::Mouse(_) => Self::default(),
+            Capability::Keyboard(_) => Self::default(),
+            Capability::Touchpad(touchpad) => match touchpad {
+                Touchpad::LeftPad(pad) => match pad {
+                    Touch::Motion => {
+                        let value = match event.get_value() {
+                            InputValue::Touch {
+                                index,
+                                is_touching,
+                                pressure,
+                                x,
+                                y,
+                            } => TouchValue {
+                                index: Integer::from_primitive(index),
+                                is_touching,
+                                pressure: pressure
+                                    .map(|p| (p * u8::MAX as f64) as u8)
+                                    .unwrap_or(u8::MAX),
+                                x: x.map(|x| (x * u16::MAX as f64) as u16).unwrap_or(0),
+                                y: y.map(|y| (y * u16::MAX as f64) as u16).unwrap_or(0),
+                            },
+                            _ => {
+                                return Self::default();
+                            }
+                        };
+                        let value = ValueUpdate::Touch(value);
+
+                        Self { capability, value }
+                    }
+                    Touch::Button(_) => {
+                        let value = match event.get_value() {
+                            InputValue::Bool(value) => BoolUpdate { value },
+                            InputValue::Float(value) => BoolUpdate { value: value > 0.5 },
+                            _ => {
+                                // Cannot convert other values to bool
+                                return Self::default();
+                            }
+                        };
+                        let value = ValueUpdate::Bool(value);
+
+                        Self { capability, value }
+                    }
+                },
+                Touchpad::RightPad(pad) => match pad {
+                    Touch::Motion => {
+                        let value = match event.get_value() {
+                            InputValue::Touch {
+                                index,
+                                is_touching,
+                                pressure,
+                                x,
+                                y,
+                            } => TouchValue {
+                                index: Integer::from_primitive(index),
+                                is_touching,
+                                pressure: pressure
+                                    .map(|p| (p * u8::MAX as f64) as u8)
+                                    .unwrap_or(u8::MAX),
+                                x: x.map(|x| (x * u16::MAX as f64) as u16).unwrap_or(0),
+                                y: y.map(|y| (y * u16::MAX as f64) as u16).unwrap_or(0),
+                            },
+                            _ => {
+                                return Self::default();
+                            }
+                        };
+                        let value = ValueUpdate::Touch(value);
+
+                        Self { capability, value }
+                    }
+                    Touch::Button(_) => {
+                        let value = match event.get_value() {
+                            InputValue::Bool(value) => BoolUpdate { value },
+                            InputValue::Float(value) => BoolUpdate { value: value > 0.5 },
+                            _ => {
+                                // Cannot convert other values to bool
+                                return Self::default();
+                            }
+                        };
+                        let value = ValueUpdate::Bool(value);
+
+                        Self { capability, value }
+                    }
+                },
+                Touchpad::CenterPad(pad) => match pad {
+                    Touch::Motion => {
+                        let value = match event.get_value() {
+                            InputValue::Touch {
+                                index,
+                                is_touching,
+                                pressure,
+                                x,
+                                y,
+                            } => TouchValue {
+                                index: Integer::from_primitive(index),
+                                is_touching,
+                                pressure: pressure
+                                    .map(|p| (p * u8::MAX as f64) as u8)
+                                    .unwrap_or(u8::MAX),
+                                x: x.map(|x| (x * u16::MAX as f64) as u16).unwrap_or(0),
+                                y: y.map(|y| (y * u16::MAX as f64) as u16).unwrap_or(0),
+                            },
+                            _ => {
+                                return Self::default();
+                            }
+                        };
+                        let value = ValueUpdate::Touch(value);
+
+                        Self { capability, value }
+                    }
+                    Touch::Button(_) => {
+                        let value = match event.get_value() {
+                            InputValue::Bool(value) => BoolUpdate { value },
+                            InputValue::Float(value) => BoolUpdate { value: value > 0.5 },
+                            _ => {
+                                // Cannot convert other values to bool
+                                return Self::default();
+                            }
+                        };
+                        let value = ValueUpdate::Bool(value);
+
+                        Self { capability, value }
+                    }
+                },
+            },
+            Capability::Touchscreen(_) => Self::default(),
+        }
+    }
+}
+
+/// Implementation to convert an InputPlumber [Capability] into Unified Controller [InputCapability]
+impl From<Capability> for InputCapability {
+    fn from(capability: Capability) -> Self {
+        // TODO: Finish implementing this
+        match capability {
+            Capability::None => Self::default(),
+            Capability::NotImplemented => Self::default(),
+            Capability::Sync => Self::default(),
+            Capability::DBus(_) => Self::default(),
+            Capability::Gamepad(gamepad) => match gamepad {
+                Gamepad::Button(button) => match button {
+                    GamepadButton::South => Self::GamepadButtonSouth,
+                    GamepadButton::East => Self::GamepadButtonEast,
+                    GamepadButton::North => Self::GamepadButtonNorth,
+                    GamepadButton::West => Self::GamepadButtonWest,
+                    GamepadButton::Start => Self::GamepadButtonStart,
+                    GamepadButton::Select => Self::GamepadButtonSelect,
+                    GamepadButton::Guide => Self::GamepadButtonGuide,
+                    GamepadButton::QuickAccess => Self::GamepadButtonQuick,
+                    GamepadButton::QuickAccess2 => Self::GamepadButtonQuick2,
+                    GamepadButton::Keyboard => Self::GamepadButtonKeyboard,
+                    GamepadButton::Screenshot => Self::GamepadButtonScreenshot,
+                    GamepadButton::Mute => Self::GamepadButtonMute,
+                    GamepadButton::DPadUp => Self::GamepadButtonDpadUp,
+                    GamepadButton::DPadDown => Self::GamepadButtonDpadDown,
+                    GamepadButton::DPadLeft => Self::GamepadButtonDpadLeft,
+                    GamepadButton::DPadRight => Self::GamepadButtonDpadRight,
+                    GamepadButton::LeftBumper => Self::GamepadButtonLeftBumper,
+                    GamepadButton::LeftTop => Self::default(),
+                    GamepadButton::LeftTrigger => Self::GamepadButtonLeftTrigger,
+                    GamepadButton::LeftPaddle1 => Self::GamepadButtonLeftPaddle1,
+                    GamepadButton::LeftPaddle2 => Self::GamepadButtonLeftPaddle2,
+                    GamepadButton::LeftPaddle3 => Self::GamepadButtonLeftPaddle3,
+                    GamepadButton::LeftStick => Self::GamepadButtonLeftStick,
+                    GamepadButton::LeftStickTouch => Self::GamepadButtonLeftStickTouch,
+                    GamepadButton::RightBumper => Self::GamepadButtonRightBumper,
+                    GamepadButton::RightTop => Self::default(),
+                    GamepadButton::RightTrigger => Self::GamepadButtonRightTrigger,
+                    GamepadButton::RightPaddle1 => Self::GamepadButtonRightPaddle1,
+                    GamepadButton::RightPaddle2 => Self::GamepadButtonRightPaddle2,
+                    GamepadButton::RightPaddle3 => Self::GamepadButtonRightPaddle3,
+                    GamepadButton::RightStick => Self::GamepadButtonRightStick,
+                    GamepadButton::RightStickTouch => Self::GamepadButtonRightStickTouch,
+                },
+                Gamepad::Axis(axis) => match axis {
+                    GamepadAxis::LeftStick => Self::GamepadAxisLeftStick,
+                    GamepadAxis::RightStick => Self::GamepadAxisRightStick,
+                    GamepadAxis::Hat0 => Self::default(),
+                    GamepadAxis::Hat1 => Self::default(),
+                    GamepadAxis::Hat2 => Self::default(),
+                    GamepadAxis::Hat3 => Self::default(),
+                },
+                Gamepad::Trigger(trigger) => match trigger {
+                    GamepadTrigger::LeftTrigger => Self::GamepadTriggerLeft,
+                    GamepadTrigger::LeftTouchpadForce => Self::GamepadTriggerLeftTouchpadForce,
+                    GamepadTrigger::LeftStickForce => Self::GamepadTriggerLeftStickForce,
+                    GamepadTrigger::RightTrigger => Self::GamepadTriggerRight,
+                    GamepadTrigger::RightTouchpadForce => Self::GamepadTriggerRightTouchpadForce,
+                    GamepadTrigger::RightStickForce => Self::GamepadTriggerRightStickForce,
+                },
+                Gamepad::Accelerometer => Self::GamepadAccelerometerCenter,
+                Gamepad::Gyro => Self::GamepadGyroCenter,
+            },
+            Capability::Mouse(_) => Self::default(),
+            Capability::Keyboard(_) => Self::default(),
+            Capability::Touchpad(touchpad) => match touchpad {
+                Touchpad::LeftPad(pad) => match pad {
+                    Touch::Motion => Self::TouchpadLeftMotion,
+                    Touch::Button(_) => Self::TouchpadLeftButton,
+                },
+                Touchpad::RightPad(pad) => match pad {
+                    Touch::Motion => Self::TouchpadRightMotion,
+                    Touch::Button(_) => Self::TouchpadRightButton,
+                },
+                Touchpad::CenterPad(pad) => match pad {
+                    Touch::Motion => Self::TouchpadCenterMotion,
+                    Touch::Button(_) => Self::TouchpadCenterButton,
+                },
+            },
+            Capability::Touchscreen(_) => Self::default(),
+        }
+    }
+}
+
+/// Implementation to convert an InputPlumber [Capability] into [InputCapabilityInfo]
+impl From<Capability> for InputCapabilityInfo {
+    // TODO: Finish implementing this
+    fn from(value: Capability) -> Self {
+        let capability = value.clone().into();
+        match value {
+            Capability::None => Self::default(),
+            Capability::NotImplemented => Self::default(),
+            Capability::Sync => Self::default(),
+            Capability::DBus(_) => Self::default(),
+            Capability::Gamepad(gamepad) => match gamepad {
+                Gamepad::Button(_) => Self::new(capability, ValueType::Bool),
+                Gamepad::Axis(_) => Self::new(capability, ValueType::UInt16Vector2),
+                Gamepad::Trigger(_) => Self::new(capability, ValueType::UInt8),
+                Gamepad::Accelerometer => Self::new(capability, ValueType::Int16Vector3),
+                Gamepad::Gyro => Self::new(capability, ValueType::Int16Vector3),
+            },
+            Capability::Mouse(_) => Self::default(),
+            Capability::Keyboard(_) => Self::default(),
+            Capability::Touchpad(touchpad) => match touchpad {
+                Touchpad::LeftPad(pad) => match pad {
+                    Touch::Motion => Self::new(capability, ValueType::Touch),
+                    Touch::Button(_) => Self::new(capability, ValueType::Bool),
+                },
+                Touchpad::RightPad(pad) => match pad {
+                    Touch::Motion => Self::new(capability, ValueType::Touch),
+                    Touch::Button(_) => Self::new(capability, ValueType::Bool),
+                },
+                Touchpad::CenterPad(pad) => match pad {
+                    Touch::Motion => Self::new(capability, ValueType::Touch),
+                    Touch::Button(_) => Self::new(capability, ValueType::Bool),
+                },
+            },
+            Capability::Touchscreen(touch) => match touch {
+                Touch::Motion => Self::new(capability, ValueType::Touch),
+                Touch::Button(_) => Self::new(capability, ValueType::Bool),
+            },
+        }
+    }
+}


### PR DESCRIPTION
This change adds the Unified Controller as defined by the [Unified Controller Input Spec](https://github.com/ShadowBlip/UnifiedControllerInputSpec). If used as a target device, it will create a virtual hidraw interface that will send input reports based on the source device capabilities.