### PR TITLE
feat(LED): add dbus interface to control source LED color

### DIFF
--- a/src/dbus/interface/source/mod.rs
+++ b/src/dbus/interface/source/mod.rs
@@ -2,4 +2,5 @@ pub mod evdev;
 pub mod hidraw;
 pub mod iio_imu;
 pub mod led;
+pub mod output;
 pub mod udev;

--- a/src/dbus/interface/source/output.rs
+++ b/src/dbus/interface/source/output.rs
@@ -1,0 +1,87 @@
+use crate::{
+    constants::BUS_SOURCES_PREFIX,
+    input::{output_event::OutputEvent, source::command::SourceCommand},
+};
+use std::{error::Error, time::Duration};
+use tokio::sync::mpsc::Sender;
+use zbus::{fdo, Connection};
+use zbus_macros::interface;
+
+/// DBusInterface exposing LED output
+pub struct SourceOutputLedInterface {
+    tx: Sender<SourceCommand>,
+}
+
+impl SourceOutputLedInterface {
+    fn new(tx: Sender<SourceCommand>) -> SourceOutputLedInterface {
+        SourceOutputLedInterface { tx }
+    }
+
+    /// Creates a new instance of the source led interface on DBus.
+    pub fn listen_on_dbus(
+        conn: Connection,
+        device_id: &str,
+        tx: Sender<SourceCommand>,
+    ) -> Result<(), Box<dyn Error>> {
+        // Create a task to start the dbus interface
+        let conn_iface = conn.clone();
+        let iface = Self::new(tx.clone());
+        let dbus_path = get_dbus_path(device_id);
+        tokio::task::spawn(async move {
+            log::debug!("Starting dbus interface: {dbus_path}");
+            let result = conn_iface
+                .object_server()
+                .at(dbus_path.clone(), iface)
+                .await;
+            if let Err(e) = result {
+                log::debug!("Failed to start dbus interface {dbus_path}: {e:?}");
+            } else {
+                log::debug!("Started dbus interface: {dbus_path}");
+            }
+        });
+
+        // Create a task to remove the interface whenever the receiver no longer
+        // exists.
+        let dbus_path = get_dbus_path(device_id);
+        tokio::task::spawn(async move {
+            // Wait for the receiver to close
+            tx.closed().await;
+
+            log::debug!("Stopping dbus interface: {dbus_path}");
+            let result = conn
+                .object_server()
+                .remove::<Self, _>(dbus_path.clone())
+                .await;
+            if let Err(e) = result {
+                log::debug!("Failed to remove dbus interface {dbus_path}: {e:?}");
+            } else {
+                log::debug!("Stopped dbus interface: {dbus_path}");
+            }
+        });
+
+        Ok(())
+    }
+}
+
+#[interface(
+    name = "org.shadowblip.Output.Source.LED",
+    proxy(default_service = "org.shadowblip.InputPlumber")
+)]
+impl SourceOutputLedInterface {
+    /// Set the overall color of the device to the given RGB value.
+    async fn set_color(&self, r: u8, g: u8, b: u8) -> fdo::Result<()> {
+        let event = OutputEvent::LedColor { r, g, b };
+        self.tx
+            .send_timeout(SourceCommand::WriteEvent(event), Duration::from_millis(200))
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+        Ok(())
+    }
+}
+
+/// Returns the DBus path for a given device ID
+fn get_dbus_path(id: &str) -> String {
+    let name = id.replace(':', "_");
+    let name = name.split('/').last().unwrap_or_default();
+    format!("{}/{}", BUS_SOURCES_PREFIX, name)
+}

--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -661,6 +661,9 @@ impl CompositeDevice {
                 SourceIioImuInterface::listen_on_dbus(self.conn.clone(), device.clone()).await?;
             }
 
+            // Add any other source device DBus interfaces
+            source_device.listen_on_dbus(self.conn.clone());
+
             self.source_device_tasks.spawn(async move {
                 if let Err(e) = source_device.run().await {
                     log::error!("Failed running device: {:?}", e);

--- a/src/input/output_event/mod.rs
+++ b/src/input/output_event/mod.rs
@@ -7,7 +7,7 @@ use crate::drivers::{
     steam_deck::hid_report::{PackedHapticReport, PackedRumbleReport, PadSide},
 };
 
-use super::output_capability::{Haptic, OutputCapability};
+use super::output_capability::{Haptic, OutputCapability, LED};
 
 /// Output events are events that flow from target devices back to source devices
 #[derive(Debug, Clone)]
@@ -17,6 +17,7 @@ pub enum OutputEvent {
     DualSense(SetStatePackedOutputData),
     SteamDeckHaptics(PackedHapticReport),
     SteamDeckRumble(PackedRumbleReport),
+    LedColor { r: u8, g: u8, b: u8 },
 }
 
 impl OutputEvent {
@@ -71,6 +72,7 @@ impl OutputEvent {
                 }
             }
             OutputEvent::SteamDeckRumble(_) => vec![OutputCapability::ForceFeedback],
+            OutputEvent::LedColor { r: _, g: _, b: _ } => vec![OutputCapability::LED(LED::Color)],
         }
     }
 }

--- a/src/input/source/evdev.rs
+++ b/src/input/source/evdev.rs
@@ -8,6 +8,7 @@ use std::{collections::HashMap, error::Error, time::Duration};
 use evdev::{Device, EventType};
 use keyboard::KeyboardEventDevice;
 use touchscreen::TouchscreenEventDevice;
+use zbus::Connection;
 
 use crate::{
     config::{
@@ -94,6 +95,15 @@ impl SourceDeviceCompatible for EventDevice {
             EventDevice::Gamepad(source_driver) => source_driver.get_device_path(),
             EventDevice::Touchscreen(source_driver) => source_driver.get_device_path(),
             EventDevice::Keyboard(source_driver) => source_driver.get_device_path(),
+        }
+    }
+
+    fn listen_on_dbus(&self, conn: Connection) {
+        match self {
+            EventDevice::Blocked(source_driver) => source_driver.listen_on_dbus(conn),
+            EventDevice::Gamepad(source_driver) => source_driver.listen_on_dbus(conn),
+            EventDevice::Touchscreen(source_driver) => source_driver.listen_on_dbus(conn),
+            EventDevice::Keyboard(source_driver) => source_driver.listen_on_dbus(conn),
         }
     }
 }

--- a/src/input/source/evdev/gamepad.rs
+++ b/src/input/source/evdev/gamepad.rs
@@ -545,6 +545,7 @@ impl SourceOutputDevice for GamepadEventDevice {
                 }
                 Ok(())
             }
+            OutputEvent::LedColor { r: _, g: _, b: _ } => Ok(()),
         }
     }
 

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -27,8 +27,8 @@ use legos_touchpad::LegionSTouchpadController;
 use msi_claw::MsiClaw;
 use rog_ally::RogAlly;
 use xpad_uhid::XpadUhid;
-use zotac_zone::ZotacZone;
 use zbus::Connection;
+use zotac_zone::ZotacZone;
 
 use crate::{
     config, constants::BUS_SOURCES_PREFIX, drivers,

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -28,6 +28,7 @@ use msi_claw::MsiClaw;
 use rog_ally::RogAlly;
 use xpad_uhid::XpadUhid;
 use zotac_zone::ZotacZone;
+use zbus::Connection;
 
 use crate::{
     config, constants::BUS_SOURCES_PREFIX, drivers,
@@ -227,6 +228,29 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::Vader4Pro(source_driver) => source_driver.get_device_path(),
             HidRawDevice::XpadUhid(source_driver) => source_driver.get_device_path(),
             HidRawDevice::ZotacZone(source_driver) => source_driver.get_device_path(),
+        }
+    }
+
+    fn listen_on_dbus(&self, conn: Connection) {
+        match self {
+            HidRawDevice::Blocked(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::DualSense(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::Fts3528Touchscreen(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::HoripadSteam(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::LegionGoDCombined(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::LegionGoDSplit(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::LegionGoFPS(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::LegionGoSImu(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::LegionGoSTouchpad(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::LegionGoSXInput(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::LegionGoXInput(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::OrangePiNeo(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::MsiClaw(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::RogAlly(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::SteamDeck(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::XpadUhid(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::Vader4Pro(source_driver) => source_driver.listen_on_dbus(conn),
+            HidRawDevice::ZotacZone(source_driver) => source_driver.listen_on_dbus(conn),
         }
     }
 }

--- a/src/input/source/hidraw/dualsense.rs
+++ b/src/input/source/hidraw/dualsense.rs
@@ -6,6 +6,7 @@ use packed_struct::types::SizedInteger;
 
 use crate::drivers::dualsense::driver::{DS5_EDGE_PID, DS5_PID, DS5_VID};
 use crate::drivers::steam_deck::hid_report::PackedRumbleReport;
+use crate::input::output_capability::{OutputCapability, LED};
 use crate::{
     drivers::dualsense::{self, driver::Driver},
     input::{
@@ -175,6 +176,10 @@ impl SourceOutputDevice for DualSenseController {
                 }
                 Ok(())
             }
+            OutputEvent::LedColor { r, g, b } => {
+                self.driver.set_led_color(r, g, b)?;
+                Ok(())
+            }
         }
     }
 
@@ -203,6 +208,14 @@ impl SourceOutputDevice for DualSenseController {
         log::debug!("Erasing FF effect data");
         self.ff_evdev_effects.remove(&effect_id);
         Ok(())
+    }
+
+    /// Returns the output capabilities of the device
+    fn get_output_capabilities(&self) -> Result<Vec<OutputCapability>, OutputError> {
+        Ok(vec![
+            OutputCapability::ForceFeedback,
+            OutputCapability::LED(LED::Color),
+        ])
     }
 }
 

--- a/src/input/source/hidraw/legos_xinput.rs
+++ b/src/input/source/hidraw/legos_xinput.rs
@@ -181,6 +181,7 @@ impl SourceOutputDevice for LegionSXInputController {
                 let r_speed = (report.right_speed.to_primitive() / 256) as u8;
                 self.driver.haptic_rumble(l_speed, r_speed)?;
             }
+            OutputEvent::LedColor { r: _, g: _, b: _ } => (),
         }
 
         Ok(())

--- a/src/input/source/hidraw/steam_deck.rs
+++ b/src/input/source/hidraw/steam_deck.rs
@@ -231,6 +231,7 @@ impl SourceOutputDevice for DeckController {
                 let report = packed_rumble_report.pack().map_err(|e| e.to_string())?;
                 self.driver.write(&report)?;
             }
+            OutputEvent::LedColor { r: _, g: _, b: _ } => (),
         }
 
         Ok(())

--- a/src/input/source/hidraw/xpad_uhid.rs
+++ b/src/input/source/hidraw/xpad_uhid.rs
@@ -148,6 +148,7 @@ impl SourceOutputDevice for XpadUhid {
             OutputEvent::Uinput(_) => Ok(()),
             OutputEvent::SteamDeckHaptics(_packed_haptic_report) => Ok(()),
             OutputEvent::SteamDeckRumble(_packed_rumble_report) => Ok(()),
+            OutputEvent::LedColor { r: _, g: _, b: _ } => Ok(()),
         }
     }
 

--- a/src/input/source/iio.rs
+++ b/src/input/source/iio.rs
@@ -6,6 +6,7 @@ pub mod bmi_imu_new;
 use std::error::Error;
 
 use glob_match::glob_match;
+use zbus::Connection;
 
 use crate::{
     config, constants::BUS_SOURCES_PREFIX, input::composite_device::client::CompositeDeviceClient,
@@ -72,6 +73,13 @@ impl SourceDeviceCompatible for IioDevice {
         match self {
             IioDevice::BmiImu(source_driver) => source_driver.get_device_path(),
             IioDevice::AccelGryo3D(source_driver) => source_driver.get_device_path(),
+        }
+    }
+
+    fn listen_on_dbus(&self, conn: Connection) {
+        match self {
+            IioDevice::BmiImu(source_driver) => source_driver.listen_on_dbus(conn),
+            IioDevice::AccelGryo3D(source_driver) => source_driver.listen_on_dbus(conn),
         }
     }
 }

--- a/src/input/source/led.rs
+++ b/src/input/source/led.rs
@@ -54,6 +54,12 @@ impl SourceDeviceCompatible for LedDevice {
             LedDevice::MultiColorChassis(source_driver) => source_driver.get_device_path(),
         }
     }
+
+    fn listen_on_dbus(&self, conn: zbus::Connection) {
+        match self {
+            LedDevice::MultiColorChassis(source_driver) => source_driver.listen_on_dbus(conn),
+        }
+    }
 }
 
 impl LedDevice {

--- a/src/input/source/led/multicolor_chassis.rs
+++ b/src/input/source/led/multicolor_chassis.rs
@@ -2,6 +2,7 @@ use crate::{
     config::LedFixedColor,
     input::{
         capability::Capability,
+        output_capability::{OutputCapability, LED},
         output_event::OutputEvent,
         source::{InputError, OutputError, SourceInputDevice, SourceOutputDevice},
     },
@@ -132,10 +133,18 @@ impl SourceOutputDevice for MultiColorChassis {
                 }
                 self.write_color(report.led_red, report.led_green, report.led_blue)?;
             }
+            OutputEvent::LedColor { r, g, b } => {
+                self.write_color(r, g, b)?;
+            }
             _ => {
                 return Ok(());
             }
         }
         Ok(())
+    }
+
+    /// Returns the output capabilities of the device
+    fn get_output_capabilities(&self) -> Result<Vec<OutputCapability>, OutputError> {
+        Ok(vec![OutputCapability::LED(LED::Color)])
     }
 }


### PR DESCRIPTION
This change adds a new `org.shadowblip.Output.Source.LED` dbus interface on any source device that supports the `OutputCapability::LED(LED::Color)` capability to allow LED control over dbus.

```bash
$ busctl introspect org.shadowblip.InputPlumber /org/shadowblip/InputPlumber/devices/source/hidraw5
NAME                                     TYPE      SIGNATURE RESULT/VALUE                             FLAGS
org.shadowblip.Input.Source.UdevDevice   interface -         -                                        -
.DevicePath                              property  s         "/dev/hidraw5"                           emits-change
.IdBustype                               property  s         "3"                                      emits-change
.IdProduct                               property  s         "0ce6"                                   emits-change
.IdVendor                                property  s         "054c"                                   emits-change
.IdVersion                               property  s         "33041"                                  emits-change
.Name                                    property  s         "Sony Interactive Entertainment DualSen… emits-change
.PhysPath                                property  s         ""                                       emits-change
.Properties                              property  a{ss}     15 "CURRENT_TAGS" ":uaccess:seat:" "DEV… emits-change
.Subsystem                               property  s         "hidraw"                                 emits-change
.SysfsPath                               property  s         "/devices/pci0000:00/0000:00:08.3/0000:… emits-change
org.shadowblip.Output.Source.LED         interface -         -                                        -
.SetColor                                method    yyy       -                                        -
```

The LED color can be set by calling the `SetColor` method on this interface:

```bash
busctl call org.shadowblip.InputPlumber \
    /org/shadowblip/InputPlumber/devices/source/hidraw5 \
    org.shadowblip.Output.Source.LED \
    SetColor "yyy" 255 0 255
```