### PR TITLE
feat(CLI): add input testing menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +248,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +402,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +446,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.5.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -418,6 +513,12 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "either"
@@ -547,22 +648,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
-name = "futures-core"
-version = "0.3.30"
+name = "futures"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -575,6 +718,47 @@ dependencies = [
  "futures-io",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -629,6 +813,11 @@ name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -700,6 +889,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -718,6 +913,12 @@ dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
 ]
+
+[[package]]
+name = "indoc"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "industrial-io"
@@ -761,6 +962,7 @@ dependencies = [
  "clap_complete",
  "env_logger",
  "evdev",
+ "futures",
  "glob-match",
  "hidapi",
  "industrial-io",
@@ -771,6 +973,7 @@ dependencies = [
  "packed_struct",
  "procfs",
  "rand",
+ "ratatui",
  "serde",
  "serde_yaml",
  "tabled",
@@ -782,6 +985,20 @@ dependencies = [
  "xdg",
  "zbus",
  "zbus_macros",
+]
+
+[[package]]
+name = "instability"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac48900be4ab1c0dd6f1c2553d86ef371eda69c52b97ffd22af3e4f0a1771eb8"
+dependencies = [
+ "darling",
+ "indoc",
+ "pretty_assertions",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -819,9 +1036,9 @@ checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -900,6 +1117,15 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.2",
+]
 
 [[package]]
 name = "memchr"
@@ -1075,7 +1301,7 @@ dependencies = [
  "ansitok",
  "bytecount",
  "fnv",
- "unicode-width",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -1108,6 +1334,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1136,6 +1368,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "proc-macro-crate"
@@ -1249,6 +1491,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.5.0",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1573,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -1374,6 +1643,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1392,6 +1682,15 @@ dependencies = [
  "log",
  "time",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "slab"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1440,6 +1739,28 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.98",
+]
 
 [[package]]
 name = "syn"
@@ -1701,6 +2022,29 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2049,6 +2393,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zbus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ libiio = "*"
 libevdev = "*"
 
 [dependencies]
-clap = { version = "4.5.29", features = ["derive"] }
+clap = { version = "4.5.29", features = ["derive", "string"] }
 clap_complete = "4.5.44"
 env_logger = "0.11.6"
 evdev = { git = "https://github.com/emberian/evdev.git", features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ env_logger = "0.11.6"
 evdev = { git = "https://github.com/emberian/evdev.git", features = [
   "tokio",
 ], rev = "42b58ee08508b7799322a13bf89121a1d29cf0a2" }
+futures = "0.3.31"
 glob-match = "0.2.1"
 hidapi = "2.6.3"
 industrial-io = "0.6.0"
@@ -45,6 +46,7 @@ nix = { version = "0.29.0", features = ["fs"] }
 packed_struct = "0.10.1"
 procfs = "0.17.0"
 rand = "0.9.0"
+ratatui = "0.29.0"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_yaml = "0.9.34"
 tabled = { version = "0.18.0", features = ["ansi"] }

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ target/release/$(NAME): $(ALL_RS) Cargo.lock
 all: build debug ## Build release and debug builds
 
 .PHONY: run
-run: setup debug ## Build and run
+run: debug ## Build and run
 	sudo LOG_LEVEL=$(LOG_LEVEL) ./target/debug/$(NAME)
 
 .PHONY: clean

--- a/rootfs/usr/share/inputplumber/profiles/debug.yaml
+++ b/rootfs/usr/share/inputplumber/profiles/debug.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/device_profile_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: DeviceProfile
+
+# Name of the device profile
+name: Debug
+
+# Profile mappings
+mapping: []

--- a/src/cli/device.rs
+++ b/src/cli/device.rs
@@ -12,7 +12,6 @@ use crate::dbus::interface::composite_device::CompositeDeviceInterfaceProxy;
 use crate::dbus::interface::manager::ManagerInterfaceProxy;
 
 use super::ui::menu::device_test_menu::DeviceTestMenu;
-use super::ui::menu::Menu;
 use super::ui::TextUserInterface;
 
 #[derive(Subcommand, Debug, Clone)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,7 @@
 pub mod device;
 pub mod source;
 pub mod target;
+pub mod ui;
 
 use std::error::Error;
 

--- a/src/cli/ui.rs
+++ b/src/cli/ui.rs
@@ -1,0 +1,145 @@
+pub mod menu;
+pub mod widgets;
+
+use menu::{Menu, MenuWidget};
+use ratatui::{
+    buffer::Buffer,
+    crossterm::event::{self, Event, KeyEvent, KeyEventKind},
+    layout::Rect,
+    widgets::Widget,
+    Frame,
+};
+use std::{error::Error, io, time::Duration};
+
+/// InterfaceCommands are used to allow menus to communicate with the user interface
+pub enum InterfaceCommand {
+    /// Exit the interface
+    Quit,
+    /// Replace the current menu with the given menu
+    #[allow(dead_code)]
+    ReplaceMenu(Menu),
+    /// Push the given menu to the menu stack
+    #[allow(dead_code)]
+    PushMenu(Menu),
+    /// Pop the current menu from the menu stack
+    #[allow(dead_code)]
+    PopMenu,
+}
+
+/// The [Tui] is a text-based user interface for interacting with InputPlumber
+#[derive(Debug, Default)]
+pub struct TextUserInterface {
+    exit: bool,
+    current_menu: Option<Menu>,
+    menu_stack: Vec<Menu>,
+}
+
+impl TextUserInterface {
+    /// Create a new instance of the TUI
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Replace the current menu with the given menu
+    pub fn replace_menu(&mut self, menu: Menu) {
+        self.current_menu = Some(menu);
+    }
+
+    /// Switch to the given menu
+    pub fn push_menu(&mut self, menu: Menu) {
+        let last_menu = self.current_menu.take();
+        self.current_menu = Some(menu);
+        if let Some(last_menu) = last_menu {
+            self.menu_stack.push(last_menu);
+        }
+    }
+
+    /// Pop the current menu from the stack
+    pub fn pop_menu(&mut self) {
+        self.current_menu = self.menu_stack.pop();
+        if self.current_menu.is_none() {
+            self.exit = true;
+        }
+    }
+
+    /// Run the text interface
+    pub fn run(&mut self, menu: Menu) -> Result<(), Box<dyn Error>> {
+        self.current_menu = Some(menu);
+        let mut terminal = ratatui::init();
+        while !self.exit {
+            self.handle_events()?;
+            self.update();
+            terminal.draw(|frame| self.draw(frame))?;
+        }
+
+        ratatui::restore();
+        Ok(())
+    }
+
+    /// Update all menus
+    fn update(&mut self) {
+        let Some(menu) = self.current_menu.as_mut() else {
+            return;
+        };
+        let mut commands = menu.update();
+        for menu in self.menu_stack.iter_mut() {
+            commands.extend(menu.update());
+        }
+        self.handle_commands(commands);
+    }
+
+    /// Draw a frame to the terminal
+    fn draw(&self, frame: &mut Frame) {
+        frame.render_widget(self, frame.area());
+    }
+
+    /// Handle menu commands
+    fn handle_commands(&mut self, commands: Vec<InterfaceCommand>) {
+        for cmd in commands {
+            match cmd {
+                InterfaceCommand::Quit => self.exit = true,
+                InterfaceCommand::ReplaceMenu(menu) => self.replace_menu(menu),
+                InterfaceCommand::PushMenu(menu) => self.push_menu(menu),
+                InterfaceCommand::PopMenu => self.pop_menu(),
+            }
+        }
+    }
+
+    /// Updates the application's state based on user input
+    fn handle_events(&mut self) -> io::Result<()> {
+        // Poll for events
+        if !event::poll(Duration::from_millis(50))? {
+            return Ok(());
+        }
+        match event::read()? {
+            // it's important to check that the event is a key press event as
+            // crossterm also emits key release and repeat events on Windows.
+            Event::Key(key_event) if key_event.kind == KeyEventKind::Press => {
+                self.handle_key_event(key_event)
+            }
+            _ => {}
+        };
+        Ok(())
+    }
+
+    /// Handles key input to the terminal
+    fn handle_key_event(&mut self, key_event: KeyEvent) {
+        let Some(menu) = self.current_menu.as_mut() else {
+            return;
+        };
+        let commands = menu.handle_key_event(key_event);
+        self.handle_commands(commands);
+    }
+}
+
+impl Widget for &TextUserInterface {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let Some(menu) = self.current_menu.as_ref() else {
+            return;
+        };
+        for menu in self.menu_stack.iter() {
+            menu.render(area, buf);
+        }
+        menu.render(area, buf);
+    }
+}

--- a/src/cli/ui/menu.rs
+++ b/src/cli/ui/menu.rs
@@ -1,0 +1,60 @@
+pub mod device_test_menu;
+
+use device_test_menu::DeviceTestMenu;
+use ratatui::{
+    crossterm::event::{KeyCode, KeyEvent},
+    prelude::{Buffer, Rect},
+    widgets::Widget,
+};
+
+use super::InterfaceCommand;
+
+/// A [MenuWidget] is a [Widget] that can also handle key input
+pub trait MenuWidget {
+    fn update(&mut self) -> Vec<InterfaceCommand> {
+        vec![]
+    }
+    fn handle_key_event(&mut self, key_event: KeyEvent) -> Vec<InterfaceCommand> {
+        match key_event.code {
+            KeyCode::Char('q') => vec![InterfaceCommand::Quit],
+            _ => vec![],
+        }
+    }
+}
+
+/// Enumeration of all available menus
+#[derive(Debug)]
+pub enum Menu {
+    DeviceTest(DeviceTestMenu),
+}
+
+impl Widget for &Menu {
+    fn render(self, area: Rect, buf: &mut Buffer)
+    where
+        Self: Sized,
+    {
+        match self {
+            Menu::DeviceTest(device_test_menu) => device_test_menu.render(area, buf),
+        }
+    }
+}
+
+impl MenuWidget for Menu {
+    fn update(&mut self) -> Vec<InterfaceCommand> {
+        match self {
+            Menu::DeviceTest(device_test_menu) => device_test_menu.update(),
+        }
+    }
+
+    fn handle_key_event(&mut self, key_event: KeyEvent) -> Vec<InterfaceCommand> {
+        match self {
+            Menu::DeviceTest(device_test_menu) => device_test_menu.handle_key_event(key_event),
+        }
+    }
+}
+
+impl From<DeviceTestMenu> for Menu {
+    fn from(value: DeviceTestMenu) -> Self {
+        Self::DeviceTest(value)
+    }
+}

--- a/src/cli/ui/menu/device_test_menu.rs
+++ b/src/cli/ui/menu/device_test_menu.rs
@@ -1,0 +1,610 @@
+use std::{error::Error, i16, time::Duration};
+
+use futures::StreamExt;
+use packed_struct::PackedStruct;
+use ratatui::{
+    crossterm::event::KeyCode,
+    layout::{Constraint, Direction, Layout},
+    prelude::*,
+    symbols::border,
+    text::{Line, Text},
+    widgets::{
+        canvas::{Canvas, Circle},
+        Block, Gauge, Paragraph, Widget,
+    },
+};
+use tokio::sync::mpsc;
+use zbus::Connection;
+
+use crate::{
+    cli::ui::{
+        widgets::{
+            axis_gauge::AxisGauge, button_gauge::ButtonGauge, gyro_gauge::GyroGauge,
+            touch_gauge::TouchGauge, trigger_gauge::TriggerGauge,
+        },
+        InterfaceCommand,
+    },
+    dbus::interface::{
+        composite_device::CompositeDeviceInterfaceProxy,
+        target::{
+            debug::{TargetDebugInterface, TargetDebugInterfaceProxy},
+            TargetInterfaceProxy,
+        },
+    },
+    drivers::unified_gamepad::{
+        capability::InputCapability,
+        reports::{
+            input_capability_report::InputCapabilityReport, input_data_report::InputDataReport,
+            ValueType,
+        },
+        value::Value,
+    },
+    input::target::TargetDeviceTypeId,
+};
+
+use super::{Menu, MenuWidget};
+
+/// Menu for testing an input device
+#[derive(Debug)]
+pub struct DeviceTestMenu {
+    conn: Connection,
+    capability_report: Option<InputCapabilityReport>,
+    rx_reports: mpsc::Receiver<Vec<u8>>,
+    rx_capabilities: mpsc::Receiver<Vec<u8>>,
+    device_path: String,
+    target_device_types: Vec<TargetDeviceTypeId>,
+    intercept_mode: u32,
+    ui_buttons: Vec<ButtonGauge>,
+    ui_triggers: Vec<TriggerGauge>,
+    ui_axes: Vec<AxisGauge>,
+    ui_gyro: Vec<GyroGauge>,
+    ui_touch: Vec<TouchGauge>,
+}
+
+impl DeviceTestMenu {
+    pub async fn new(conn: &Connection, dbus_path: &str) -> Result<Self, Box<dyn Error>> {
+        // Get a reference to the device to debug
+        let device = CompositeDeviceInterfaceProxy::builder(conn)
+            .path(dbus_path.to_string())?
+            .build()
+            .await?;
+
+        // Save the current target devices used so they can be restored
+        let mut target_device_types = vec![];
+        let target_devices = device.target_devices().await?;
+        for path in target_devices {
+            let target_device = TargetInterfaceProxy::builder(conn)
+                .path(path)?
+                .build()
+                .await?;
+            let device_type = target_device.device_type().await?;
+            let device_type = TargetDeviceTypeId::try_from(device_type.as_str()).unwrap();
+            target_device_types.push(device_type);
+        }
+
+        // Save the current intercept mode so it can be restored
+        let intercept_mode = device.intercept_mode().await?;
+
+        // Add the debug target device if it does not exist
+        if !target_device_types.iter().any(|t| t.as_str() == "debug") {
+            let mut target_devices = vec!["debug".into()];
+            for kind in target_device_types.iter() {
+                target_devices.push(kind.as_str().to_string());
+            }
+            device.set_target_devices(target_devices).await?;
+        }
+
+        // Disable intercept mode
+        if intercept_mode != 0 {
+            device.set_intercept_mode(0).await?;
+        }
+
+        // Create channels to listen for input reports
+        let (tx_reports, rx_reports) = mpsc::channel(2048);
+        let (tx_capabilities, rx_capabilities) = mpsc::channel(16);
+
+        // Spawn a task to listen for input reports
+        let conn_clone = conn.clone();
+        let path_clone = dbus_path.to_string();
+        tokio::task::spawn(async move {
+            let _ = Self::listen_for_signals(&conn_clone, path_clone, tx_reports, tx_capabilities)
+                .await;
+        });
+
+        Ok(Self {
+            conn: conn.clone(),
+            device_path: dbus_path.to_string(),
+            rx_reports,
+            rx_capabilities,
+            capability_report: None,
+            target_device_types,
+            intercept_mode,
+            ui_buttons: Default::default(),
+            ui_triggers: Default::default(),
+            ui_axes: Default::default(),
+            ui_gyro: Default::default(),
+            ui_touch: Default::default(),
+        })
+    }
+}
+
+impl DeviceTestMenu {
+    /// Listen for device signals over dbus
+    async fn listen_for_signals(
+        conn: &Connection,
+        dbus_path: String,
+        tx_reports: mpsc::Sender<Vec<u8>>,
+        tx_capabilities: mpsc::Sender<Vec<u8>>,
+    ) -> Result<(), Box<dyn Error>> {
+        // Get a reference to the device to debug
+        let device = CompositeDeviceInterfaceProxy::builder(conn)
+            .path(dbus_path.to_string())?
+            .build()
+            .await?;
+
+        // Wait until the debug target is available
+        let mut debug_target_path = None;
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let target_devices = device.target_devices().await?;
+            for path in target_devices {
+                if !path.contains("/debug") {
+                    continue;
+                }
+                debug_target_path = Some(path);
+            }
+            if debug_target_path.is_some() {
+                break;
+            }
+        }
+        let Some(target_path) = debug_target_path else {
+            panic!("Failed to find target debug device!");
+        };
+
+        // Get a reference to the debug target device
+        let debug_device = TargetDebugInterfaceProxy::builder(conn)
+            .path(target_path)
+            .unwrap()
+            .build()
+            .await?;
+
+        // Get the current capability report
+        let capability_report = debug_device.input_capability_report().await?;
+        tx_capabilities.send(capability_report).await?;
+
+        // Listen for input reports
+        let mut receive_report = debug_device.receive_input_report().await?;
+        tokio::task::spawn(async move {
+            while let Some(signal) = receive_report.next().await {
+                let args = signal.args().unwrap();
+                tx_reports.send(args.data).await.unwrap();
+            }
+        });
+
+        // Listen for capability changes
+        let mut receive_caps = debug_device.receive_input_capability_report_changed().await;
+        tokio::task::spawn(async move {
+            while let Some(change) = receive_caps.next().await {
+                let value = change.get().await.unwrap();
+                tx_capabilities.send(value).await.unwrap();
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Render all the buttons for the device in the given area
+    fn render_buttons(&self, area: Rect, buf: &mut Buffer) {
+        // Create a block for the buttons
+        let block = Block::bordered()
+            .title("Buttons")
+            .border_set(border::ROUNDED)
+            .border_style(Style::new().green());
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        // Define the grid for the buttons
+        let cells = create_grid(inside_block, 5, 9);
+
+        // Render each gauge
+        for (btn, area) in self.ui_buttons.iter().zip(cells.iter()) {
+            btn.render(*area, buf);
+        }
+    }
+
+    fn render_triggers(&self, area: Rect, buf: &mut Buffer) {
+        // Create a block
+        let block = Block::bordered()
+            .title("Triggers")
+            .border_set(border::ROUNDED)
+            .border_style(Style::new().yellow());
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        // Define the grid for the widgets
+        let cells = create_grid(inside_block, 4, 2);
+
+        // Render each gauge
+        for (widget, area) in self.ui_triggers.iter().zip(cells.iter()) {
+            widget.render(*area, buf);
+        }
+    }
+
+    fn render_axes(&self, area: Rect, buf: &mut Buffer) {
+        // Create a block
+        let block = Block::bordered()
+            .title("Axes")
+            .border_set(border::ROUNDED)
+            .border_style(Style::new().yellow());
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        // Define the grid for the buttons
+        let cells = create_grid(inside_block, 1, 2);
+
+        // Render each widget
+        for (widget, area) in self.ui_axes.iter().zip(cells.iter()) {
+            widget.render(*area, buf);
+        }
+    }
+
+    fn render_gyro(&self, area: Rect, buf: &mut Buffer) {
+        // Create a block
+        let block = Block::bordered()
+            .title("Gyro")
+            .border_set(border::ROUNDED)
+            .border_style(Style::new().blue());
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        let cells = create_grid(inside_block, 1, 2);
+
+        // Render each gauge
+        for (widget, area) in self.ui_gyro.iter().zip(cells.iter()) {
+            widget.render(*area, buf);
+        }
+    }
+
+    fn render_touch(&self, area: Rect, buf: &mut Buffer) {
+        // Create a block
+        let block = Block::bordered()
+            .title("Touch")
+            .border_set(border::ROUNDED)
+            .border_style(Style::new().red());
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        // Define the grid for the widgets
+        let cells = create_grid(inside_block, 1, 2);
+
+        // Render each gauge
+        for (widget, area) in self.ui_touch.iter().zip(cells.iter()) {
+            widget.render(*area, buf);
+        }
+    }
+}
+
+impl MenuWidget for DeviceTestMenu {
+    fn update(&mut self) -> Vec<InterfaceCommand> {
+        if self.rx_capabilities.is_closed() || self.rx_reports.is_closed() {
+            return vec![InterfaceCommand::Quit];
+        }
+
+        // Check for capability report updates
+        let mut capabilities_updated = false;
+        while !self.rx_capabilities.is_empty() {
+            let Some(data) = self.rx_capabilities.blocking_recv() else {
+                return vec![InterfaceCommand::Quit];
+            };
+            self.capability_report = InputCapabilityReport::unpack(data.as_slice()).ok();
+            capabilities_updated = true;
+        }
+
+        // Update the UI if capabilities have been updated
+        if capabilities_updated {
+            // Clear the old UI elements
+            self.ui_buttons.clear();
+            self.ui_triggers.clear();
+            self.ui_axes.clear();
+            self.ui_gyro.clear();
+            self.ui_touch.clear();
+
+            for cap in self.capability_report.as_ref().unwrap().get_capabilities() {
+                match cap.value_type {
+                    ValueType::None => (),
+                    ValueType::Bool => {
+                        let label = format!("{:?}", cap.capability);
+                        let button = ButtonGauge::new(label.as_str());
+                        self.ui_buttons.push(button);
+                    }
+                    ValueType::UInt8 => {
+                        let label = format!("{:?}", cap.capability);
+                        let trigger = TriggerGauge::new(label.as_str());
+                        self.ui_triggers.push(trigger);
+                    }
+                    ValueType::UInt16 => {
+                        let label = format!("{:?}", cap.capability);
+                        let trigger = TriggerGauge::new(label.as_str());
+                        self.ui_triggers.push(trigger);
+                    }
+                    ValueType::UInt16Vector2 => match cap.capability {
+                        InputCapability::GamepadAxisLeftStick
+                        | InputCapability::GamepadAxisRightStick => {
+                            let label = format!("{:?}", cap.capability);
+                            let gauge = AxisGauge::new(label.as_str());
+                            self.ui_axes.push(gauge);
+                        }
+                        // Assume touch for everything else
+                        _ => {
+                            let label = format!("{:?}", cap.capability);
+                            let gauge = TouchGauge::new(label.as_str());
+                            self.ui_touch.push(gauge);
+                        }
+                    },
+                    ValueType::Int16Vector3 => {
+                        let label = format!("{:?}", cap.capability);
+                        let gauge = GyroGauge::new(label.as_str());
+                        self.ui_gyro.push(gauge);
+                    }
+                    ValueType::Touch => {
+                        let label = format!("{:?}", cap.capability);
+                        let gauge = TouchGauge::new(label.as_str());
+                        self.ui_touch.push(gauge);
+                    }
+                }
+            }
+        }
+
+        // Check for input reports
+        let mut state_bytes = None;
+        while !self.rx_reports.is_empty() {
+            let Some(data) = self.rx_reports.blocking_recv() else {
+                return vec![InterfaceCommand::Quit];
+            };
+            state_bytes = Some(data);
+        }
+        let Some(state_bytes) = state_bytes else {
+            return vec![];
+        };
+        let state_slice = state_bytes.as_slice().try_into().unwrap();
+        let state = InputDataReport::unpack(state_slice).unwrap();
+
+        // Use the capability report to decode the input report
+        let Some(capability_report) = self.capability_report.as_ref() else {
+            return vec![];
+        };
+        let values = capability_report.decode_data_report(&state).unwrap();
+
+        // Clear the old UI elements
+        self.ui_buttons.clear();
+        self.ui_triggers.clear();
+        self.ui_axes.clear();
+        self.ui_gyro.clear();
+        self.ui_touch.clear();
+
+        // Update the interface with the values
+        let capabilities = capability_report.get_capabilities();
+        for (cap, value) in capabilities.iter().zip(values.iter()) {
+            match value {
+                Value::None => (),
+                Value::Bool(value) => {
+                    let label = format!("{:?}", cap.capability);
+                    let mut button = ButtonGauge::new(label.as_str());
+                    button.set_value(value.value);
+                    self.ui_buttons.push(button);
+                }
+                Value::UInt8(value) => {
+                    let label = format!("{:?}", cap.capability);
+                    let mut trigger = TriggerGauge::new(label.as_str());
+                    trigger.set_value(value.value as f64 / u8::MAX as f64);
+                    self.ui_triggers.push(trigger);
+                }
+                Value::UInt16(value) => {
+                    let label = format!("{:?}", cap.capability);
+                    let mut trigger = TriggerGauge::new(label.as_str());
+                    trigger.set_value(value.value as f64 / u16::MAX as f64);
+                    self.ui_triggers.push(trigger);
+                }
+                Value::UInt16Vector2(value) => match cap.capability {
+                    InputCapability::GamepadAxisLeftStick
+                    | InputCapability::GamepadAxisRightStick => {
+                        let label = format!("{:?}", cap.capability);
+                        let mut gauge = AxisGauge::new(label.as_str());
+                        let (x, y) = {
+                            let x = value.x as f64 / u16::MAX as f64;
+                            // Convert from 0.0 - 1.0 to -1.0 - 1.0
+                            let x = 1.0 - (x * 2.0);
+                            let y = value.y as f64 / u16::MAX as f64;
+                            // Convert from 0.0 - 1.0 to -1.0 - 1.0
+                            let y = 1.0 - (y * 2.0);
+                            // X-axis is flipped?
+                            (-x, y)
+                        };
+                        gauge.set_value(x, y);
+                        self.ui_axes.push(gauge);
+                    }
+                    // Assume touch for everything else
+                    _ => {
+                        let label = format!("{:?}", cap.capability);
+                        let mut gauge = TouchGauge::new(label.as_str());
+                        let (x, y) = {
+                            let x = value.x as f64 / u16::MAX as f64;
+                            let y = value.y as f64 / u16::MAX as f64;
+                            (x, y)
+                        };
+                        gauge.set_value(x, y, true);
+                        self.ui_touch.push(gauge);
+                    }
+                },
+                Value::Int16Vector3(value) => {
+                    let label = format!("{:?}", cap.capability);
+                    let mut gauge = GyroGauge::new(label.as_str());
+                    //let x = value.x / i16::MAX;
+                    //let y = value.y / i16::MAX;
+                    //let z = value.z / i16::MAX;
+                    //gauge.set_value(x as f64, y as f64, z as f64);
+                    gauge.set_value(value.x as f64, value.y as f64, value.z as f64);
+                    self.ui_gyro.push(gauge);
+                }
+                Value::Touch(value) => {
+                    let label = format!("{:?}", cap.capability);
+                    let mut gauge = TouchGauge::new(label.as_str());
+                    let (x, y) = {
+                        let x = value.x as f64 / u16::MAX as f64;
+                        let y = value.y as f64 / u16::MAX as f64;
+                        (x, y)
+                    };
+                    gauge.set_value(x, y, value.is_touching);
+                    self.ui_touch.push(gauge);
+                }
+            }
+        }
+
+        vec![]
+    }
+
+    fn handle_key_event(
+        &mut self,
+        key_event: ratatui::crossterm::event::KeyEvent,
+    ) -> Vec<InterfaceCommand> {
+        let commands = match key_event.code {
+            KeyCode::Char('q') => vec![InterfaceCommand::Quit],
+            _ => vec![],
+        };
+        if commands.is_empty() {
+            return commands;
+        }
+
+        // Restore the state of the device
+        let conn = self.conn.clone();
+        let dbus_path = self.device_path.clone();
+        let target_device_types = self.target_device_types.clone();
+        let intercept_mode = self.intercept_mode;
+        tokio::task::spawn(async move {
+            // Restore the target devices of the device
+            let device = CompositeDeviceInterfaceProxy::builder(&conn)
+                .path(dbus_path)
+                .unwrap()
+                .build()
+                .await
+                .unwrap();
+            let target_devices = target_device_types
+                .clone()
+                .into_iter()
+                .map(|kind| kind.as_str().to_string())
+                .collect();
+            device.set_target_devices(target_devices).await.unwrap();
+
+            // Restore the intercept mode
+            device.set_intercept_mode(intercept_mode).await.unwrap();
+        });
+
+        // Wait a beat for the target devices to be restored
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        commands
+    }
+}
+
+impl Widget for &DeviceTestMenu {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        // Split the area into two parts vertically
+        let outer_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(area);
+
+        // Top layout
+        let top_layout = outer_layout[0];
+        self.render_buttons(top_layout, buf);
+
+        // Bottom layout
+        // Split into 2 parts
+        let bottom_layout = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![Constraint::Percentage(65), Constraint::Percentage(35)])
+            .split(outer_layout[1]);
+
+        // Bottom-left
+        // Split vertically
+        let bottom_left_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(bottom_layout[0]);
+        let axes_triggers_layout = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(bottom_left_layout[0]);
+        self.render_axes(axes_triggers_layout[0], buf);
+        self.render_triggers(axes_triggers_layout[1], buf);
+        self.render_gyro(bottom_left_layout[1], buf);
+
+        // Bottom-right
+        let bottom_right_layout = bottom_layout[1];
+        self.render_touch(bottom_right_layout, buf);
+
+        //let block = Block::bordered().title("Buttons").border_set(border::THICK);
+        //block.render(outer_layout[0], buf);
+
+        // Buttons, Triggers, Axes, Gyro/Accel, Touch
+
+        //let title = Line::from(" Counter App Tutorial ".bold());
+        //let instructions = Line::from(vec![
+        //    " Decrement ".into(),
+        //    "<Left>".blue().bold(),
+        //    " Increment ".into(),
+        //    "<Right>".blue().bold(),
+        //    " Quit ".into(),
+        //    "<Q> ".blue().bold(),
+        //]);
+        //let block = Block::bordered()
+        //    .title(title.centered())
+        //    .title_bottom(instructions.centered())
+        //    .border_set(border::THICK);
+
+        //let counter_text = Text::from(vec![Line::from(vec![
+        //    "Value: ".into(),
+        //    "1".to_string().yellow(),
+        //])]);
+
+        //// Create a layout for multiple gauges
+        //use Constraint::{Length, Min, Percentage, Ratio};
+        //let [area1, area2] = Layout::horizontal([Ratio(1, 2); 2]).areas(area);
+        //let mut button_gauge = ButtonGauge::new("A Button");
+        //button_gauge.set_value(true);
+        //button_gauge.render(area1, buf);
+
+        //let gauge = AxisGauge::new("Left Stick");
+        //gauge.render(area2, buf);
+
+        //Paragraph::new(counter_text)
+        //    .centered()
+        //    .block(block)
+        //    .render(area, buf);
+    }
+}
+
+/// Creates a grid with the given rows and columns for the given area
+fn create_grid(area: Rect, rows: u16, columns: u16) -> Vec<Rect> {
+    // Create the column areas
+    let constraints: Vec<Constraint> = (0..columns).map(|_| Constraint::Fill(1)).collect();
+    let column_areas = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints(constraints)
+        .split(area);
+
+    // Create the individual grid cell areas
+    let mut cells = Vec::with_capacity((rows * columns) as usize);
+    for column in column_areas.iter() {
+        let constraints: Vec<Constraint> = (0..rows).map(|_| Constraint::Fill(1)).collect();
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(constraints)
+            .split(*column);
+        for cell in rows.iter() {
+            cells.push(*cell);
+        }
+    }
+
+    cells
+}

--- a/src/cli/ui/menu/device_test_menu.rs
+++ b/src/cli/ui/menu/device_test_menu.rs
@@ -423,45 +423,52 @@ impl MenuWidget for DeviceTestMenu {
                     ValueType::None => (),
                     ValueType::Bool => {
                         let label = format!("{:?}", cap.capability);
-                        let button = ButtonGauge::new(label.as_str());
+                        let button = ButtonGauge::new(cap.capability, label.as_str());
                         self.ui_buttons.push(button);
                     }
                     ValueType::UInt8 => {
                         let label = format!("{:?}", cap.capability);
-                        let trigger = TriggerGauge::new(label.as_str());
+                        let trigger = TriggerGauge::new(cap.capability, label.as_str());
                         self.ui_triggers.push(trigger);
                     }
                     ValueType::UInt16 => {
                         let label = format!("{:?}", cap.capability);
-                        let trigger = TriggerGauge::new(label.as_str());
+                        let trigger = TriggerGauge::new(cap.capability, label.as_str());
                         self.ui_triggers.push(trigger);
                     }
                     ValueType::UInt16Vector2 => match cap.capability {
                         InputCapability::GamepadAxisLeftStick
                         | InputCapability::GamepadAxisRightStick => {
                             let label = format!("{:?}", cap.capability);
-                            let gauge = AxisGauge::new(label.as_str());
+                            let gauge = AxisGauge::new(cap.capability, label.as_str());
                             self.ui_axes.push(gauge);
                         }
                         // Assume touch for everything else
                         _ => {
                             let label = format!("{:?}", cap.capability);
-                            let gauge = TouchGauge::new(label.as_str());
+                            let gauge = TouchGauge::new(cap.capability, label.as_str());
                             self.ui_touch.push(gauge);
                         }
                     },
                     ValueType::Int16Vector3 => {
                         let label = format!("{:?}", cap.capability);
-                        let gauge = GyroGauge::new(label.as_str());
+                        let gauge = GyroGauge::new(cap.capability, label.as_str());
                         self.ui_gyro.push(gauge);
                     }
                     ValueType::Touch => {
                         let label = format!("{:?}", cap.capability);
-                        let gauge = TouchGauge::new(label.as_str());
+                        let gauge = TouchGauge::new(cap.capability, label.as_str());
                         self.ui_touch.push(gauge);
                     }
                 }
             }
+
+            // Sort each widget by their capability
+            self.ui_buttons.sort_by_key(|widget| widget.sort_value());
+            self.ui_triggers.sort_by_key(|widget| widget.sort_value());
+            self.ui_axes.sort_by_key(|widget| widget.sort_value());
+            self.ui_gyro.sort_by_key(|widget| widget.sort_value());
+            self.ui_touch.sort_by_key(|widget| widget.sort_value());
         }
 
         // Check for input reports
@@ -499,19 +506,19 @@ impl MenuWidget for DeviceTestMenu {
                 Value::None => (),
                 Value::Bool(value) => {
                     let label = format!("{:?}", cap.capability);
-                    let mut button = ButtonGauge::new(label.as_str());
+                    let mut button = ButtonGauge::new(cap.capability, label.as_str());
                     button.set_value(value.value);
                     self.ui_buttons.push(button);
                 }
                 Value::UInt8(value) => {
                     let label = format!("{:?}", cap.capability);
-                    let mut trigger = TriggerGauge::new(label.as_str());
+                    let mut trigger = TriggerGauge::new(cap.capability, label.as_str());
                     trigger.set_value(value.value as f64 / u8::MAX as f64);
                     self.ui_triggers.push(trigger);
                 }
                 Value::UInt16(value) => {
                     let label = format!("{:?}", cap.capability);
-                    let mut trigger = TriggerGauge::new(label.as_str());
+                    let mut trigger = TriggerGauge::new(cap.capability, label.as_str());
                     trigger.set_value(value.value as f64 / u16::MAX as f64);
                     self.ui_triggers.push(trigger);
                 }
@@ -519,7 +526,7 @@ impl MenuWidget for DeviceTestMenu {
                     InputCapability::GamepadAxisLeftStick
                     | InputCapability::GamepadAxisRightStick => {
                         let label = format!("{:?}", cap.capability);
-                        let mut gauge = AxisGauge::new(label.as_str());
+                        let mut gauge = AxisGauge::new(cap.capability, label.as_str());
                         let (x, y) = {
                             let x = value.x as f64 / u16::MAX as f64;
                             // Convert from 0.0 - 1.0 to -1.0 - 1.0
@@ -536,7 +543,7 @@ impl MenuWidget for DeviceTestMenu {
                     // Assume touch for everything else
                     _ => {
                         let label = format!("{:?}", cap.capability);
-                        let mut gauge = TouchGauge::new(label.as_str());
+                        let mut gauge = TouchGauge::new(cap.capability, label.as_str());
                         let (x, y) = {
                             let x = value.x as f64 / u16::MAX as f64;
                             let y = value.y as f64 / u16::MAX as f64;
@@ -548,7 +555,7 @@ impl MenuWidget for DeviceTestMenu {
                 },
                 Value::Int16Vector3(value) => {
                     let label = format!("{:?}", cap.capability);
-                    let mut gauge = GyroGauge::new(label.as_str());
+                    let mut gauge = GyroGauge::new(cap.capability, label.as_str());
                     //let x = value.x / i16::MAX;
                     //let y = value.y / i16::MAX;
                     //let z = value.z / i16::MAX;
@@ -558,7 +565,7 @@ impl MenuWidget for DeviceTestMenu {
                 }
                 Value::Touch(value) => {
                     let label = format!("{:?}", cap.capability);
-                    let mut gauge = TouchGauge::new(label.as_str());
+                    let mut gauge = TouchGauge::new(cap.capability, label.as_str());
                     let (x, y) = {
                         let x = value.x as f64 / u16::MAX as f64;
                         let y = value.y as f64 / u16::MAX as f64;
@@ -569,6 +576,13 @@ impl MenuWidget for DeviceTestMenu {
                 }
             }
         }
+
+        // Sort each widget by their capability
+        self.ui_buttons.sort_by_key(|widget| widget.sort_value());
+        self.ui_triggers.sort_by_key(|widget| widget.sort_value());
+        self.ui_axes.sort_by_key(|widget| widget.sort_value());
+        self.ui_gyro.sort_by_key(|widget| widget.sort_value());
+        self.ui_touch.sort_by_key(|widget| widget.sort_value());
 
         vec![]
     }

--- a/src/cli/ui/widgets.rs
+++ b/src/cli/ui/widgets.rs
@@ -1,0 +1,5 @@
+pub mod axis_gauge;
+pub mod button_gauge;
+pub mod gyro_gauge;
+pub mod touch_gauge;
+pub mod trigger_gauge;

--- a/src/cli/ui/widgets/axis_gauge.rs
+++ b/src/cli/ui/widgets/axis_gauge.rs
@@ -6,17 +6,21 @@ use ratatui::{
     },
 };
 
+use crate::drivers::unified_gamepad::capability::InputCapability;
+
 #[derive(Debug, Default)]
 pub struct AxisGauge {
+    capability: InputCapability,
     text: String,
     x: f64,
     y: f64,
 }
 
 impl AxisGauge {
-    pub fn new(text: &str) -> Self {
+    pub fn new(capability: InputCapability, text: &str) -> Self {
         Self {
             text: text.to_string(),
+            capability,
             x: 0.0,
             y: 0.0,
         }
@@ -25,6 +29,10 @@ impl AxisGauge {
     pub fn set_value(&mut self, x: f64, y: f64) {
         self.x = x;
         self.y = y;
+    }
+
+    pub fn sort_value(&self) -> u32 {
+        self.capability as u32
     }
 }
 

--- a/src/cli/ui/widgets/axis_gauge.rs
+++ b/src/cli/ui/widgets/axis_gauge.rs
@@ -1,0 +1,70 @@
+use ratatui::{
+    prelude::*,
+    widgets::{
+        canvas::{Canvas, Circle},
+        Block, Widget,
+    },
+};
+
+#[derive(Debug, Default)]
+pub struct AxisGauge {
+    text: String,
+    x: f64,
+    y: f64,
+}
+
+impl AxisGauge {
+    pub fn new(text: &str) -> Self {
+        Self {
+            text: text.to_string(),
+            x: 0.0,
+            y: 0.0,
+        }
+    }
+
+    pub fn set_value(&mut self, x: f64, y: f64) {
+        self.x = x;
+        self.y = y;
+    }
+}
+
+impl Widget for &AxisGauge {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let canvas = Canvas::default()
+            .block(Block::bordered().title(self.text.as_str()))
+            .marker(ratatui::symbols::Marker::Braille)
+            .x_bounds([-100.0, 100.0])
+            .y_bounds([-100.0, 100.0])
+            .paint(|ctx| {
+                // Draw the edges
+                let circle = Circle {
+                    radius: 100.0,
+                    ..Default::default()
+                };
+                ctx.draw(&circle);
+
+                // Draw the current position
+                for radius in 0..10 {
+                    let cursor = Circle {
+                        x: self.x * 100.0,
+                        y: self.y * 100.0,
+                        radius: radius as f64,
+                        color: Color::LightRed,
+                    };
+                    ctx.draw(&cursor);
+                }
+
+                // Draw the coordinates
+                ctx.print(
+                    0.0,
+                    0.0,
+                    format!(
+                        "({}, {})",
+                        (self.x * 100.0).round(),
+                        (self.y * 100.0).round()
+                    ),
+                );
+            });
+        canvas.render(area, buf);
+    }
+}

--- a/src/cli/ui/widgets/button_gauge.rs
+++ b/src/cli/ui/widgets/button_gauge.rs
@@ -1,0 +1,53 @@
+use ratatui::{
+    prelude::*,
+    style::Style,
+    symbols::border,
+    widgets::{Block, Gauge, Widget},
+};
+
+#[derive(Debug, Default)]
+pub struct ButtonGauge {
+    text: String,
+    value: bool,
+}
+
+impl ButtonGauge {
+    pub fn new(text: &str) -> Self {
+        Self {
+            text: text.to_string(),
+            value: false,
+        }
+    }
+
+    pub fn set_value(&mut self, value: bool) {
+        self.value = value;
+    }
+}
+
+impl Widget for &ButtonGauge {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        // Choose the style based on the value
+        let style = if self.value {
+            Style::new().green()
+        } else {
+            Style::new().gray()
+        };
+
+        // Create a block
+        let block = Block::bordered()
+            .title(self.text.as_str())
+            .border_set(border::ROUNDED)
+            .border_style(style);
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        // Create the gauge
+        let color = if self.value {
+            Color::Indexed(93)
+        } else {
+            Color::Indexed(105)
+        };
+        let gauge = Gauge::default().ratio(1.0).gauge_style(color).label("");
+        gauge.render(inside_block, buf);
+    }
+}

--- a/src/cli/ui/widgets/button_gauge.rs
+++ b/src/cli/ui/widgets/button_gauge.rs
@@ -5,22 +5,30 @@ use ratatui::{
     widgets::{Block, Gauge, Widget},
 };
 
+use crate::drivers::unified_gamepad::capability::InputCapability;
+
 #[derive(Debug, Default)]
 pub struct ButtonGauge {
     text: String,
+    capability: InputCapability,
     value: bool,
 }
 
 impl ButtonGauge {
-    pub fn new(text: &str) -> Self {
+    pub fn new(capability: InputCapability, text: &str) -> Self {
         Self {
             text: text.to_string(),
+            capability,
             value: false,
         }
     }
 
     pub fn set_value(&mut self, value: bool) {
         self.value = value;
+    }
+
+    pub fn sort_value(&self) -> u32 {
+        self.capability as u32
     }
 }
 

--- a/src/cli/ui/widgets/gyro_gauge.rs
+++ b/src/cli/ui/widgets/gyro_gauge.rs
@@ -1,0 +1,111 @@
+use ratatui::{
+    prelude::*,
+    style::Style,
+    symbols::border,
+    widgets::{Block, Gauge, LineGauge, Widget},
+};
+
+enum Axis {
+    X,
+    Y,
+    Z,
+}
+
+#[derive(Debug, Default)]
+pub struct GyroGauge {
+    text: String,
+    x: f64,
+    y: f64,
+    z: f64,
+}
+
+impl GyroGauge {
+    pub fn new(text: &str) -> Self {
+        Self {
+            text: text.to_string(),
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        }
+    }
+
+    pub fn set_value(&mut self, x: f64, y: f64, z: f64) {
+        self.x = x;
+        self.y = y;
+        self.z = z;
+    }
+
+    fn render_axis(&self, axis: Axis, area: Rect, buf: &mut Buffer) {
+        let (label, value, color) = match axis {
+            Axis::X => ("X Axis", self.x, Color::Indexed(55)),
+            Axis::Y => ("Y Axis", self.y, Color::Indexed(56)),
+            Axis::Z => ("Z Axis", self.z, Color::Indexed(57)),
+        };
+
+        // Create a block
+        let block = Block::bordered()
+            .title(label)
+            .border_set(border::ROUNDED)
+            .border_style(Style::new());
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        // Split the area to have a negative and positive gauge
+        let layout = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![Constraint::Fill(1), Constraint::Fill(1)])
+            .split(inside_block);
+
+        // Create the gauge for the negative side
+        let neg_value = if value.is_sign_negative() {
+            (value.abs() / i16::MAX as f64).min(1.0)
+        } else {
+            0.0
+        };
+        let negative_area = layout[0];
+        let gauge = Gauge::default()
+            .ratio((1.0 - neg_value).abs())
+            .gauge_style(color)
+            .reversed()
+            .label("");
+        gauge.render(negative_area, buf);
+
+        // Create the gauge for the positive side
+        let pos_value = if value.is_sign_positive() {
+            (value / i16::MAX as f64).min(1.0)
+        } else {
+            0.0
+        };
+        let positive_area = layout[1];
+        let gauge = Gauge::default()
+            .ratio(pos_value)
+            .gauge_style(color)
+            .label(format!("{}", value));
+        gauge.render(positive_area, buf);
+    }
+}
+
+impl Widget for &GyroGauge {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        // Create a block
+        let block = Block::bordered()
+            .title(self.text.as_str())
+            .border_set(border::ROUNDED)
+            .border_style(Style::new());
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        // Create rows for each axis
+        let rows = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![
+                Constraint::Fill(1),
+                Constraint::Fill(1),
+                Constraint::Fill(1),
+            ])
+            .split(inside_block);
+        self.render_axis(Axis::X, rows[0], buf);
+        self.render_axis(Axis::Y, rows[1], buf);
+        self.render_axis(Axis::Z, rows[2], buf);
+    }
+}

--- a/src/cli/ui/widgets/gyro_gauge.rs
+++ b/src/cli/ui/widgets/gyro_gauge.rs
@@ -5,6 +5,8 @@ use ratatui::{
     widgets::{Block, Gauge, LineGauge, Widget},
 };
 
+use crate::drivers::unified_gamepad::capability::InputCapability;
+
 enum Axis {
     X,
     Y,
@@ -14,15 +16,17 @@ enum Axis {
 #[derive(Debug, Default)]
 pub struct GyroGauge {
     text: String,
+    capability: InputCapability,
     x: f64,
     y: f64,
     z: f64,
 }
 
 impl GyroGauge {
-    pub fn new(text: &str) -> Self {
+    pub fn new(capability: InputCapability, text: &str) -> Self {
         Self {
             text: text.to_string(),
+            capability,
             x: 0.0,
             y: 0.0,
             z: 0.0,
@@ -33,6 +37,10 @@ impl GyroGauge {
         self.x = x;
         self.y = y;
         self.z = z;
+    }
+
+    pub fn sort_value(&self) -> u32 {
+        self.capability as u32
     }
 
     fn render_axis(&self, axis: Axis, area: Rect, buf: &mut Buffer) {

--- a/src/cli/ui/widgets/touch_gauge.rs
+++ b/src/cli/ui/widgets/touch_gauge.rs
@@ -6,18 +6,22 @@ use ratatui::{
     },
 };
 
+use crate::drivers::unified_gamepad::capability::InputCapability;
+
 #[derive(Debug, Default)]
 pub struct TouchGauge {
     text: String,
+    capability: InputCapability,
     x: f64,
     y: f64,
     touching: bool,
 }
 
 impl TouchGauge {
-    pub fn new(text: &str) -> Self {
+    pub fn new(capability: InputCapability, text: &str) -> Self {
         Self {
             text: text.to_string(),
+            capability,
             x: 0.0,
             y: 0.0,
             touching: false,
@@ -28,6 +32,10 @@ impl TouchGauge {
         self.x = x;
         self.y = y;
         self.touching = touching;
+    }
+
+    pub fn sort_value(&self) -> u32 {
+        self.capability as u32
     }
 }
 

--- a/src/cli/ui/widgets/touch_gauge.rs
+++ b/src/cli/ui/widgets/touch_gauge.rs
@@ -1,0 +1,67 @@
+use ratatui::{
+    prelude::*,
+    widgets::{
+        canvas::{Canvas, Circle},
+        Block, Widget,
+    },
+};
+
+#[derive(Debug, Default)]
+pub struct TouchGauge {
+    text: String,
+    x: f64,
+    y: f64,
+    touching: bool,
+}
+
+impl TouchGauge {
+    pub fn new(text: &str) -> Self {
+        Self {
+            text: text.to_string(),
+            x: 0.0,
+            y: 0.0,
+            touching: false,
+        }
+    }
+
+    pub fn set_value(&mut self, x: f64, y: f64, touching: bool) {
+        self.x = x;
+        self.y = y;
+        self.touching = touching;
+    }
+}
+
+impl Widget for &TouchGauge {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let canvas = Canvas::default()
+            .block(Block::bordered().title(self.text.as_str()))
+            .marker(ratatui::symbols::Marker::Braille)
+            .x_bounds([0.0, 100.0])
+            .y_bounds([0.0, 100.0])
+            .paint(|ctx| {
+                let x = self.x;
+                let y = (1.0 - self.y).abs();
+
+                // Draw the current position
+                if self.touching {
+                    for radius in 0..10 {
+                        let cursor = Circle {
+                            x: x * 100.0,
+                            y: y * 100.0,
+                            radius: radius as f64,
+                            color: Color::LightRed,
+                        };
+                        ctx.draw(&cursor);
+                    }
+                }
+
+                // Draw the coordinates
+                ctx.print(
+                    50.0,
+                    50.0,
+                    format!("({}, {})", (x * 100.0).round(), (y * 100.0).round()),
+                );
+            });
+        canvas.render(area, buf);
+    }
+}

--- a/src/cli/ui/widgets/trigger_gauge.rs
+++ b/src/cli/ui/widgets/trigger_gauge.rs
@@ -1,0 +1,59 @@
+use ratatui::{
+    prelude::*,
+    style::Style,
+    symbols::border,
+    widgets::{Block, Gauge, Widget},
+};
+
+#[derive(Debug, Default)]
+pub struct TriggerGauge {
+    text: String,
+    value: f64,
+}
+
+impl TriggerGauge {
+    pub fn new(text: &str) -> Self {
+        Self {
+            text: text.to_string(),
+            value: 0.0,
+        }
+    }
+
+    pub fn set_value(&mut self, value: f64) {
+        if value > 1.0 {
+            return;
+        }
+        self.value = value;
+    }
+}
+
+impl Widget for &TriggerGauge {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        // Create a block
+        let block = Block::bordered()
+            .title(self.text.as_str())
+            .border_set(border::ROUNDED)
+            .border_style(Style::new());
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        // Set the color based on the value
+        let color = {
+            if self.value < 0.2 {
+                Color::Indexed(53)
+            } else if self.value < 0.4 {
+                Color::Indexed(54)
+            } else if self.value < 0.6 {
+                Color::Indexed(55)
+            } else if self.value < 0.8 {
+                Color::Indexed(56)
+            } else {
+                Color::Indexed(57)
+            }
+        };
+
+        // Create the gauge
+        let gauge = Gauge::default().gauge_style(color).ratio(self.value);
+        gauge.render(inside_block, buf);
+    }
+}

--- a/src/cli/ui/widgets/trigger_gauge.rs
+++ b/src/cli/ui/widgets/trigger_gauge.rs
@@ -5,16 +5,20 @@ use ratatui::{
     widgets::{Block, Gauge, Widget},
 };
 
+use crate::drivers::unified_gamepad::capability::InputCapability;
+
 #[derive(Debug, Default)]
 pub struct TriggerGauge {
     text: String,
+    capability: InputCapability,
     value: f64,
 }
 
 impl TriggerGauge {
-    pub fn new(text: &str) -> Self {
+    pub fn new(capability: InputCapability, text: &str) -> Self {
         Self {
             text: text.to_string(),
+            capability,
             value: 0.0,
         }
     }
@@ -24,6 +28,10 @@ impl TriggerGauge {
             return;
         }
         self.value = value;
+    }
+
+    pub fn sort_value(&self) -> u32 {
+        self.capability as u32
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -5,7 +5,7 @@ use std::io;
 use ::procfs::CpuInfo;
 use glob_match::glob_match;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
@@ -23,7 +23,7 @@ pub enum LoadError {
     DeserializeError(#[from] serde_yaml::Error),
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct DeviceProfile {
     pub version: u32, //useful?
@@ -49,7 +49,7 @@ impl DeviceProfile {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct ProfileMapping {
     pub name: String,
@@ -155,7 +155,7 @@ impl ProfileMapping {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct CapabilityMap {
     pub version: u32,
@@ -181,7 +181,7 @@ impl CapabilityMap {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct CapabilityMapping {
     pub name: String,
@@ -189,7 +189,7 @@ pub struct CapabilityMapping {
     pub target_event: CapabilityConfig,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct CapabilityConfig {
     pub gamepad: Option<GamepadCapability>,
@@ -200,7 +200,7 @@ pub struct CapabilityConfig {
     pub touchscreen: Option<TouchCapability>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct GamepadCapability {
     pub axis: Option<AxisCapability>,
@@ -209,7 +209,7 @@ pub struct GamepadCapability {
     pub gyro: Option<GyroCapability>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct AxisCapability {
     pub name: String,
@@ -217,14 +217,14 @@ pub struct AxisCapability {
     pub deadzone: Option<f64>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct TriggerCapability {
     pub name: String,
     pub deadzone: Option<f64>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct GyroCapability {
     pub name: String,
@@ -233,35 +233,35 @@ pub struct GyroCapability {
     pub axis: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct MouseCapability {
     pub button: Option<String>,
     pub motion: Option<MouseMotionCapability>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct MouseMotionCapability {
     pub direction: Option<String>,
     pub speed_pps: Option<u64>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct TouchpadCapability {
     pub name: String,
     pub touch: TouchCapability,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct TouchCapability {
     pub button: Option<String>,
     pub motion: Option<TouchMotionCapability>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct TouchMotionCapability {
     pub region: Option<String>,
@@ -269,7 +269,7 @@ pub struct TouchMotionCapability {
 }
 
 /// Defines available options for loading a [CompositeDeviceConfig]
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct CompositeDeviceConfigOptions {
     /// If true, InputPlumber will automatically try to manage the input device.
@@ -280,14 +280,14 @@ pub struct CompositeDeviceConfigOptions {
 }
 
 /// Defines a platform match for loading a [CompositeDeviceConfig]
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct Match {
     pub dmi_data: Option<DMIMatch>,
 }
 
 /// Match DMI data for loading a [CompositeDevice]
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct DMIMatch {
     pub bios_release: Option<String>,
@@ -301,7 +301,7 @@ pub struct DMIMatch {
     pub cpu_vendor: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct SourceDevice {
     /// Custom group identifier for the source device.
@@ -335,7 +335,7 @@ pub struct SourceDevice {
     pub events: Option<EventsConfig>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct SourceDeviceConfig {
     pub touchscreen: Option<TouchscreenConfig>,
@@ -343,7 +343,7 @@ pub struct SourceDeviceConfig {
     pub led: Option<LedConfig>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct TouchscreenConfig {
     /// Orientation of the touchscreen. Can be one of: ["normal", "left", "right", "upsidedown"]
@@ -359,19 +359,19 @@ pub struct TouchscreenConfig {
     pub override_source_size: Option<bool>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct ImuConfig {
     pub mount_matrix: Option<MountMatrix>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct LedConfig {
     pub fixed_color: Option<LedFixedColor>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct Evdev {
     pub name: Option<String>,
@@ -381,7 +381,7 @@ pub struct Evdev {
     pub product_id: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct Hidraw {
     pub vendor_id: Option<u16>,
@@ -391,7 +391,7 @@ pub struct Hidraw {
     pub name: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct Udev {
     pub attributes: Option<Vec<UdevAttribute>>,
@@ -404,14 +404,14 @@ pub struct Udev {
     pub sys_path: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct UdevAttribute {
     pub name: String,
     pub value: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[allow(clippy::upper_case_acronyms)]
 pub struct IIO {
@@ -424,7 +424,7 @@ pub struct IIO {
     pub mount_matrix: Option<MountMatrix>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[allow(clippy::upper_case_acronyms)]
 pub struct Led {
@@ -432,7 +432,7 @@ pub struct Led {
     pub name: Option<String>,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[allow(clippy::upper_case_acronyms)]
 pub struct LedFixedColor {
@@ -441,7 +441,7 @@ pub struct LedFixedColor {
     pub b: u8,
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 #[allow(clippy::upper_case_acronyms)]
 pub struct MountMatrix {
@@ -450,7 +450,7 @@ pub struct MountMatrix {
     pub z: [f64; 3],
 }
 
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct EventsConfig {
     /// Events to exclude from being processed by a source device
@@ -460,7 +460,7 @@ pub struct EventsConfig {
 }
 
 /// Defines a combined device
-#[derive(Debug, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct CompositeDeviceConfig {
     pub version: u32,

--- a/src/config/path.rs
+++ b/src/config/path.rs
@@ -26,6 +26,10 @@ pub fn get_base_path() -> PathBuf {
 
 /// Returns the directory for input profiles (e.g. "/usr/share/inputplumber/profiles")
 pub fn get_profiles_path() -> PathBuf {
+    let rel_path = PathBuf::from("./rootfs/usr/share/inputplumber/profiles");
+    if rel_path.exists() && rel_path.is_dir() {
+        return rel_path;
+    }
     let base_path = get_base_path();
     base_path.join("profiles")
 }

--- a/src/dbus/interface/target/debug.rs
+++ b/src/dbus/interface/target/debug.rs
@@ -1,0 +1,46 @@
+use zbus::{fdo, object_server::SignalEmitter};
+use zbus_macros::interface;
+
+use crate::drivers::unified_gamepad::reports::input_capability_report::InputCapabilityReport;
+
+/// The [TargetDBusInterface] provides a DBus interface that can be exposed for managing
+/// a [DBusDevice]. It works by sending command messages to a channel that the
+/// [DBusDevice] is listening on.
+pub struct TargetDebugInterface {
+    pub capability_report: InputCapabilityReport,
+}
+
+impl TargetDebugInterface {
+    pub fn new() -> TargetDebugInterface {
+        TargetDebugInterface {
+            capability_report: InputCapabilityReport::default(),
+        }
+    }
+}
+
+impl Default for TargetDebugInterface {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[interface(
+    name = "org.shadowblip.Input.Debug",
+    proxy(default_service = "org.shadowblip.InputPlumber",)
+)]
+impl TargetDebugInterface {
+    /// Returns the input capability report data that can be used to decode
+    /// the values from the input report.
+    #[zbus(property)]
+    pub async fn input_capability_report(&self) -> fdo::Result<Vec<u8>> {
+        let data = self
+            .capability_report
+            .pack_to_vec()
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        Ok(data)
+    }
+
+    /// Emitted when a input is emitted.
+    #[zbus(signal)]
+    pub async fn input_report(emitter: &SignalEmitter<'_>, data: Vec<u8>) -> zbus::Result<()>;
+}

--- a/src/dbus/interface/target/mod.rs
+++ b/src/dbus/interface/target/mod.rs
@@ -1,4 +1,5 @@
 pub mod dbus;
+pub mod debug;
 pub mod gamepad;
 pub mod keyboard;
 pub mod mouse;
@@ -25,7 +26,10 @@ impl TargetInterface {
     }
 }
 
-#[interface(name = "org.shadowblip.Input.Target")]
+#[interface(
+    name = "org.shadowblip.Input.Target",
+    proxy(default_service = "org.shadowblip.InputPlumber",)
+)]
 impl TargetInterface {
     /// Name of the DBus device
     #[zbus(property)]

--- a/src/input/target/debug.rs
+++ b/src/input/target/debug.rs
@@ -1,0 +1,301 @@
+use std::{collections::HashSet, error::Error, fmt::Debug};
+
+use packed_struct::prelude::*;
+use tokio::sync::mpsc::{self, error::TryRecvError, Receiver};
+use zbus::Connection;
+
+use crate::{
+    dbus::interface::target::{
+        debug::{TargetDebugInterface, TargetDebugInterfaceSignals},
+        TargetInterface,
+    },
+    drivers::unified_gamepad::reports::{
+        input_capability_report::{InputCapabilityInfo, InputCapabilityReport},
+        input_data_report::InputDataReport,
+    },
+    input::{
+        capability::Capability, composite_device::client::CompositeDeviceClient,
+        event::native::NativeEvent, output_capability::OutputCapability, output_event::OutputEvent,
+    },
+};
+
+use super::{
+    client::TargetDeviceClient, InputError, OutputError, TargetDeviceTypeId, TargetInputDevice,
+    TargetOutputDevice,
+};
+
+/// A [DebugDevice] implements the Unified Controller Input Specification but writes
+/// to dbus instead of an hidraw device.
+pub struct DebugDevice {
+    conn: Connection,
+    dbus_path: Option<String>,
+    composite_device: Option<CompositeDeviceClient>,
+    capabilities: HashSet<Capability>,
+    capabilities_rx: Option<Receiver<HashSet<Capability>>>,
+    capability_report: InputCapabilityReport,
+    state: InputDataReport,
+}
+
+impl DebugDevice {
+    /// Create a new [DebugDevice]
+    pub fn new(conn: Connection) -> Self {
+        Self {
+            conn,
+            dbus_path: None,
+            composite_device: None,
+            capabilities: HashSet::new(),
+            capabilities_rx: None,
+            capability_report: InputCapabilityReport::default(),
+            state: InputDataReport::default(),
+        }
+    }
+
+    /// Checks to see if new capabilities are available in the capabilities channel
+    fn receive_new_capabilities(&mut self) -> Option<HashSet<Capability>> {
+        let rx = self.capabilities_rx.as_mut()?;
+
+        match rx.try_recv() {
+            Ok(capabilities) => Some(capabilities),
+            Err(e) => match e {
+                TryRecvError::Empty => None,
+                TryRecvError::Disconnected => {
+                    self.capabilities_rx = None;
+                    None
+                }
+            },
+        }
+    }
+
+    /// Update the device capabilities with the given capabilities
+    fn update_capabilities(&mut self, capabilities: HashSet<Capability>) {
+        log::debug!("Updating device capabilities with: {capabilities:?}");
+        let Some(composite_device) = self.composite_device.as_ref() else {
+            log::warn!("No composite device set to update capabilities");
+            return;
+        };
+
+        // Set the capabilities of the device
+        self.capabilities = capabilities.clone();
+
+        // Update the capability report with the source capabilities
+        let mut cap_info: Vec<InputCapabilityInfo> = capabilities
+            .clone()
+            .into_iter()
+            .map(|cap| cap.into())
+            .collect();
+        cap_info.sort_by_key(|cap| cap.value_type.order_priority());
+
+        // Update the capability report
+        self.capability_report = InputCapabilityReport::default();
+        for info in cap_info {
+            log::trace!("Updating report with info: {info}");
+            if let Err(e) = self.capability_report.add_capability(info) {
+                log::warn!("Failed to add input capability for gamepad: {e}");
+            }
+        }
+        log::debug!("Using capability report: {}", self.capability_report);
+
+        // Inform the composite device that the capabilities have changed
+        if let Some(dbus_path) = self.dbus_path.as_ref() {
+            log::debug!("Updating composite device with new capabilities");
+            if let Err(e) = composite_device
+                .blocking_update_target_capabilities(dbus_path.clone(), capabilities)
+            {
+                log::warn!("Failed to update target capabilities: {e:?}");
+            }
+        }
+
+        // Signal that capabilities have changed
+        let capability_report = self.capability_report.clone();
+        if let Some(dbus_path) = self.dbus_path.clone() {
+            let conn = self.conn.clone();
+            tokio::task::spawn(async move {
+                // Get the object instance at the given path so we can send DBus signal
+                // updates
+                let iface_ref = match conn
+                    .object_server()
+                    .interface::<_, TargetDebugInterface>(dbus_path.clone())
+                    .await
+                {
+                    Ok(iface) => iface,
+                    Err(e) => {
+                        log::error!(
+                            "Failed to get DBus interface for debug device to signal: {e:?}"
+                        );
+                        return;
+                    }
+                };
+                let mut iface = iface_ref.get_mut().await;
+                iface.capability_report = capability_report;
+                let result = iface
+                    .input_capability_report_changed(iface_ref.signal_emitter())
+                    .await;
+                if let Err(e) = result {
+                    log::error!("Failed to signal input capability report changed: {e}");
+                }
+            });
+        }
+
+        log::debug!("Updated capabilities");
+    }
+
+    /// Write the current device state to the virtual device
+    fn write_state(&mut self) -> Result<(), Box<dyn Error>> {
+        let Some(dbus_path) = self.dbus_path.clone() else {
+            return Ok(());
+        };
+        let conn = self.conn.clone();
+
+        // Write the state to the dbus interface
+        let data = self.state.pack()?;
+        tokio::task::spawn(async move {
+            // Get the object instance at the given path so we can send DBus signal
+            // updates
+            let iface_ref = match conn
+                .object_server()
+                .interface::<_, TargetDebugInterface>(dbus_path.clone())
+                .await
+            {
+                Ok(iface) => iface,
+                Err(e) => {
+                    log::error!("Failed to get DBus interface for debug device to signal: {e:?}");
+                    return;
+                }
+            };
+            if let Err(e) = iface_ref.input_report(data.to_vec()).await {
+                log::error!("Failed to send input report signal: {e}");
+            }
+        });
+
+        Ok(())
+    }
+}
+
+impl TargetInputDevice for DebugDevice {
+    /// Start the DBus interface for this target device
+    fn start_dbus_interface(
+        &mut self,
+        dbus: Connection,
+        path: String,
+        client: TargetDeviceClient,
+        type_id: TargetDeviceTypeId,
+    ) {
+        log::debug!("Starting dbus interface: {path}");
+        log::trace!("Using device client: {client:?}");
+        self.dbus_path = Some(path.clone());
+        tokio::task::spawn(async move {
+            let generic_interface = TargetInterface::new(&type_id);
+            let iface = TargetDebugInterface::new();
+
+            let object_server = dbus.object_server();
+            let (gen_result, result) = tokio::join!(
+                object_server.at(path.clone(), generic_interface),
+                object_server.at(path.clone(), iface)
+            );
+
+            if gen_result.is_err() || result.is_err() {
+                log::debug!("Failed to start dbus interface: {path} generic: {gen_result:?} type-specific: {result:?}");
+            } else {
+                log::debug!("Started dbus interface: {path}");
+            }
+        });
+    }
+
+    fn stop_dbus_interface(&mut self, dbus: Connection, path: String) {
+        log::debug!("Stopping dbus interface for {path}");
+        tokio::task::spawn(async move {
+            let object_server = dbus.object_server();
+            let (target, generic) = tokio::join!(
+                object_server.remove::<TargetDebugInterface, String>(path.clone()),
+                object_server.remove::<TargetInterface, String>(path.clone())
+            );
+            if generic.is_err() || target.is_err() {
+                if let Err(err) = target {
+                    log::debug!("Failed to stop debug interface {path}: {err}");
+                }
+                if let Err(err) = generic {
+                    log::debug!("Failed to stop target interface {path}: {err}");
+                }
+            } else {
+                log::debug!("Stopped dbus interface for {path}");
+            }
+        });
+    }
+
+    fn on_composite_device_attached(
+        &mut self,
+        composite_device: CompositeDeviceClient,
+    ) -> Result<(), InputError> {
+        self.composite_device = Some(composite_device.clone());
+
+        // Spawn a task to asyncronously fetch the source capabilities of
+        // the composite device.
+        let (tx, rx) = mpsc::channel(1);
+        tokio::task::spawn(async move {
+            log::debug!("Getting capabilities from the composite device!");
+            let capabilities = match composite_device.get_capabilities().await {
+                Ok(caps) => caps,
+                Err(e) => {
+                    log::warn!("Failed to fetch composite device capabilities: {e:?}");
+                    return;
+                }
+            };
+            if let Err(e) = tx.send(capabilities).await {
+                log::warn!("Failed to send composite device capabilities: {e:?}");
+            }
+        });
+
+        // Keep a reference to the receiver so it can be checked every poll iteration
+        self.capabilities_rx = Some(rx);
+
+        Ok(())
+    }
+
+    fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
+        log::trace!("Received event: {event:?}");
+
+        // Update the internal controller state when events are emitted.
+        if let Err(e) = self.state.update(&self.capability_report, event.into()) {
+            log::warn!("Failed to update gamepad state: {e}");
+            log::warn!("Current capability report: {}", self.capability_report);
+        }
+
+        // Write the current state
+        self.write_state()?;
+
+        Ok(())
+    }
+
+    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
+        // Get the input capabilities from the source device(s)
+        let capabilities = Vec::from_iter(self.capabilities.iter().cloned());
+        Ok(capabilities)
+    }
+}
+
+impl TargetOutputDevice for DebugDevice {
+    fn poll(
+        &mut self,
+        _composite_device: &Option<CompositeDeviceClient>,
+    ) -> Result<Vec<OutputEvent>, OutputError> {
+        // Check to see if there are any capability updates
+        if let Some(new_capabilities) = self.receive_new_capabilities() {
+            self.update_capabilities(new_capabilities);
+        }
+
+        Ok(vec![])
+    }
+
+    fn get_output_capabilities(&self) -> Result<Vec<OutputCapability>, OutputError> {
+        // TODO: Get the output capabilities from the source device(s)
+        Ok(vec![])
+    }
+}
+
+impl Debug for DebugDevice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DebugDevice")
+            .field("state", &self.state)
+            .finish()
+    }
+}

--- a/src/input/target/unified_gamepad.rs
+++ b/src/input/target/unified_gamepad.rs
@@ -430,6 +430,9 @@ impl Debug for UnifiedGamepadDevice {
 /// Implementation to convert an InputPlumber [NativeEvent] into a Unified Controller [StateUpdate]
 impl From<NativeEvent> for StateUpdate {
     fn from(event: NativeEvent) -> Self {
+        // TODO: We need a consistent way to scale small float values to integers
+        const GYRO_SCALE_FACTOR: f64 = 10.0; // amount to scale imu data
+        const ACCEL_SCALE_FACTOR: f64 = 3000.0; // amount to scale imu data
         let event_capability = event.as_capability();
         let capability = event_capability.clone().into();
         match event_capability {
@@ -488,9 +491,9 @@ impl From<NativeEvent> for StateUpdate {
                 Gamepad::Accelerometer => {
                     let value = match event.get_value() {
                         InputValue::Vector3 { x, y, z } => Int16Vector3Update {
-                            x: x.map(|x| x as i16),
-                            y: y.map(|y| y as i16),
-                            z: z.map(|z| z as i16),
+                            x: x.map(|x| (x * ACCEL_SCALE_FACTOR) as i16),
+                            y: y.map(|y| (y * ACCEL_SCALE_FACTOR) as i16),
+                            z: z.map(|z| (z * ACCEL_SCALE_FACTOR) as i16),
                         },
                         _ => {
                             return Self::default();
@@ -503,9 +506,9 @@ impl From<NativeEvent> for StateUpdate {
                 Gamepad::Gyro => {
                     let value = match event.get_value() {
                         InputValue::Vector3 { x, y, z } => Int16Vector3Update {
-                            x: x.map(|x| x as i16),
-                            y: y.map(|y| y as i16),
-                            z: z.map(|z| z as i16),
+                            x: x.map(|x| (x * GYRO_SCALE_FACTOR) as i16),
+                            y: y.map(|y| (y * GYRO_SCALE_FACTOR) as i16),
+                            z: z.map(|z| (z * GYRO_SCALE_FACTOR) as i16),
                         },
                         _ => {
                             return Self::default();


### PR DESCRIPTION
This change adds a new input testing to the inputplumber command line interface. It uses a new `debug` target device that uses the [UCIS](https://github.com/ShadowBlip/UnifiedControllerInputSpec) standard for emitting input events, but over dbus.

You can run it with:

```bash
inputplumber device 0 test
```

where `0` is the composite device id:

[2025-02-24 20-34-26.webm](https://github.com/user-attachments/assets/1a5f603a-e7a0-4ae1-8e0c-cdd9f6e43d0c)

![Screenshot From 2025-02-24 20-37-13](https://github.com/user-attachments/assets/cdd2dd70-91d1-48e8-bd33-eae550391c80)
