### PR TITLE
fix(GPD): Support upstream gyro driver

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
@@ -34,7 +34,7 @@ source_devices:
       handler: event*
   - group: imu
     iio:
-      name: i2c-BMI0160:00
+      name: "{i2c-BMI0160:00,bmi260}"
       mount_matrix:
         x: [1, 0, 0]
         y: [0, 0, -1]

--- a/src/input/source/iio.rs
+++ b/src/input/source/iio.rs
@@ -107,7 +107,7 @@ impl IioDevice {
         let name = device_name.as_str();
         log::debug!("Finding driver for IIO interface: {name}");
         // BMI_IMU
-        if glob_match("{i2c-10EC5280*,i2c-BOSC*,i2c-BMI*,bmi*-imu}", name) {
+        if glob_match("{i2c-10EC5280*,i2c-BOSC*,i2c-BMI*,bmi*-imu,bmi260}", name) {
             log::info!("Detected BMI IMU");
             return DriverType::BmiImu;
         }


### PR DESCRIPTION
The upstream driver has a different device name and needs to be detected using the new name.

I added `bmi260` literally because `bmi*` seemed like it could be too generic, but I'm happy to change `bmi*-imu` to `bmi*` if you'd prefer.