### PR TITLE
fix(GPD): Remove keyboard entry from winmini device

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
@@ -27,11 +27,6 @@ source_devices:
       name: "Microsoft X-Box 360 pad"
       phys_path: usb-0000:63:00.3-5/input0
       handler: event*
-  - group: keyboard
-    evdev:
-      name: "  Mouse for Windows"
-      phys_path: usb-0000:63:00.3-3/input1
-      handler: event*
   - group: imu
     iio:
       name: i2c-BMI0160:00


### PR DESCRIPTION
When force feedback effects occurred, InputPlumber would try to communicate with event5 (Mouse for Windows) instead of event7 (Microsoft X-Box 360 pad). This would initially appear as warnings in the log, and would cause FF effects to fail after a suspend / resume cycle.

It seems like there's an underlying problem, but I'm not familiar enough with how InputPlumber works to do any heavy debugging. Removing this entry is a way to work around it, and shouldn't have an effect since keyboard / trackpad support isn't fully functional in InputPlumber for the Win Mini anyway yet.

Fixes #255.

Before the change:

```
[2025-05-10T20:19:14Z INFO  inputplumber::input::manager] Gamepad order: ["/org/shadowblip/InputPlumber/CompositeDevice0"]
[2025-05-10T20:19:21Z WARN  inputplumber::input::composite_device] Unable to find source effect id for effect 0 from evdev://event5
[2025-05-10T20:19:22Z WARN  inputplumber::input::composite_device] Unable to find source effect id for effect 0 from evdev://event5

Broadcast message from jweiss@arch-sd (Sat 2025-05-10 13:19:24 PDT):

The system will suspend now!

[2025-05-10T20:20:12Z ERROR inputplumber::input::composite_device] Failed running device: "InputError occurred running source device: Failed to fetch events: Os { code: 19, kind: Uncategorized, message: \"No such device\" }"
[2025-05-10T20:20:12Z INFO  inputplumber::input::manager] Found missing input device, adding source device evdev://event7 to existing composite device: "/org/shadowblip/InputPlumber/CompositeDevice0"
[2025-05-10T20:20:26Z WARN  inputplumber::input::source::evdev::gamepad] Unable to find existing FF effect with id 0
[2025-05-10T20:20:26Z WARN  inputplumber::input::composite_device] Unable to find source effect id for effect 0 from evdev://event5
[2025-05-10T20:20:26Z WARN  inputplumber::input::source::evdev::gamepad] Unable to find existing FF effect with id 0
[2025-05-10T20:20:26Z WARN  inputplumber::input::composite_device] Unable to find source effect id for effect 0 from evdev://event5
[2025-05-10T20:20:26Z WARN  inputplumber::input::source::evdev::gamepad] Unable to find existing FF effect with id 0
```

After:

```
[2025-05-10T20:33:48Z INFO  inputplumber::input::manager] Found matching source device for: "GPD WinMini"
[2025-05-10T20:33:48Z INFO  inputplumber::input::composite_device] Creating CompositeDevice with config: GPD WinMini
[2025-05-10T20:33:48Z INFO  inputplumber::input::composite_device] Loading device profile `Default` from: /usr/share/inputplumber/profiles/default.yaml
[2025-05-10T20:33:48Z ERROR inputplumber::input::manager] Failed to remove udev dbus interface /org/shadowblip/InputPlumber/devices/source/inputplumber: InterfaceNotFound
[2025-05-10T20:33:48Z ERROR inputplumber::input::manager] Failed to remove dbus interface /org/shadowblip/InputPlumber/devices/source/inputplumber: Failure("Invalid subsystem: ''")
[2025-05-10T20:33:48Z INFO  inputplumber::input::manager] Gamepad order: ["/org/shadowblip/InputPlumber/CompositeDevice0"]

Broadcast message from jweiss@arch-sd (Sat 2025-05-10 13:34:09 PDT):

The system will suspend now!

[2025-05-10T20:34:24Z ERROR inputplumber::input::manager] Failed to remove udev dbus interface /org/shadowblip/InputPlumber/devices/source/inputplumber: InterfaceNotFound
[2025-05-10T20:34:24Z INFO  inputplumber::input::composite_device] CompositeDevice stopping: /org/shadowblip/InputPlumber/CompositeDevice0
[2025-05-10T20:34:24Z ERROR inputplumber::input::manager] Failed to remove dbus interface /org/shadowblip/InputPlumber/devices/source/inputplumber: Failure("Invalid subsystem: ''")
[2025-05-10T20:34:24Z ERROR inputplumber::input::composite_device] Failed running device: "InputError occurred running source device: Failed to fetch events: Os { code: 19, kind: Uncategorized, message: \"No such device\" }"
[2025-05-10T20:34:24Z INFO  inputplumber::input::composite_device] CompositeDevice stopped: /org/shadowblip/InputPlumber/CompositeDevice0
[2025-05-10T20:34:24Z ERROR inputplumber::input::manager] Failed to check if device is suspended: ChannelClosed
[2025-05-10T20:34:24Z ERROR inputplumber::input::manager] Failed to check if device is suspended: SendError(SendError { .. })
[2025-05-10T20:34:24Z INFO  inputplumber::input::manager] Gamepad order: []
[2025-05-10T20:34:24Z ERROR inputplumber::input::composite_device] Failed to send source devices changed signal: FDO(Failed("device no longer exists"))
[2025-05-10T20:34:24Z INFO  inputplumber::input::manager] Found a matching input device evdev://event7, creating CompositeDevice
[2025-05-10T20:34:24Z INFO  inputplumber::input::manager] Found matching source device for: "GPD WinMini"
[2025-05-10T20:34:24Z INFO  inputplumber::input::composite_device] Creating CompositeDevice with config: GPD WinMini
[2025-05-10T20:34:24Z INFO  inputplumber::input::composite_device] Loading device profile `Default` from: /usr/share/inputplumber/profiles/default.yaml
[2025-05-10T20:34:24Z INFO  inputplumber::input::manager] Gamepad order: ["/org/shadowblip/InputPlumber/CompositeDevice0"]
```

Despite the errors, rumble worked correctly after this change.