### PR TITLE
fix(Device Hiding): add ignore for libinput

### DIFF
--- a/src/udev/mod.rs
+++ b/src/udev/mod.rs
@@ -44,8 +44,8 @@ pub async fn hide_device(path: &str) -> Result<(), Box<dyn Error>> {
 {match_rule}, GOTO="inputplumber_valid"
 GOTO="inputplumber_end"
 LABEL="inputplumber_valid"
-KERNEL=="js[0-9]*|event[0-9]*", SUBSYSTEM=="{subsystem}", MODE:="0000", GROUP:="root", RUN:="{chmod_cmd} 000 /dev/input/%k", SYMLINK+="inputplumber/by-hidden/%k"
-KERNEL=="hidraw[0-9]*", SUBSYSTEM=="{subsystem}", MODE:="0000", GROUP:="root", RUN:="{chmod_cmd} 000 /dev/%k", SYMLINK+="inputplumber/by-hidden/%k"
+KERNEL=="js[0-9]*|event[0-9]*", SUBSYSTEM=="{subsystem}", MODE:="0000", GROUP:="root", RUN:="{chmod_cmd} 000 /dev/input/%k", SYMLINK+="inputplumber/by-hidden/%k", ENV{{LIBINPUT_IGNORE}}="1", ENV{{LIBINPUT_IGNORE_DEVICE}}="1"
+KERNEL=="hidraw[0-9]*", SUBSYSTEM=="{subsystem}", MODE:="0000", GROUP:="root", RUN:="{chmod_cmd} 000 /dev/%k", SYMLINK+="inputplumber/by-hidden/%k", ENV{{LIBINPUT_IGNORE}}="1", ENV{{LIBINPUT_IGNORE_DEVICE}}="1"
 LABEL="inputplumber_end"
 "#
     );
@@ -63,8 +63,8 @@ LABEL="inputplumber_end"
 {match_rule}, GOTO="inputplumber_valid"
 GOTO="inputplumber_end"
 LABEL="inputplumber_valid"
-KERNEL=="js[0-9]*|event[0-9]*", SUBSYSTEM=="{subsystem}", MODE="000", GROUP="root", TAG-="uaccess", RUN+="{chmod_cmd} 000 /dev/input/%k"
-KERNEL=="hidraw[0-9]*", SUBSYSTEM=="{subsystem}", MODE="000", GROUP="root", TAG-="uaccess", RUN+="{chmod_cmd} 000 /dev/%k"
+KERNEL=="js[0-9]*|event[0-9]*", SUBSYSTEM=="{subsystem}", MODE="000", GROUP="root", TAG-="uaccess", RUN+="{chmod_cmd} 000 /dev/input/%k", ENV{{LIBINPUT_IGNORE}}="1", ENV{{LIBINPUT_IGNORE_DEVICE}}="1"
+KERNEL=="hidraw[0-9]*", SUBSYSTEM=="{subsystem}", MODE="000", GROUP="root", TAG-="uaccess", RUN+="{chmod_cmd} 000 /dev/%k", ENV{{LIBINPUT_IGNORE}}="1", ENV{{LIBINPUT_IGNORE_DEVICE}}="1"
 LABEL="inputplumber_end"
 "#
     );


### PR DESCRIPTION
This change updates the hiding rules to include hiding devices from libinput:
https://wayland.freedesktop.org/libinput/doc/latest/ignoring-devices.html