### PR TITLE
feat(Autostart): Add autostart rules/hwdb for InputPlumber

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ assets = [
   { source = "rootfs/usr/share/inputplumber/capability_maps/*.yaml", dest = "/usr/share/inputplumber/capability_maps/", mode = "644" },
   { source = "rootfs/usr/share/inputplumber/profiles/*.yaml", dest = "/usr/share/inputplumber/profiles/", mode = "644" },
   { source = "rootfs/usr/lib/udev/hwdb.d/59-inputplumber.hwdb", dest = "/usr/lib/udev/hwdb.d/59-inputplumber.hwdb", mode = "644" },
+  { source = "rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb", dest = "/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb", mode = "644" },
+  { source = "rootfs/usr/lib/udev/rules.d/90-inputplumber-autostart.rules", dest = "/usr/lib/udev/rules.d/90-inputplumber-autostart.rules", mode = "644" },
 ]
 auto-req = "no"
 

--- a/Makefile
+++ b/Makefile
@@ -48,8 +48,10 @@ install: build ## Install inputplumber to the given prefix (default: PREFIX=/usr
 		$(PREFIX)/share/dbus-1/system.d/$(DBUS_NAME).conf
 	install -D -m 644 -t $(PREFIX)/lib/systemd/system/ \
 		rootfs/usr/lib/systemd/system/*
-	install -D -m 644 rootfs/usr/lib/udev/hwdb.d/59-inputplumber.hwdb \
-		$(PREFIX)/lib/udev/hwdb.d/59-inputplumber.hwdb
+	install -D -m 644 -t $(PREFIX)/lib/udev/hwdb.d/ \
+		rootfs/usr/lib/udev/hwdb.d/*
+	install -D -m 644 -t $(PREFIX)/lib/udev/rules.d/ \
+		rootfs/usr/lib/udev/rules.d/*
 	install -D -m 644 -t $(PREFIX)/share/$(NAME)/devices/ \
 		rootfs/usr/share/$(NAME)/devices/*
 	install -D -m 644 -t $(PREFIX)/share/$(NAME)/schema/ \
@@ -70,6 +72,8 @@ uninstall: ## Uninstall inputplumber
 	rm $(PREFIX)/lib/systemd/system/$(NAME).service
 	rm $(PREFIX)/lib/systemd/system/$(NAME)-suspend.service
 	rm $(PREFIX)/lib/udev/hwdb.d/59-inputplumber.hwdb
+	rm $(PREFIX)/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
+	rm $(PREFIX)/lib/udev/rules.d/90-inputplumber-autostart.rules
 	rm -rf $(PREFIX)/share/$(NAME)/devices/
 	rm -rf $(PREFIX)/share/$(NAME)/schema/
 	rm -rf $(PREFIX)/share/$(NAME)/capability_maps/

--- a/pkg/rpm/inputplumber.spec
+++ b/pkg/rpm/inputplumber.spec
@@ -31,6 +31,7 @@ mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/share/dbus-1/system.d
 mkdir -p %{buildroot}/usr/lib/systemd/system
 mkdir -p %{buildroot}/usr/lib/udev/hwdb.d
+mkdir -p %{buildroot}/usr/lib/udev/rules.d
 mkdir -p %{buildroot}/usr/share/inputplumber/capability_maps
 mkdir -p %{buildroot}/usr/share/inputplumber/devices
 mkdir -p %{buildroot}/usr/share/inputplumber/profiles
@@ -40,6 +41,8 @@ install -D -m 755 %{_builddir}/InputPlumber/target/%{_arch}-unknown-linux-gnu/re
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf %{buildroot}/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/lib/systemd/system/* %{buildroot}/usr/lib/systemd/system/
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/lib/udev/hwdb.d/59-inputplumber.hwdb %{buildroot}/usr/lib/udev/hwdb.d/59-inputplumber.hwdb
+install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb %{buildroot}/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
+install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/lib/udev/rules.d/90-inputplumber-autostart.rules %{buildroot}/usr/lib/udev/rules.d/90-inputplumber-autostart.rules
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/share/inputplumber/capability_maps/* %{buildroot}/usr/share/inputplumber/capability_maps/
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/share/inputplumber/devices/* %{buildroot}/usr/share/inputplumber/devices/
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/share/inputplumber/profiles/* %{buildroot}/usr/share/inputplumber/profiles/

--- a/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
+++ b/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
@@ -1,0 +1,85 @@
+# AOKZOE A1
+dmi:*svnAOKZOE:pnAOKZOEA1AR07:*
+dmi:*svnAOKZOE:pnAOKZOEA1Pro:*
+# ASUS Rog Ally/X
+dmi:*svnASUSTeKCOMPUTERINC.:*rnRC71L:*
+dmi:*svnASUSTeKCOMPUTERINC.:*rnRC72LA:*
+# AYANEO 2
+dmi:*svnAYANEO:pnAYANEO2:*
+dmi:*svnAYANEO:pnAYANEO2S:*
+dmi:*svnAYANEO:pnAYANEOGEEK:*
+dmi:*svnAYANEO:pnAYANEOGEEK1S:*
+# AYANEO 2021
+dmi:*svnAYANEO:pnAYANEO2021:*
+dmi:*svnAYANEO:pnAYANEO2021Pro:*
+dmi:*svnAYANEO:pnAYANEO2021ProRetroPower:*
+dmi:*svnAYANEO:pnAYANEOFOUNDER:*
+# AYANEO Air
+dmi:*svnAYANEO:pnAIR1S:*
+dmi:*svnAYANEO:pnAIR1SLimited:*
+dmi:*svnAYANEO:pnAIR:*
+dmi:*svnAYANEO:pnAIRPlus:*
+dmi:*svnAYANEO:pnAIRPro:*
+# AYANEO Flip
+dmi:*svnAYANEO:pnFLIPDS:*
+dmi:*svnAYANEO:pnFLIPKB:*
+# AYANEO Kun
+dmi:*svnAYANEO:pnAYANEOKUN:*
+# AYANEO Next
+dmi:*svnAYANEO:pnAYANEONEXT:*
+dmi:*svnAYANEO:pnAYANEONEXTAdvance:*
+dmi:*svnAYANEO:pnAYANEONEXTPro:*
+dmi:*svnAYANEO:pnNEXT:*
+dmi:*svnAYANEO:pnNEXTAdvance:*
+dmi:*svnAYANEO:pnNEXTLite:*
+dmi:*svnAYANEO:pnNEXTPro:*
+# AYANEO Slide
+dmi:*svnAYANEO:pnSLIDE:*
+# AYN Loki
+dmi:*svnayn:pnLokiMax:*
+dmi:*svnayn:pnLokiMiniPro:*
+dmi:*svnayn:pnLokiZero:*
+# GPD Win 3
+dmi:*svnGPD:pnG1618-03:*
+# GPD Win 4
+dmi:*svnGPD:pnG1618-04:*
+# GPD Win Max 2
+dmi:*svnGPD:pnG1619-04:*
+# GPD Win Mini
+dmi:*svnGPD:pnG1617-01:*
+# Lenovo Legion Go
+dmi:*svnLENOVO:pn83E1:*
+# Lenovo Legion Go S
+dmi:*svnLENOVO:pn83L3:*
+dmi:*svnLENOVO:pn83N6:*
+dmi:*svnLENOVO:pn83Q2:*
+dmi:*svnLENOVO:pn83Q3:*
+# MSI Claw
+dmi:*:svnMicro-StarInternationalCo.,Ltd.:pnClaw7AI+A2VM:*
+dmi:*:svnMicro-StarInternationalCo.,Ltd.:pnClaw8AI+A2VM:*
+dmi:*:svnMicro-StarInternationalCo.,Ltd.:pnClawA1M:*
+# OneXPlayer Old models
+dmi:*svnONE-NETBOOK:pnONEXPLAYER:*
+dmi:*svnONE-NETBOOKTECHNOLOGYCO.,LTD.:pnONEXPLAYER:*
+# OneXPlayer 2
+dmi:*svnONE-NETBOOK:pnONEXPLAYER2ARP23:*
+dmi:*svnONE-NETBOOK:pnONEXPLAYER2PROARP23:*
+dmi:*svnONE-NETBOOK:pnONEXPLAYER2PROARP23EVA-01:*
+# OneXPlayer Mini A07
+dmi:*svnONE-NETBOOK:pnONEXPLAYERminiA07:*
+# OneXPlayer Mini Pro
+dmi:*svnONE-NETBOOK:pnONEXPLAYERMiniPro:*
+# OneXPlayer OneXFly
+dmi:*svnONE-NETBOOK:pnONEXPLAYERF1:*
+dmi:*svnONE-NETBOOK:pnONEXPLAYERF1Pro:*
+# OneXPlayer X1
+dmi:*svnONE-NETBOOK:pnONEXPLAYERX1A:*
+dmi:*svnONE-NETBOOK:pnONEXPLAYERX1i:*
+dmi:*svnONE-NETBOOK:pnONEXPLAYERX1mini:*
+# OrangePi Neo
+dmi:*svnOrangePi:pnNEO-01:*
+# Zotac Zone
+dmi:*svnZOTAC:*rnG0A1W:*
+dmi:*svnZOTAC:*rnG1A1W:*
+  USE_INPUTPLUMBER=1
+

--- a/rootfs/usr/lib/udev/rules.d/90-inputplumber-autostart.rules
+++ b/rootfs/usr/lib/udev/rules.d/90-inputplumber-autostart.rules
@@ -1,0 +1,1 @@
+ENV{USE_INPUTPLUMBER}=="1", TAG+="uaccess", TAG+="systemd", ENV{SYSTEMD_WANTS}+="inputplumber.service"


### PR DESCRIPTION
- Modified from steamos-customizations, the new udev hwdb and udev rules allow for automatic startup of inputplumber on boot. This allows immutable systems to ship inputplumber and not need clever hacks or a blanket service enabling when not needed. This will also improve the level of support out of the box in SteamOS.