### PR TITLE
fix(evdev) Add in missing mapping for evdev keycodes to capabilities

### DIFF
--- a/rootfs/usr/share/inputplumber/schema/capability_map_v1.json
+++ b/rootfs/usr/share/inputplumber/schema/capability_map_v1.json
@@ -47,10 +47,10 @@
         "name": {
           "type": "string"
         },
-        "source_event": {
+        "target_event": {
           "$ref": "#/definitions/Event"
         },
-        "target_events": {
+        "source_events": {
           "type": "array",
           "items": {
             "$ref": "#/definitions/Event"
@@ -59,8 +59,8 @@
       },
       "required": [
         "name",
-        "source_event",
-        "target_events"
+        "source_events",
+        "target_event"
       ]
     },
     "Event": {

--- a/src/input/event/evdev.rs
+++ b/src/input/event/evdev.rs
@@ -160,6 +160,12 @@ impl EvdevEvent {
                 KeyCode::BTN_START => Capability::Gamepad(Gamepad::Button(GamepadButton::Start)),
                 KeyCode::BTN_SELECT => Capability::Gamepad(Gamepad::Button(GamepadButton::Select)),
                 KeyCode::BTN_MODE => Capability::Gamepad(Gamepad::Button(GamepadButton::Guide)),
+                KeyCode::BTN_TRIGGER_HAPPY5 => Capability::Gamepad(Gamepad::Button(GamepadButton::RightPaddle1)),
+                KeyCode::BTN_TRIGGER_HAPPY6 => Capability::Gamepad(Gamepad::Button(GamepadButton::RightPaddle2)),
+                KeyCode::BTN_TRIGGER_HAPPY7 => Capability::Gamepad(Gamepad::Button(GamepadButton::LeftPaddle1)),
+                KeyCode::BTN_TRIGGER_HAPPY8 => Capability::Gamepad(Gamepad::Button(GamepadButton::LeftPaddle2)),
+                KeyCode::BTN_TRIGGER_HAPPY9 => Capability::Gamepad(Gamepad::Button(GamepadButton::RightPaddle3)),
+                KeyCode::BTN_TRIGGER_HAPPY10 => Capability::Gamepad(Gamepad::Button(GamepadButton::LeftPaddle3)),
                 KeyCode::BTN_THUMBL => {
                     Capability::Gamepad(Gamepad::Button(GamepadButton::LeftStick))
                 }


### PR DESCRIPTION
`event_codes_from_capability` already has capability -> keycodes, just adding the missing keycodes -> capability

Additionally fix the capability map schema to match the Config code and the existing capability maps.