### PR TITLE
fix(Target Touchpad): use higher resolution and polling rate to fix slow, jittery touch behavior

### DIFF
--- a/src/input/target/mod.rs
+++ b/src/input/target/mod.rs
@@ -694,7 +694,7 @@ impl TargetDevice {
             "touchpad" => {
                 let device = TouchpadDevice::new()?;
                 let options = TargetDriverOptions {
-                    poll_rate: Duration::from_micros(13605),
+                    poll_rate: Duration::from_millis(3),
                     buffer_size: 2048,
                 };
                 let driver = TargetDriver::new_with_options(id, device, dbus, options);


### PR DESCRIPTION
This change fixes slowness, jitter, and overall bad feeling of virtual touchpads. An example of this can be found in the following review video:

[![ETA Prime Video](https://img.youtube.com/vi/lU9LkJYfd68/maxresdefault.jpg)](https://www.youtube.com/embed/lU9LkJYfd68?start=137&end=158)
https://www.youtube.com/embed/lU9LkJYfd68?start=137&end=158

The main change that fixed this issue was to change the polling rate of the target touchpad device from 13ms to 3ms.