### PR TITLE
fix(Makefile): use target triple from rustc for TARGET_ARCH

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,4 +28,4 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: |
-          make in-docker TARGET='dist' BUILD_TYPE='debug' ARCH='aarch64'
+          make in-docker TARGET='dist' BUILD_TYPE='debug' TARGET_ARCH='aarch64-unknown-linux-gnu'

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -37,7 +37,7 @@ plugins:
     - shell: true
       prepareCmd: |
         make in-docker TARGET='dist update-pkgbuild-hash'
-        make in-docker TARGET='dist' ARCH="aarch64"
+        make in-docker TARGET='dist' TARGET_ARCH="aarch64-unknown-linux-gnu"
       publishCmd: "echo '${nextRelease.version}' > .version.txt"
 
   # Commit the following changes to git after other plugins have run

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME := $(shell grep 'name =' Cargo.toml | head -n 1 | cut -d'"' -f2)
 VERSION := $(shell grep '^version =' Cargo.toml | cut -d'"' -f2)
-ARCH ?= $(shell uname -m)
-TARGET_ARCH ?= $(ARCH)-unknown-linux-gnu
+TARGET_ARCH ?= $(shell rustc -vV | sed -n 's/host: //p')
+ARCH := $(shell echo "$(TARGET_ARCH)" | cut -d'-' -f1)
 DBUS_NAME := org.shadowblip.InputPlumber
 ALL_RS := $(shell find src -name '*.rs')
 ALL_ROOTFS := $(shell find rootfs -type f)


### PR DESCRIPTION
Sometimes `uname -m` does not match target triple's arch (like riscv64, which is riscv64gc-*), sometimes we don't have `gnu` but `gnueabi` or `musl`. Use the [method](https://wiki.archlinux.org/title/Rust_package_guidelines#Prepare) used on Arch Linux to directly get target triple from rustc.