### PR TITLE
fix(Legion Go S): Use Tip Switch for touch detect.

### DIFF
--- a/src/drivers/legos/mod.rs
+++ b/src/drivers/legos/mod.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
+pub mod config_driver;
 pub mod event;
 pub mod hid_report;
-pub mod config_driver;
 pub mod imu_driver;
 pub mod touchpad_driver;
 pub mod xinput_driver;
@@ -27,8 +27,7 @@ const XINPUT_PACKET_SIZE: usize = 32;
 pub const GYRO_SCALE: i16 = 2;
 pub const PAD_FORCE_MAX: f64 = 127.0;
 pub const PAD_FORCE_NORMAL: u8 = 32; /* Simulated average pressure */
-pub const PAD_X_MAX: f64 = 400.0;
-pub const PAD_Y_MAX: f64 = 400.0;
+pub const PAD_MOTION_MAX: f64 = 400.0;
 pub const STICK_X_MAX: f64 = 127.0;
 pub const STICK_X_MIN: f64 = -127.0;
 pub const STICK_Y_MAX: f64 = 127.0;
@@ -40,4 +39,3 @@ const TOUCH_REPORT_ID: u8 = 0x31;
 
 // Timeouts
 const HID_TIMEOUT: i32 = 10;
-pub const PAD_RELEASE_DELAY: Duration = Duration::from_millis(25);

--- a/src/input/source/hidraw/legos_touchpad.rs
+++ b/src/input/source/hidraw/legos_touchpad.rs
@@ -1,7 +1,7 @@
 use std::{error::Error, fmt::Debug};
 
 use crate::{
-    drivers::legos::{event, touchpad_driver::TouchpadDriver, PAD_FORCE_MAX, PAD_X_MAX, PAD_Y_MAX},
+    drivers::legos::{event, touchpad_driver::TouchpadDriver, PAD_FORCE_MAX, PAD_MOTION_MAX},
     input::{
         capability::{Capability, Gamepad, GamepadTrigger, Touch, TouchButton, Touchpad},
         event::{native::NativeEvent, value::InputValue},
@@ -60,23 +60,16 @@ fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
     raw_value / max
 }
 
-/// Normalize the value to something between -1.0 and 1.0 based on the Deck's
+/// Normalize the value to something between -1.0 and 1.0 based on the
 /// minimum and maximum axis ranges.
 fn normalize_axis_value(event: event::AxisEvent) -> InputValue {
     match event {
         event::AxisEvent::Touchpad(value) => {
-            let max = PAD_X_MAX;
-            let x = normalize_unsigned_value(value.x as f64, max);
+            let x = normalize_unsigned_value(value.x as f64, PAD_MOTION_MAX);
+            let x = Some(x);
 
-            let max = PAD_Y_MAX;
-            let y = normalize_unsigned_value(value.y as f64, max);
-
-            // If this is an UP event, clear the position of X/Y
-            let (x, y) = if !value.is_touching {
-                (Some(0.0), Some(0.0))
-            } else {
-                (Some(x), Some(y))
-            };
+            let y = normalize_unsigned_value(value.y as f64, PAD_MOTION_MAX);
+            let y = Some(y);
 
             InputValue::Touch {
                 index: value.index,


### PR DESCRIPTION
- Remove delay based 'touch up' detection and use tip_switch value instead, which will remain 1 while the finger is present even if there is no motion.
- Minor cleanups while at it.