### PR TITLE
fix(Legion Go S): Use correct poll rates for Go S source devices.

### DIFF
--- a/src/drivers/legos/mod.rs
+++ b/src/drivers/legos/mod.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 pub mod config_driver;
 pub mod event;
 pub mod hid_report;

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -321,23 +321,63 @@ impl HidRawDevice {
                 Ok(Self::LegionGoXInput(source_device))
             }
             DriverType::LegionGoSConfig => {
+                let options = SourceDriverOptions {
+                    poll_rate: Duration::from_secs(1),
+                    buffer_size: 2048,
+                };
                 let device = LegionSConfigController::new(device_info.clone())?;
-                let source_device = SourceDriver::new(composite_device, device, device_info, conf);
+                let source_device = SourceDriver::new_with_options(
+                    composite_device,
+                    device,
+                    device_info,
+                    options,
+                    conf,
+                );
                 Ok(Self::LegionGoSConfig(source_device))
             }
             DriverType::LegionGoSImu => {
+                let options = SourceDriverOptions {
+                    poll_rate: Duration::from_millis(4),
+                    buffer_size: 2048,
+                };
                 let device = LegionSImuController::new(device_info.clone())?;
-                let source_device = SourceDriver::new(composite_device, device, device_info, conf);
+                let source_device = SourceDriver::new_with_options(
+                    composite_device,
+                    device,
+                    device_info,
+                    options,
+                    conf,
+                );
                 Ok(Self::LegionGoSImu(source_device))
             }
             DriverType::LegionGoSTouchpad => {
+                let options = SourceDriverOptions {
+                    poll_rate: Duration::from_millis(8),
+                    buffer_size: 2048,
+                };
                 let device = LegionSTouchpadController::new(device_info.clone())?;
-                let source_device = SourceDriver::new(composite_device, device, device_info, conf);
+                let source_device = SourceDriver::new_with_options(
+                    composite_device,
+                    device,
+                    device_info,
+                    options,
+                    conf,
+                );
                 Ok(Self::LegionGoSTouchpad(source_device))
             }
             DriverType::LegionGoSXInput => {
+                let options = SourceDriverOptions {
+                    poll_rate: Duration::from_millis(4),
+                    buffer_size: 2048,
+                };
                 let device = LegionSXInputController::new(device_info.clone())?;
-                let source_device = SourceDriver::new(composite_device, device, device_info, conf);
+                let source_device = SourceDriver::new_with_options(
+                    composite_device,
+                    device,
+                    device_info,
+                    options,
+                    conf,
+                );
                 Ok(Self::LegionGoSXInput(source_device))
             }
             DriverType::OrangePiNeo => {


### PR DESCRIPTION
The Legion Go S Poll rates were not correct for each source device. This caused stuttering in steam's virtual menus and affected steam input's momentum calculations. Steam input treats duplicate touch events as a "stop motion" case, if the x and y have not changes for more than 1 consecutive event.

Changing these values to the correct poll rates fixes both problems and reduces CPU load.