### PR TITLE
fix(ASUS Ally): don't crash out of driver init if attrs fail

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/ally_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ally_type1.yaml
@@ -27,9 +27,21 @@ mapping:
     target_event:
       gamepad:
         button: Keyboard
+  - name: Control Center (Long)
+    source_events:
+      - keyboard: KeyF20
+    target_event:
+      gamepad:
+        button: Keyboard
   - name: Armory Crate (Short)
     source_events:
       - keyboard: KeyProg1
+    target_event:
+      gamepad:
+        button: QuickAccess
+  - name: Armory Crate (Short)
+    source_events:
+      - keyboard: KeyF19
     target_event:
       gamepad:
         button: QuickAccess

--- a/rootfs/usr/share/inputplumber/devices/50-rog_ally.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-rog_ally.yaml
@@ -46,6 +46,21 @@ source_devices:
       vendor_id: 0b05
       product_id: 1abe
       handler: event*
+  # New driver group name from `asus_ally_hid`
+  - group: mouse
+    evdev:
+      name: ROG Ally Mouse
+      vendor_id: 0b05
+      product_id: 1abe
+      handler: event*
+  # New driver group name from `asus_ally_hid`
+  - group: keyboard
+    unique: false
+    evdev:
+      name: ROG Ally Keyboard
+      vendor_id: 0b05
+      product_id: 1abe
+      handler: event*
   - group: imu
     iio:
       name: bmi323-imu

--- a/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml
@@ -45,6 +45,24 @@ source_devices:
       vendor_id: 0b05
       product_id: 1b4c
       handler: event*
+  - group: mouse # New driver group name from `asus_ally_hid`
+    evdev:
+      name: "ROG Ally Mouse"
+      vendor_id: 0b05
+      product_id: 1b4c
+      handler: event*
+  - group: keyboard # New driver group name from `asus_ally_hid`
+    evdev:
+      name: "ROG Ally Keyboard"
+      vendor_id: 0b05
+      product_id: 1b4c
+      handler: event*
+  - group: gamepad # New driver group name from `asus_ally_hid`
+    evdev:
+      name: ROG Ally X Gamepad
+      vendor_id: 0b05
+      product_id: 1b4c
+      handler: event*
   - group: imu
     iio:
       name: bmi323-imu

--- a/src/drivers/rog_ally/driver.rs
+++ b/src/drivers/rog_ally/driver.rs
@@ -1,10 +1,7 @@
+use crate::udev::device::{AttributeGetter, AttributeSetter, UdevDevice};
 use std::{error::Error, time::Duration};
-
 use udev::Device;
 
-use crate::udev::device::{AttributeGetter, AttributeSetter, UdevDevice};
-
-// Hardware ID's
 const ALLY_PID: u16 = 0x1abe;
 const ALLYX_PID: u16 = 0x1b4c;
 pub const PIDS: [u16; 2] = [ALLY_PID, ALLYX_PID];
@@ -21,68 +18,52 @@ impl Driver {
         if VID != vid || !PIDS.contains(&pid) {
             return Err(format!("'{}' is not an ROG Ally controller", udevice.devnode()).into());
         }
-        // TODO: When resuming from sleep, if mcu_powersave is set, the device init takes longer.
-        // inotify will trigger this driver before the attribute tree is fully built and the driver
-        // will error and exit, leaving some controls unusable. We should find a way to only
-        // trigger this driver or continue processing once we know the driver has fully init.
+
+        // Wait for device initialization due to powersave_mode
         std::thread::sleep(Duration::from_millis(300));
 
-        // Set the controller buttons to the correct values at startup
         let device = udevice.get_device()?;
         let Some(mut parent) = device.parent() else {
             return Err("Failed to get device parent".into());
         };
+
         let Some(driver) = parent.driver() else {
             return Err("Failed to identify device driver".into());
         };
-        // Apply settings for the controller
-        if driver.to_str().unwrap() == "asus_rog_ally" {
-            let if_num = device.get_attribute_from_tree("bInterfaceNumber");
-            let if_num = if_num.as_str();
-            match if_num {
-                "02" => {
-                    // Ally and Ally X, map back buttons and ensure it is in gamepad mode.
-                    log::debug!("Setting buttons and gamepad mode.");
-                    set_attribute(device.clone(), "btn_m1/remap", "KB_F15")?;
-                    set_attribute(device.clone(), "btn_m2/remap", "KB_F14")?;
-                    set_attribute(device, "gamepad_mode", "1")?;
-                    //TODO: Figure out why this fails and manually running the same thing
-                    //doesn't.
-                    //set_attribute(device, "apply", "1")?;
-                    let result = parent.set_attribute_value("apply_all", "1");
-                    match result {
-                        Ok(_) => log::debug!("set apply_all to 1"),
-                        Err(e) => return Err(format!("Could set apply_all to 1: {e:?}").into()),
-                    };
-                }
-                "05" => {
-                    // Ally X only, switch from driver emiting a BTN_MODE with CC and a
-                    // BTN_MODE/BTN_SOUTH chord with AC to the same events as original
-                    // Ally so we can capture them as the Guide and QuickAccess Capabilities.
-                    log::debug!("Setting qam mode.");
-                    set_attribute(device, "qam_mode", "0")?;
-                }
-                _ => return Err(format!("Invalid interface number {if_num} provided.").into()),
-            };
-        } else {
+
+        if driver != "asus_rog_ally" && driver != "asus_ally_hid" {
             return Err("Device is not using the asus_rog_ally driver.".into());
         }
+
+        let if_num = device.get_attribute_from_tree("bInterfaceNumber");
+        match if_num.as_str() {
+            "02" => {
+                log::trace!("Setting buttons and gamepad mode.");
+                set_attribute(device.clone(), "btn_m1/remap", "KB_F15");
+                set_attribute(device.clone(), "btn_m2/remap", "KB_F14");
+                set_attribute(device.clone(), "gamepad_mode", "1");
+                parent
+                    .set_attribute_value("apply_all", "1")
+                    .map_err(|e| log::warn!("Could not set apply_all to 1: {e:?}"))
+                    .ok();
+            }
+            "05" => {
+                // Configure QAM mode for Ally X
+                log::trace!("Setting qam mode.");
+                set_attribute(device, "qam_mode", "0");
+            }
+            _ => return Err(format!("Invalid interface number {if_num} provided.").into()),
+        };
 
         Ok(Self { _device: udevice })
     }
 }
 
-pub fn set_attribute(
-    mut device: Device,
-    attribute: &str,
-    value: &str,
-) -> Result<(), Box<dyn Error + Send + Sync>> {
-    let result = device.set_attribute_on_tree(attribute, value);
-    match result {
-        Ok(r) => {
-            log::debug!("set {attribute} to {value}");
-            Ok(r)
-        }
-        Err(e) => Err(format!("Could not set {attribute} to {value}: {e:?}").into()),
+fn set_attribute(mut device: Device, attribute: &str, value: &str) {
+    // log errors but don't bomb out of InputPlumber by returning them,
+    // this should allow at least some usability of devices if errored
+    match device.set_attribute_on_tree(attribute, value) {
+        Ok(_) => log::debug!("set {attribute} to {value}"),
+        Err(e) => log::warn!("Could not set {attribute} to {value}: {e:?}"),
     }
 }


### PR DESCRIPTION
Instead of bombing out of the driver init process allow IP to keep working as the majority of parts should still be usable.