### PR TITLE
feat(Legion Go S): Add Config Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,6 +989,7 @@ dependencies = [
  "tokio",
  "udev",
  "uhid-virt",
+ "version-compare",
  "virtual-usb",
  "xdg",
  "zbus",
@@ -2127,6 +2128,12 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom 0.2.15",
 ]
+
+[[package]]
+name = "version-compare"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
 
 [[package]]
 name = "virtual-usb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ thiserror = "1.0.69"
 tokio = { version = "1.43.0", features = ["full"] }
 udev = { version = "0.9.3", features = ["mio"] }
 uhid-virt = "0.0.8"
+version-compare = "0.2.0"
 virtual-usb = { git = "https://github.com/ShadowBlip/virtual-usb-rs.git", rev = "5c4c551a23b56f627a36d6775a5876c174be9eb3" }
 xdg = "2.5.2"
 zbus = { version = "5.5.0", default-features = false, features = ["tokio"] }

--- a/rootfs/usr/share/inputplumber/devices/50-legion_go_s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go_s.yaml
@@ -23,6 +23,39 @@ matches:
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.
 source_devices:
+  # Config, used for setting attributes on load
+  - group: gamepad
+    udev:
+      attributes:
+        - name: bInterfaceNumber
+          value: "03"
+        - name: idVendor
+          value: "1a86"
+        - name: idProduct
+          value: "e310"
+      driver: lenovo-legos-hid
+      subsystem: hidraw
+  - group: gamepad
+    udev:
+      attributes:
+        - name: bInterfaceNumber
+          value: "03"
+        - name: idVendor
+          value: "1a86"
+        - name: idProduct
+          value: "e311"
+      driver: lenovo-legos-hid
+      subsystem: hidraw
+  #- group: gamepad
+  #  hidraw:
+  #    vendor_id: 0x1a86
+  #    product_id: 0xe310
+  #    interface_num: 3
+  #- group: gamepad
+  #  hidraw:
+  #    vendor_id: 0x1a86
+  #    product_id: 0xe311
+  #    interface_num: 3
   # Mouse
   - group: mouse
     blocked: true

--- a/src/drivers/legos/config_driver.rs
+++ b/src/drivers/legos/config_driver.rs
@@ -1,0 +1,78 @@
+use crate::udev::device::{AttributeGetter, AttributeSetter, UdevDevice};
+use std::error::Error;
+use udev::Device;
+use version_compare::{compare, Cmp};
+
+use super::{CFG_IID, PIDS, VID};
+
+pub struct ConfigDriver {
+    _device: UdevDevice,
+}
+
+impl ConfigDriver {
+    pub fn new(udevice: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let vid = udevice.id_vendor();
+        let pid = udevice.id_product();
+        let iid = udevice.interface_number();
+
+        if vid != VID || iid != CFG_IID || !PIDS.contains(&pid) {
+            return Err(
+                format!("'{}' is not a Legion Go S Config Device", udevice.devnode()).into(),
+            );
+        }
+
+        let device = udevice.get_device()?;
+        let Some(parent) = device.parent() else {
+            return Err("Failed to get device parent".into());
+        };
+
+        let Some(driver) = parent.driver() else {
+            return Err("Failed to identify device driver".into());
+        };
+
+        if driver != "lenovo-legos-hid" {
+            return Err("Device is not using the lenovo-legos-hid driver.".into());
+        }
+
+        let mcu_version = device.get_attribute_from_tree("mcu_version");
+        if compare(mcu_version.as_str(), "0.0.3.4") == Ok(Cmp::Lt) {
+            log::warn!("MCU firmware v{mcu_version} does not meet the minimum supported feature level. Update to v0.0.3.4 or greater to ensure full compatibility.");
+        }
+
+        let tp_vendor = device.get_attribute_from_tree("touchpad/manufacturer");
+        let tp_version = device.get_attribute_from_tree("touchpad/version");
+
+        match tp_vendor.as_str() {
+            "BetterLife" => {
+                if compare(tp_version.as_str(), "15") == Ok(Cmp::Lt) {
+                    log::warn!("Touchpad firmware v{tp_version} does not meet the minimum supported feature level. Update to v15 or greater to ensure full compatibility.");
+                };
+            }
+
+            "SIPO" => {
+                if compare(tp_version.as_str(), "20") == Ok(Cmp::Lt) {
+                    log::warn!("Touchpad firmware v{tp_version} does not meet the minimum supported feature level. Update to v20 or greater to ensure full compatibility.");
+                };
+            }
+            _ => {
+                log::warn!("Unable to determine Touchpad vendor. Update your device to the latest firmware to ensure full compatibility.");
+            }
+        }
+
+        set_attribute(device.clone(), "gamepad/auto_sleep_time", "0");
+        set_attribute(device.clone(), "gamepad/dpad_mode", "8-way");
+        set_attribute(device.clone(), "gamepad/mode", "xinput");
+        set_attribute(device.clone(), "gamepad/poll_rate", "250");
+        set_attribute(device.clone(), "os_mode", "linux");
+        set_attribute(device.clone(), "touchpad/linux_mode", "absolute");
+
+        Ok(Self { _device: udevice })
+    }
+}
+
+fn set_attribute(mut device: Device, attribute: &str, value: &str) {
+    match device.set_attribute_on_tree(attribute, value) {
+        Ok(_) => log::debug!("set {attribute} to {value}"),
+        Err(e) => log::warn!("Could not set {attribute} to {value}: {e:?}"),
+    }
+}

--- a/src/drivers/legos/mod.rs
+++ b/src/drivers/legos/mod.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 pub mod event;
 pub mod hid_report;
+pub mod config_driver;
 pub mod imu_driver;
 pub mod touchpad_driver;
 pub mod xinput_driver;
@@ -12,8 +13,9 @@ pub const XINPUT_PID: u16 = 0xe310;
 pub const DINPUT_PID: u16 = 0xe311;
 pub const PIDS: [u16; 2] = [XINPUT_PID, DINPUT_PID];
 
-pub const IMU_IID: i32 = 0x5;
+pub const CFG_IID: i32 = 0x3;
 pub const TP_IID: i32 = 0x2;
+pub const IMU_IID: i32 = 0x5;
 pub const GP_IID: i32 = 0x6;
 
 // Input report sizes

--- a/src/input/source/hidraw/legos_config.rs
+++ b/src/input/source/hidraw/legos_config.rs
@@ -1,0 +1,42 @@
+use std::{error::Error, fmt::Debug};
+
+use crate::{
+    drivers::legos::config_driver::ConfigDriver,
+    input::{
+        capability::Capability,
+        event::native::NativeEvent,
+        source::{InputError, SourceInputDevice, SourceOutputDevice},
+    },
+    udev::device::UdevDevice,
+};
+
+/// XpadUhid source device implementation
+pub struct LegionSConfigController {
+    _driver: ConfigDriver,
+}
+
+impl LegionSConfigController {
+    /// Create a new source device with the given udev
+    /// device information
+    pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let driver = ConfigDriver::new(device_info)?;
+        Ok(Self { _driver: driver })
+    }
+}
+
+impl Debug for LegionSConfigController {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LegionSConfig").finish()
+    }
+}
+impl SourceInputDevice for LegionSConfigController {
+    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        Ok(vec![])
+    }
+
+    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
+        Ok(vec![])
+    }
+}
+
+impl SourceOutputDevice for LegionSConfigController {}


### PR DESCRIPTION
- Adds support for configuring the Legion Go S Gamepad and Touchpad devices. Depends on lenovo-legos-hid driver.