### PR TITLE
fix(OrangePi NEO): Add BOSC0260 IIO detection

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-orangepi_neo.yaml
@@ -59,7 +59,7 @@ source_devices:
       handler: event*
   - group: imu
     iio:
-      name: i2c-BMI0260:00
+      name: "{i2c-BOSC0260:00,i2c-BMI0260:00}"
       mount_matrix:
         # TODO: Reverify on actual hardware
         x: [1, 0, 0]

--- a/src/input/source/iio.rs
+++ b/src/input/source/iio.rs
@@ -109,7 +109,7 @@ impl IioDevice {
         let name = device_name.as_str();
         log::debug!("Finding driver for IIO interface: {name}");
         // BMI_IMU
-        if glob_match("{i2c-10EC5280*,i2c-BMI*,bmi*-imu}", name) {
+        if glob_match("{i2c-10EC5280*,i2c-BOSC*,i2c-BMI*,bmi*-imu}", name) {
             log::info!("Detected BMI IMU");
             return DriverType::BmiImu;
         }


### PR DESCRIPTION
this add the BOSC0260 IIO detection. Tested on firmware set `BCPH01_V1.20_OrangePi_modoify_audio269_table` with `EC_BCPH01_V0.15`.