### PR TITLE
README.md: Use repository package for install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ make build
 sudo make install
 ```
 
-If you are using ArchLinux, you can install InputPlumber from the AUR:
+If you are using ArchLinux or any of its derivaties,
+you can install InputPlumber from the official repositories:
 
 ```bash
-yay -S inputplumber-bin
+sudo pacman -S inputplumber
 ```
 
 Then start the service with:


### PR DESCRIPTION
inputplumber is available in the official Arch Linux repositories, so there is no reason to prefer the AUR package over the former.