### PR TITLE
fix(Legion Go S): Fix breakage from upstream kernel changes.

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-legion_go_s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go_s.yaml
@@ -28,7 +28,7 @@ source_devices:
     blocked: true
     evdev:
       vendor_id: "1a86"
-      product_id: "e310"
+      product_id: "{e310,e311}"
       name: "wch.cn Legion Go S Mouse"
       handler: event*
 
@@ -38,11 +38,17 @@ source_devices:
       vendor_id: 0x1a86
       product_id: 0xe310
       interface_num: 6
+  - group: gamepad # Gamepad Mode
+    hidraw:
+      vendor_id: 0x1a86
+      product_id: 0xe311
+      interface_num: 6
   - group: gamepad
+    blocked: true
     evdev:
       vendor_id: "1a86"
-      product_id: "e310"
-      name: "QH Electronics Controller"
+      product_id: "{e310,e311}"
+      name: "{QH Electronics Controller,Legion Go S}"
       handler: event*
 
   # IMU
@@ -50,6 +56,11 @@ source_devices:
     hidraw:
       vendor_id: 0x1a86
       product_id: 0xe310
+      interface_num: 5
+  - group: imu
+    hidraw:
+      vendor_id: 0x1a86
+      product_id: 0xe311
       interface_num: 5
 
 # Optional configuration for the composite device

--- a/src/drivers/legos/driver.rs
+++ b/src/drivers/legos/driver.rs
@@ -15,7 +15,9 @@ use super::{
 
 // Hardware ID's
 pub const VID: u16 = 0x1a86;
-pub const PID: u16 = 0xe310;
+pub const XINPUT_PID: u16 = 0xe310;
+pub const DINPUT_PID: u16 = 0xe310;
+pub const PIDS: [u16; 2] = [XINPUT_PID, DINPUT_PID];
 // Input report sizes
 const XINPUT_PACKET_SIZE: usize = 32;
 const INERTIAL_PACKET_SIZE: usize = 9;
@@ -50,7 +52,7 @@ impl Driver {
         let api = hidapi::HidApi::new()?;
         let device = api.open_path(&path)?;
         let info = device.get_device_info()?;
-        if info.vendor_id() != VID || info.product_id() != PID {
+        if info.vendor_id() != VID || !PIDS.contains(&info.product_id()) {
             return Err(format!("Device '{fmtpath}' is not a Legion Go S Controller").into());
         }
         Ok(Self {

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -325,7 +325,7 @@ impl HidRawDevice {
         }
 
         // Legion Go S
-        if vid == drivers::legos::driver::VID && pid == drivers::legos::driver::PID {
+        if vid == drivers::legos::driver::VID && drivers::legos::driver::PIDS.contains(&pid) {
             log::info!("Detected Legion Go S");
             return DriverType::LegionGoS;
         }


### PR DESCRIPTION
- Adds new name from upstream kernel patch. https://lore.kernel.org/linux-input/20250222170010.188761-4-lkml@antheas.dev/
- While at it, add support for dinput PID