### PR TITLE
fix(Legion Go): Split Legion Go 2 config due to different PID to Go 1

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
@@ -16,7 +16,7 @@ single_source: false
 # /sys/class/dmi/id/product_name
 matches:
   - dmi_data:
-      product_name: "{83E1,83N0,83N1}"
+      product_name: "83E1"
       sys_vendor: LENOVO
       cpu_vendor: AuthenticAMD
 

--- a/rootfs/usr/share/inputplumber/devices/50-legion_go_2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go_2.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: Lenovo Legion Go 2
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# Only use this profile if *any* of the given matches match. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches:
+  - dmi_data:
+      product_name: "{83N0,83N1}"
+      sys_vendor: LENOVO
+      cpu_vendor: AuthenticAMD
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  ## XInput - Connected 0x61eb
+  # Touchpad
+  - group: mouse # Gamepad Mode
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x61eb
+      interface_num: 1
+  # Gamepad
+  - group: gamepad
+    hidraw:
+      vendor_id: 0x17ef
+      product_id: 0x61eb
+      interface_num: 2
+  - group: gamepad
+    unique: true
+    evdev:
+      name: "{Lenovo Legion Controller for Windows,Generic X-Box pad}"
+      vendor_id: "17ef"
+      product_id: "61eb"
+      handler: event*
+  # Block all evdev devices; mouse, touchpad, keyboard
+  - group: gamepad
+    blocked: true
+    unique: false
+    evdev:
+      name: "  Legion Controller for Windows  *"
+      vendor_id: "17ef"
+      product_id: "61eb"
+      handler: event*
+
+  # Touchscreen
+  #- group: touchscreen
+  #  udev:
+  #    properties:
+  #      - name: ID_INPUT_TOUCHSCREEN
+  #        value: "1"
+  #    sys_name: "event*"
+  #    subsystem: input
+  #  config:
+  #    touchscreen:
+  #      orientation: "left"
+# Optional configuration for the composite device
+
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
+# The target input device(s) to emulate by default
+target_devices:
+  - xbox-elite
+  - mouse
+  #- keyboard
+  #- touchpad
+  #- touchscreen


### PR DESCRIPTION
Legion Go 2 uses a same MCU but different USB PID to distinguish the model, init the support for it as translate to a Xbox Elite Controller.

Tested on Legion Go 2 sample:

[device_info.log](https://github.com/user-attachments/files/19703327/device_info.log)
[devices_list.log](https://github.com/user-attachments/files/19703328/devices_list.log)
