### PR TITLE
fix(MSI Claw): add support for setting XInput mode for systems without kernel support

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw7_a2vm.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw7_a2vm.yaml
@@ -34,6 +34,12 @@ source_devices:
       vendor_id: "0db0"
       product_id: "1901"
       phys_path: "usb-0000:00:14.0-2/input0"
+  - group: gamepad
+    passthrough: true
+    hidraw:
+      vendor_id: 0x0db0
+      product_id: 0x1901
+      interface_num: 2
 
   # IMU
 

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw8_a2vm.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw8_a2vm.yaml
@@ -34,6 +34,12 @@ source_devices:
       vendor_id: "0db0"
       product_id: "1901"
       phys_path: "usb-0000:00:14.0-2/input0"
+  - group: gamepad
+    passthrough: true
+    hidraw:
+      vendor_id: 0x0db0
+      product_id: 0x1901
+      interface_num: 2
 
   # IMU
 

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw_a1m.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw_a1m.yaml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/refs/heads/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
 # Schema version number
 version: 1
 
@@ -34,6 +34,12 @@ source_devices:
       vendor_id: "0db0"
       product_id: "1901"
       phys_path: "usb-0000:00:14.0-9/input0"
+  - group: gamepad
+    passthrough: true
+    hidraw:
+      vendor_id: 0x0db0
+      product_id: 0x1901
+      interface_num: 2
 
   # IMU
   - group: imu

--- a/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+++ b/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
@@ -486,23 +486,23 @@
           }
         }
       }
-    }
-  },
-  "Color": {
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {
-      "r": {
-        "description": "Red channel color (0-255)",
-        "type": "number"
-      },
-      "g": {
-        "description": "Green channel color (0-255)",
-        "type": "number"
-      },
-      "b": {
-        "description": "Blue channel color (0-255)",
-        "type": "number"
+    },
+    "Color": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "r": {
+          "description": "Red channel color (0-255)",
+          "type": "number"
+        },
+        "g": {
+          "description": "Green channel color (0-255)",
+          "type": "number"
+        },
+        "b": {
+          "description": "Blue channel color (0-255)",
+          "type": "number"
+        }
       }
     }
   }

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -4,6 +4,7 @@ pub mod horipad_steam;
 pub mod iio_imu;
 pub mod lego;
 pub mod legos;
+pub mod msi_claw;
 pub mod opineo;
 pub mod rog_ally;
 pub mod steam_deck;

--- a/src/drivers/msi_claw/driver.rs
+++ b/src/drivers/msi_claw/driver.rs
@@ -1,0 +1,50 @@
+// References:
+// - https://github.com/zezba9000/MSI-Claw-Gamepad-Mode/blob/main/main.c
+// - https://github.com/NeroReflex/hid-msi-claw-dkms/blob/main/hid-msi-claw.c
+use std::{error::Error, ffi::CString};
+
+use hidapi::HidDevice;
+use packed_struct::PackedStruct;
+
+use crate::udev::device::UdevDevice;
+
+use super::hid_report::{GamepadMode, PackedCommandReport};
+
+// Hardware ID's
+pub const VID: u16 = 0x0db0;
+pub const PID: u16 = 0x1901;
+
+pub struct Driver {
+    device: HidDevice,
+}
+
+impl Driver {
+    pub fn new(udevice: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let vid = udevice.id_vendor();
+        let pid = udevice.id_product();
+        if VID != vid || PID != pid {
+            return Err(format!("'{}' is not a MSI Claw controller", udevice.devnode()).into());
+        }
+
+        // Open the hidraw device
+        let path = udevice.devnode();
+        let path = CString::new(path)?;
+        let api = hidapi::HidApi::new()?;
+        let device = api.open_path(&path)?;
+
+        Ok(Self { device })
+    }
+
+    // Configure the device to be in the given mode
+    // TODO: Update to use sysfs interface when kernel support is upstreamed
+    pub fn set_mode(&self, mode: GamepadMode) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let report = PackedCommandReport {
+            mode,
+            ..Default::default()
+        };
+        let data = report.pack()?;
+        self.device.write(&data)?;
+
+        Ok(())
+    }
+}

--- a/src/drivers/msi_claw/hid_report.rs
+++ b/src/drivers/msi_claw/hid_report.rs
@@ -1,0 +1,61 @@
+use packed_struct::prelude::*;
+
+#[derive(PrimitiveEnum_u8, Clone, Copy, PartialEq, Debug, Default)]
+pub enum ReportId {
+    #[default]
+    SendCommand = 15,
+}
+
+#[derive(PrimitiveEnum_u8, Clone, Copy, PartialEq, Debug, Default)]
+pub enum Command {
+    #[default]
+    SwitchMode = 36,
+}
+
+#[derive(PrimitiveEnum_u8, Clone, Copy, PartialEq, Debug, Default)]
+pub enum GamepadMode {
+    Offline = 0,
+    #[default]
+    XInput = 1,
+    DInput = 2,
+    Msi = 3,
+    Desktop = 4,
+    Bios = 5,
+    Testing = 6,
+}
+
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", size_bytes = "8")]
+pub struct PackedCommandReport {
+    #[packed_field(bytes = "0", ty = "enum")]
+    pub report_id: ReportId,
+    #[packed_field(bytes = "1")]
+    pub unk_1: u8,
+    #[packed_field(bytes = "2")]
+    pub unk_2: u8,
+    #[packed_field(bytes = "3")]
+    pub unk_3: u8,
+    #[packed_field(bytes = "4", ty = "enum")]
+    pub command: Command,
+    #[packed_field(bytes = "5", ty = "enum")]
+    pub mode: GamepadMode,
+    #[packed_field(bytes = "6")]
+    pub unk_6: u8,
+    #[packed_field(bytes = "7")]
+    pub unk_7: u8,
+}
+
+impl Default for PackedCommandReport {
+    fn default() -> Self {
+        Self {
+            report_id: ReportId::SendCommand,
+            unk_1: Default::default(),
+            unk_2: Default::default(),
+            unk_3: 60,
+            command: Command::SwitchMode,
+            mode: GamepadMode::XInput,
+            unk_6: Default::default(),
+            unk_7: Default::default(),
+        }
+    }
+}

--- a/src/drivers/msi_claw/mod.rs
+++ b/src/drivers/msi_claw/mod.rs
@@ -1,0 +1,2 @@
+pub mod driver;
+pub mod hid_report;

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -6,6 +6,7 @@ pub mod lego_dinput_split;
 pub mod lego_fps_mode;
 pub mod lego_xinput;
 pub mod legos;
+pub mod msi_claw;
 pub mod opineo;
 pub mod rog_ally;
 pub mod steam_deck;
@@ -14,6 +15,7 @@ pub mod xpad_uhid;
 use std::{error::Error, time::Duration};
 
 use horipad_steam::HoripadSteam;
+use msi_claw::MsiClaw;
 use rog_ally::RogAlly;
 use xpad_uhid::XpadUhid;
 
@@ -42,6 +44,7 @@ enum DriverType {
     LegionGoFPS,
     LegionGoS,
     LegionGoX,
+    MsiClaw,
     OrangePiNeo,
     RogAlly,
     SteamDeck,
@@ -60,6 +63,7 @@ pub enum HidRawDevice {
     LegionGoS(SourceDriver<LegionSController>),
     LegionGoX(SourceDriver<LegionControllerX>),
     OrangePiNeo(SourceDriver<OrangePiNeoTouchpad>),
+    MsiClaw(SourceDriver<MsiClaw>),
     RogAlly(SourceDriver<RogAlly>),
     SteamDeck(SourceDriver<DeckController>),
     XpadUhid(SourceDriver<XpadUhid>),
@@ -77,6 +81,7 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::LegionGoS(source_driver) => source_driver.info_ref(),
             HidRawDevice::LegionGoX(source_driver) => source_driver.info_ref(),
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.info_ref(),
+            HidRawDevice::MsiClaw(source_driver) => source_driver.info_ref(),
             HidRawDevice::RogAlly(source_driver) => source_driver.info_ref(),
             HidRawDevice::SteamDeck(source_driver) => source_driver.info_ref(),
             HidRawDevice::XpadUhid(source_driver) => source_driver.info_ref(),
@@ -94,6 +99,7 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::LegionGoS(source_driver) => source_driver.get_id(),
             HidRawDevice::LegionGoX(source_driver) => source_driver.get_id(),
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.get_id(),
+            HidRawDevice::MsiClaw(source_driver) => source_driver.get_id(),
             HidRawDevice::RogAlly(source_driver) => source_driver.get_id(),
             HidRawDevice::SteamDeck(source_driver) => source_driver.get_id(),
             HidRawDevice::XpadUhid(source_driver) => source_driver.get_id(),
@@ -111,6 +117,7 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::LegionGoS(source_driver) => source_driver.client(),
             HidRawDevice::LegionGoX(source_driver) => source_driver.client(),
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.client(),
+            HidRawDevice::MsiClaw(source_driver) => source_driver.client(),
             HidRawDevice::RogAlly(source_driver) => source_driver.client(),
             HidRawDevice::SteamDeck(source_driver) => source_driver.client(),
             HidRawDevice::XpadUhid(source_driver) => source_driver.client(),
@@ -128,6 +135,7 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::LegionGoS(source_driver) => source_driver.run().await,
             HidRawDevice::LegionGoX(source_driver) => source_driver.run().await,
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.run().await,
+            HidRawDevice::MsiClaw(source_driver) => source_driver.run().await,
             HidRawDevice::RogAlly(source_driver) => source_driver.run().await,
             HidRawDevice::SteamDeck(source_driver) => source_driver.run().await,
             HidRawDevice::XpadUhid(source_driver) => source_driver.run().await,
@@ -147,6 +155,7 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::LegionGoS(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::LegionGoX(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.get_capabilities(),
+            HidRawDevice::MsiClaw(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::RogAlly(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::SteamDeck(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::XpadUhid(source_driver) => source_driver.get_capabilities(),
@@ -164,6 +173,7 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::LegionGoS(source_driver) => source_driver.get_device_path(),
             HidRawDevice::LegionGoX(source_driver) => source_driver.get_device_path(),
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.get_device_path(),
+            HidRawDevice::MsiClaw(source_driver) => source_driver.get_device_path(),
             HidRawDevice::RogAlly(source_driver) => source_driver.get_device_path(),
             HidRawDevice::SteamDeck(source_driver) => source_driver.get_device_path(),
             HidRawDevice::XpadUhid(source_driver) => source_driver.get_device_path(),
@@ -243,6 +253,11 @@ impl HidRawDevice {
                 let device = OrangePiNeoTouchpad::new(device_info.clone())?;
                 let source_device = SourceDriver::new(composite_device, device, device_info, conf);
                 Ok(Self::OrangePiNeo(source_device))
+            }
+            DriverType::MsiClaw => {
+                let device = MsiClaw::new(device_info.clone())?;
+                let source_device = SourceDriver::new(composite_device, device, device_info, conf);
+                Ok(Self::MsiClaw(source_device))
             }
             DriverType::Fts3528Touchscreen => {
                 let device = Fts3528Touchscreen::new(device_info.clone())?;
@@ -335,6 +350,13 @@ impl HidRawDevice {
             log::info!("Detected OrangePi NEO");
 
             return DriverType::OrangePiNeo;
+        }
+
+        // MSI Claw
+        if vid == drivers::msi_claw::driver::VID && pid == drivers::msi_claw::driver::PID {
+            log::info!("Detected MSI Claw");
+
+            return DriverType::MsiClaw;
         }
 
         // FTS3528 Touchscreen

--- a/src/input/source/hidraw/msi_claw.rs
+++ b/src/input/source/hidraw/msi_claw.rs
@@ -1,0 +1,40 @@
+use std::{error::Error, fmt::Debug};
+
+use crate::{
+    drivers::msi_claw::{driver::Driver, hid_report::GamepadMode},
+    input::{
+        capability::Capability,
+        event::native::NativeEvent,
+        source::{InputError, SourceInputDevice, SourceOutputDevice},
+    },
+    udev::device::UdevDevice,
+};
+
+pub struct MsiClaw {}
+
+impl MsiClaw {
+    pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let driver = Driver::new(device_info)?;
+        log::debug!("Setting gamepad to XInput mode");
+        driver.set_mode(GamepadMode::XInput)?;
+        Ok(Self {})
+    }
+}
+
+impl Debug for MsiClaw {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MsiClaw").finish()
+    }
+}
+impl SourceInputDevice for MsiClaw {
+    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        Ok(vec![])
+    }
+
+    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
+        Ok(vec![])
+    }
+}
+
+impl SourceOutputDevice for MsiClaw {}
+


### PR DESCRIPTION
This change adds support for switching the MSI Claw into XInput mode for systems that do not have kernel support. Once Nero's driver has been upstreamed to the kernel, we can update this method to use the sysfs interface when it is available.