### PR TITLE
fix(MSI Claw A1M): send MKeys setting when switching to xinput mode

### DIFF
--- a/src/drivers/msi_claw/driver.rs
+++ b/src/drivers/msi_claw/driver.rs
@@ -6,9 +6,9 @@ use std::{error::Error, ffi::CString};
 use hidapi::HidDevice;
 use packed_struct::PackedStruct;
 
-use crate::udev::device::UdevDevice;
+use crate::{drivers::msi_claw::hid_report::Command, udev::device::UdevDevice};
 
-use super::hid_report::{GamepadMode, PackedCommandReport};
+use super::hid_report::{GamepadMode, MkeysFunction, PackedCommandReport};
 
 // Hardware ID's
 pub const VID: u16 = 0x0db0;
@@ -35,13 +35,42 @@ impl Driver {
         Ok(Self { device })
     }
 
+    pub fn poll(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let mut buf = [0; 8];
+        let bytes_read = self.device.read(&mut buf[..])?;
+        let slice = &buf[..bytes_read];
+
+        if bytes_read > 0 {
+            log::debug!("Got response bytes: {slice:?}");
+            let report = PackedCommandReport::unpack(&buf)?;
+            log::debug!("Response: {report}");
+
+            if report.command == Command::GamepadModeAck {
+                let mode: GamepadMode = report.arg1.into();
+                log::debug!("Current gamepad mode: {mode:?}");
+            }
+        }
+
+        Ok(())
+    }
+
     // Configure the device to be in the given mode
     // TODO: Update to use sysfs interface when kernel support is upstreamed
-    pub fn set_mode(&self, mode: GamepadMode) -> Result<(), Box<dyn Error + Send + Sync>> {
-        let report = PackedCommandReport {
-            mode,
-            ..Default::default()
-        };
+    pub fn set_mode(
+        &self,
+        mode: GamepadMode,
+        mkeys: MkeysFunction,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let report = PackedCommandReport::switch_mode(mode, mkeys);
+        let data = report.pack()?;
+        self.device.write(&data)?;
+
+        Ok(())
+    }
+
+    /// Send a get mode request to the device
+    pub fn get_mode(&self) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let report = PackedCommandReport::read_mode();
         let data = report.pack()?;
         self.device.write(&data)?;
 


### PR DESCRIPTION
This change fixes an issue where sometimes the gamepad would fail to switch into xinput mode. Tested on two different devices. It will also read and print the current gamepad mode if debug logging is enabled.