### PR TITLE
fix(README.md): Fix typos in Arch Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ make build
 sudo make install
 ```
 
-If you are using ArchLinux or any of its derivaties,
+If you are using Arch Linux or any of its derivatives,
 you can install InputPlumber from the official repositories:
 
 ```bash


### PR DESCRIPTION
It seems my earlier change #334 introduced a typo here. I also took some liberties and added a whitespace between Arch and Linux.