### PR TITLE
fix(Generic Gamepads): re-enable support for generic gamepads

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/65-generic_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/65-generic_gamepad.yaml
@@ -6,15 +6,15 @@ version: 1
 kind: CompositeDevice
 
 # Name of the composite device mapping
-name: Gamepads
-
-# Maximum number of source devices per CompositeDevice.
-maximum_sources: 1
+name: Generic Gamepad
 
 # Only use this profile if *any* of the given matches matches. If this list is
 # empty, then the source devices will *always* be checked.
 # /sys/class/dmi/id/product_name
 matches: []
+
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 1
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.


### PR DESCRIPTION
This change re-enables support for generic gamepads. This config will only be used if `manage-all` is set to `true` by an external process.