### PR TITLE
feat(Source Device): add async implementation

### DIFF
--- a/src/dbus/interface/source/iio_imu.rs
+++ b/src/dbus/interface/source/iio_imu.rs
@@ -21,7 +21,7 @@ impl SourceIioImuInterface {
     pub async fn listen_on_dbus(
         conn: Connection,
         device: UdevDevice,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
         let iface = SourceIioImuInterface::new(device);
         let Ok(id) = iface.id() else {
             return Ok(());

--- a/src/input/manager.rs
+++ b/src/input/manager.rs
@@ -551,7 +551,8 @@ impl Manager {
             device,
             self.next_composite_dbus_path()?,
             capability_map,
-        )?;
+        )
+        .await?;
 
         // Check to see if there's already a CompositeDevice for
         // these source devices.
@@ -809,7 +810,7 @@ impl Manager {
         let composite_path = String::from(device.dbus_path());
         let composite_path_clone = composite_path.clone();
         let tx = self.tx.clone();
-        let task = tokio::spawn(async move {
+        let task = tokio::task::spawn(async move {
             if let Err(e) = device.run().await {
                 log::error!("Error running {composite_path}: {}", e.to_string());
             }

--- a/src/input/source/evdev/blocked.rs
+++ b/src/input/source/evdev/blocked.rs
@@ -3,17 +3,13 @@ use std::{error::Error, fmt::Debug};
 use evdev::Device;
 
 use crate::{
-    input::{
-        capability::Capability,
-        event::native::NativeEvent,
-        source::{InputError, SourceInputDevice, SourceOutputDevice},
-    },
+    input::source::{SourceInputDevice, SourceOutputDevice},
     udev::device::UdevDevice,
 };
 
 /// Source device implementation to block evdev events
 pub struct BlockedEventDevice {
-    device: Device,
+    _device: Device,
 }
 
 impl BlockedEventDevice {
@@ -25,19 +21,11 @@ impl BlockedEventDevice {
         device.grab()?;
         log::info!("Blocking input events from {path}");
 
-        Ok(Self { device })
+        Ok(Self { _device: device })
     }
 }
 
-impl SourceInputDevice for BlockedEventDevice {
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        Ok(vec![])
-    }
-
-    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
-        Ok(vec![])
-    }
-}
+impl SourceInputDevice for BlockedEventDevice {}
 
 impl SourceOutputDevice for BlockedEventDevice {}
 

--- a/src/input/source/hidraw/blocked.rs
+++ b/src/input/source/hidraw/blocked.rs
@@ -1,11 +1,7 @@
 use std::{error::Error, fmt::Debug};
 
 use crate::{
-    input::{
-        capability::Capability,
-        event::native::NativeEvent,
-        source::{InputError, SourceInputDevice, SourceOutputDevice},
-    },
+    input::source::{SourceInputDevice, SourceOutputDevice},
     udev::device::UdevDevice,
 };
 
@@ -23,14 +19,6 @@ impl BlockedHidrawDevice {
     }
 }
 
-impl SourceInputDevice for BlockedHidrawDevice {
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        Ok(vec![])
-    }
-
-    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
-        Ok(vec![])
-    }
-}
+impl SourceInputDevice for BlockedHidrawDevice {}
 
 impl SourceOutputDevice for BlockedHidrawDevice {}

--- a/src/input/source/hidraw/flydigi_vader_4_pro.rs
+++ b/src/input/source/hidraw/flydigi_vader_4_pro.rs
@@ -1,4 +1,11 @@
-use std::{error::Error, fmt::Debug};
+use std::{
+    error::Error,
+    fmt::Debug,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tokio::time::{interval, Interval};
 
 use crate::{
     drivers::flydigi_vader_4_pro::{
@@ -15,15 +22,17 @@ use crate::{
 
 /// Vader4Pro source device implementation
 pub struct Vader4Pro {
-    driver: Driver,
+    driver: Arc<Mutex<Driver>>,
+    interval: Interval,
 }
 
 impl Vader4Pro {
     /// Create a new source device with the given udev
     /// device information
     pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
-        let driver = Driver::new(device_info)?;
-        Ok(Self { driver })
+        let driver = Arc::new(Mutex::new(Driver::new(device_info)?));
+        let interval = interval(Duration::from_millis(1));
+        Ok(Self { driver, interval })
     }
 }
 
@@ -31,8 +40,9 @@ impl SourceOutputDevice for Vader4Pro {}
 
 impl SourceInputDevice for Vader4Pro {
     /// Poll the given input device for input events
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        let events = match self.driver.poll() {
+    async fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        self.interval.tick().await;
+        let events = match self.driver.lock().unwrap().poll() {
             Ok(events) => events,
             Err(err) => {
                 log::error!("Got error polling!: {err:?}");

--- a/src/input/source/hidraw/lego_dinput_combined.rs
+++ b/src/input/source/hidraw/lego_dinput_combined.rs
@@ -1,4 +1,11 @@
-use std::{error::Error, fmt::Debug};
+use std::{
+    error::Error,
+    fmt::Debug,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tokio::time::{interval, Interval};
 
 use crate::{
     drivers::lego::{
@@ -18,22 +25,25 @@ use crate::{
 
 /// Legion Go Controller source device implementation
 pub struct LegionControllerDCombined {
-    driver: Driver,
+    driver: Arc<Mutex<Driver>>,
+    interval: Interval,
 }
 
 impl LegionControllerDCombined {
     /// Create a new Legion controller source device with the given udev
     /// device information
     pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
-        let driver = Driver::new(device_info.devnode())?;
-        Ok(Self { driver })
+        let driver = Arc::new(Mutex::new(Driver::new(device_info.devnode())?));
+        let interval = interval(Duration::from_micros(2500));
+        Ok(Self { driver, interval })
     }
 }
 
 impl SourceInputDevice for LegionControllerDCombined {
     /// Poll the source device for input events
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        let events = self.driver.poll()?;
+    async fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        self.interval.tick().await;
+        let events = self.driver.lock().unwrap().poll()?;
         let native_events = translate_events(events);
         Ok(native_events)
     }

--- a/src/input/source/hidraw/lego_dinput_split.rs
+++ b/src/input/source/hidraw/lego_dinput_split.rs
@@ -1,4 +1,11 @@
-use std::{error::Error, fmt::Debug};
+use std::{
+    error::Error,
+    fmt::Debug,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tokio::time::{interval, Interval};
 
 use crate::{
     drivers::lego::{
@@ -18,22 +25,25 @@ use crate::{
 
 /// Legion Go Controller source device implementation
 pub struct LegionControllerDSplit {
-    driver: Driver,
+    driver: Arc<Mutex<Driver>>,
+    interval: Interval,
 }
 
 impl LegionControllerDSplit {
     /// Create a new Legion controller source device with the given udev
     /// device information
     pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
-        let driver = Driver::new(device_info.devnode())?;
-        Ok(Self { driver })
+        let driver = Arc::new(Mutex::new(Driver::new(device_info.devnode())?));
+        let interval = interval(Duration::from_micros(2500));
+        Ok(Self { driver, interval })
     }
 }
 
 impl SourceInputDevice for LegionControllerDSplit {
     /// Poll the source device for input events
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        let events = self.driver.poll()?;
+    async fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        self.interval.tick().await;
+        let events = self.driver.lock().unwrap().poll()?;
         let native_events = translate_events(events);
         Ok(native_events)
     }

--- a/src/input/source/hidraw/lego_fps_mode.rs
+++ b/src/input/source/hidraw/lego_fps_mode.rs
@@ -1,4 +1,11 @@
-use std::{error::Error, fmt::Debug};
+use std::{
+    error::Error,
+    fmt::Debug,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tokio::time::{interval, Interval};
 
 use crate::{
     drivers::lego::{
@@ -18,22 +25,25 @@ use crate::{
 
 /// Legion Go Controller source device implementation
 pub struct LegionControllerFPS {
-    driver: Driver,
+    driver: Arc<Mutex<Driver>>,
+    interval: Interval,
 }
 
 impl LegionControllerFPS {
     /// Create a new Legion controller source device with the given udev
     /// device information
     pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
-        let driver = Driver::new(device_info.devnode())?;
-        Ok(Self { driver })
+        let driver = Arc::new(Mutex::new(Driver::new(device_info.devnode())?));
+        let interval = interval(Duration::from_micros(2500));
+        Ok(Self { driver, interval })
     }
 }
 
 impl SourceInputDevice for LegionControllerFPS {
     /// Poll the source device for input events
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        let events = self.driver.poll()?;
+    async fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        self.interval.tick().await;
+        let events = self.driver.lock().unwrap().poll()?;
         let native_events = translate_events(events);
         Ok(native_events)
     }

--- a/src/input/source/hidraw/lego_xinput.rs
+++ b/src/input/source/hidraw/lego_xinput.rs
@@ -1,4 +1,11 @@
-use std::{error::Error, fmt::Debug};
+use std::{
+    error::Error,
+    fmt::Debug,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tokio::time::{interval, Interval};
 
 use crate::{
     drivers::lego::{
@@ -18,22 +25,25 @@ use crate::{
 
 /// Legion Go Controller source device implementation
 pub struct LegionControllerX {
-    driver: Driver,
+    driver: Arc<Mutex<Driver>>,
+    interval: Interval,
 }
 
 impl LegionControllerX {
     /// Create a new Legion controller source device with the given udev
     /// device information
     pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
-        let driver = Driver::new(device_info.devnode())?;
-        Ok(Self { driver })
+        let driver = Arc::new(Mutex::new(Driver::new(device_info.devnode())?));
+        let interval = interval(Duration::from_micros(2500));
+        Ok(Self { driver, interval })
     }
 }
 
 impl SourceInputDevice for LegionControllerX {
     /// Poll the source device for input events
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        let events = self.driver.poll()?;
+    async fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        self.interval.tick().await;
+        let events = self.driver.lock().unwrap().poll()?;
         let native_events = translate_events(events);
         Ok(native_events)
     }

--- a/src/input/source/hidraw/legos_config.rs
+++ b/src/input/source/hidraw/legos_config.rs
@@ -2,11 +2,7 @@ use std::{error::Error, fmt::Debug};
 
 use crate::{
     drivers::legos::config_driver::ConfigDriver,
-    input::{
-        capability::Capability,
-        event::native::NativeEvent,
-        source::{InputError, SourceInputDevice, SourceOutputDevice},
-    },
+    input::source::{SourceInputDevice, SourceOutputDevice},
     udev::device::UdevDevice,
 };
 
@@ -29,14 +25,7 @@ impl Debug for LegionSConfigController {
         f.debug_struct("LegionSConfig").finish()
     }
 }
-impl SourceInputDevice for LegionSConfigController {
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        Ok(vec![])
-    }
 
-    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
-        Ok(vec![])
-    }
-}
+impl SourceInputDevice for LegionSConfigController {}
 
 impl SourceOutputDevice for LegionSConfigController {}

--- a/src/input/source/hidraw/legos_imu.rs
+++ b/src/input/source/hidraw/legos_imu.rs
@@ -1,34 +1,43 @@
-use std::{error::Error, fmt::Debug};
+use std::{
+    error::Error,
+    fmt::Debug,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tokio::time::{interval, Interval};
 
 use crate::{
     drivers::legos::{event, imu_driver::IMUDriver},
     input::{
         capability::{Capability, Gamepad},
         event::{native::NativeEvent, value::InputValue},
-        output_event::OutputEvent,
-        source::{InputError, OutputError, SourceInputDevice, SourceOutputDevice},
+        source::{InputError, SourceInputDevice, SourceOutputDevice},
     },
     udev::device::UdevDevice,
 };
 
 /// Legion Go Controller source device implementation
 pub struct LegionSImuController {
-    driver: IMUDriver,
+    driver: Arc<Mutex<IMUDriver>>,
+    interval: Interval,
 }
 
 impl LegionSImuController {
     /// Create a new Legion controller source device with the given udev
     /// device information
     pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
-        let driver = IMUDriver::new(device_info.devnode())?;
-        Ok(Self { driver })
+        let driver = Arc::new(Mutex::new(IMUDriver::new(device_info.devnode())?));
+        let interval = interval(Duration::from_micros(2500));
+        Ok(Self { driver, interval })
     }
 }
 
 impl SourceInputDevice for LegionSImuController {
     /// Poll the source device for input events
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        let events = self.driver.poll()?;
+    async fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        self.interval.tick().await;
+        let events = self.driver.lock().unwrap().poll()?;
         let native_events = translate_events(events);
         Ok(native_events)
     }
@@ -39,14 +48,7 @@ impl SourceInputDevice for LegionSImuController {
     }
 }
 
-impl SourceOutputDevice for LegionSImuController {
-    /// Write the given output event to the source device. Output events are
-    /// events that flow from an application (like a game) to the physical
-    /// input device, such as force feedback events.
-    fn write_event(&mut self, _event: OutputEvent) -> Result<(), OutputError> {
-        Ok(())
-    }
-}
+impl SourceOutputDevice for LegionSImuController {}
 
 impl Debug for LegionSImuController {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/input/source/hidraw/legos_touchpad.rs
+++ b/src/input/source/hidraw/legos_touchpad.rs
@@ -1,34 +1,43 @@
-use std::{error::Error, fmt::Debug};
+use std::{
+    error::Error,
+    fmt::Debug,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tokio::time::{interval, Interval};
 
 use crate::{
     drivers::legos::{event, touchpad_driver::TouchpadDriver, PAD_FORCE_MAX, PAD_MOTION_MAX},
     input::{
         capability::{Capability, Gamepad, GamepadTrigger, Touch, TouchButton, Touchpad},
         event::{native::NativeEvent, value::InputValue},
-        output_event::OutputEvent,
-        source::{InputError, OutputError, SourceInputDevice, SourceOutputDevice},
+        source::{InputError, SourceInputDevice, SourceOutputDevice},
     },
     udev::device::UdevDevice,
 };
 
 /// Legion Go Controller source device implementation
 pub struct LegionSTouchpadController {
-    driver: TouchpadDriver,
+    driver: Arc<Mutex<TouchpadDriver>>,
+    interval: Interval,
 }
 
 impl LegionSTouchpadController {
     /// Create a new Legion controller source device with the given udev
     /// device information
     pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
-        let driver = TouchpadDriver::new(device_info.devnode())?;
-        Ok(Self { driver })
+        let driver = Arc::new(Mutex::new(TouchpadDriver::new(device_info.devnode())?));
+        let interval = interval(Duration::from_micros(2500));
+        Ok(Self { driver, interval })
     }
 }
 
 impl SourceInputDevice for LegionSTouchpadController {
     /// Poll the source device for input events
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        let events = self.driver.poll()?;
+    async fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        self.interval.tick().await;
+        let events = self.driver.lock().unwrap().poll()?;
         let native_events = translate_events(events);
         Ok(native_events)
     }
@@ -39,14 +48,7 @@ impl SourceInputDevice for LegionSTouchpadController {
     }
 }
 
-impl SourceOutputDevice for LegionSTouchpadController {
-    /// Write the given output event to the source device. Output events are
-    /// events that flow from an application (like a game) to the physical
-    /// input device, such as force feedback events.
-    fn write_event(&mut self, _event: OutputEvent) -> Result<(), OutputError> {
-        Ok(())
-    }
-}
+impl SourceOutputDevice for LegionSTouchpadController {}
 
 impl Debug for LegionSTouchpadController {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/input/source/hidraw/rog_ally.rs
+++ b/src/input/source/hidraw/rog_ally.rs
@@ -2,11 +2,7 @@ use std::{error::Error, fmt::Debug};
 
 use crate::{
     drivers::rog_ally::driver::Driver,
-    input::{
-        capability::Capability,
-        event::native::NativeEvent,
-        source::{InputError, SourceInputDevice, SourceOutputDevice},
-    },
+    input::source::{SourceInputDevice, SourceOutputDevice},
     udev::device::UdevDevice,
 };
 
@@ -29,14 +25,6 @@ impl Debug for RogAlly {
         f.debug_struct("RogAlly").finish()
     }
 }
-impl SourceInputDevice for RogAlly {
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        Ok(vec![])
-    }
-
-    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
-        Ok(vec![])
-    }
-}
+impl SourceInputDevice for RogAlly {}
 
 impl SourceOutputDevice for RogAlly {}

--- a/src/input/source/hidraw/zotac_zone.rs
+++ b/src/input/source/hidraw/zotac_zone.rs
@@ -2,11 +2,7 @@ use std::{error::Error, fmt::Debug};
 
 use crate::{
     drivers::zotac_zone::driver::Driver,
-    input::{
-        capability::Capability,
-        event::native::NativeEvent,
-        source::{InputError, SourceInputDevice, SourceOutputDevice},
-    },
+    input::source::{SourceInputDevice, SourceOutputDevice},
     udev::device::UdevDevice,
 };
 
@@ -29,14 +25,6 @@ impl Debug for ZotacZone {
     }
 }
 
-impl SourceInputDevice for ZotacZone {
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        Ok(vec![])
-    }
-
-    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
-        Ok(vec![])
-    }
-}
+impl SourceInputDevice for ZotacZone {}
 
 impl SourceOutputDevice for ZotacZone {}

--- a/src/input/source/iio.rs
+++ b/src/input/source/iio.rs
@@ -6,13 +6,15 @@ use std::error::Error;
 use glob_match::glob_match;
 
 use crate::{
-    config, constants::BUS_SOURCES_PREFIX, input::composite_device::client::CompositeDeviceClient,
+    config,
+    constants::BUS_SOURCES_PREFIX,
+    input::{capability::Capability, composite_device::client::CompositeDeviceClient},
     udev::device::UdevDevice,
 };
 
 use self::{accel_gyro_3d::AccelGyro3dImu, bmi_imu::BmiImu};
 
-use super::{SourceDeviceCompatible, SourceDriver};
+use super::{InputError, SourceDeviceCompatible, SourceDriver};
 
 /// List of available drivers
 enum DriverType {
@@ -52,14 +54,12 @@ impl SourceDeviceCompatible for IioDevice {
 
     async fn run(self) -> Result<(), Box<dyn Error>> {
         match self {
-            IioDevice::BmiImu(source_driver) => source_driver.run().await,
-            IioDevice::AccelGryo3D(source_driver) => source_driver.run().await,
+            IioDevice::BmiImu(mut source_driver) => source_driver.run().await,
+            IioDevice::AccelGryo3D(mut source_driver) => source_driver.run().await,
         }
     }
 
-    fn get_capabilities(
-        &self,
-    ) -> Result<Vec<crate::input::capability::Capability>, super::InputError> {
+    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
         match self {
             IioDevice::BmiImu(source_driver) => source_driver.get_capabilities(),
             IioDevice::AccelGryo3D(source_driver) => source_driver.get_capabilities(),

--- a/src/input/source/iio/accel_gyro_3d.rs
+++ b/src/input/source/iio/accel_gyro_3d.rs
@@ -1,4 +1,12 @@
-use std::{error::Error, f64::consts::PI, fmt::Debug};
+use std::{
+    error::Error,
+    f64::consts::PI,
+    fmt::Debug,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tokio::time::{interval, Interval};
 
 use crate::{
     config,
@@ -12,7 +20,8 @@ use crate::{
 };
 
 pub struct AccelGyro3dImu {
-    driver: Driver,
+    driver: Arc<Mutex<Driver>>,
+    interval: Interval,
 }
 
 impl AccelGyro3dImu {
@@ -40,16 +49,18 @@ impl AccelGyro3dImu {
 
         let id = device_info.sysname();
         let name = device_info.name();
-        let driver = Driver::new(id, name, mount_matrix)?;
+        let driver = Arc::new(Mutex::new(Driver::new(id, name, mount_matrix)?));
+        let interval = interval(Duration::from_millis(10));
 
-        Ok(Self { driver })
+        Ok(Self { driver, interval })
     }
 }
 
 impl SourceInputDevice for AccelGyro3dImu {
     /// Poll the given input device for input events
-    fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
-        let events = self.driver.poll()?;
+    async fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
+        self.interval.tick().await;
+        let events = self.driver.lock().unwrap().poll()?;
         let native_events = translate_events(events);
         Ok(native_events)
     }
@@ -67,10 +78,6 @@ impl Debug for AccelGyro3dImu {
         f.debug_struct("AccelGyro3dImu").finish()
     }
 }
-
-// NOTE: Mark this struct as thread-safe as it will only ever be called from
-// a single thread.
-unsafe impl Send for AccelGyro3dImu {}
 
 /// Translate the given driver events into native events
 fn translate_events(events: Vec<iio_imu::event::Event>) -> Vec<NativeEvent> {

--- a/src/input/source/led.rs
+++ b/src/input/source/led.rs
@@ -1,8 +1,10 @@
 pub mod multicolor;
 use self::multicolor::LedMultiColor;
-use super::{SourceDeviceCompatible, SourceDriver};
+use super::{InputError, SourceDeviceCompatible, SourceDriver};
 use crate::{
-    config, constants::BUS_SOURCES_PREFIX, input::composite_device::client::CompositeDeviceClient,
+    config,
+    constants::BUS_SOURCES_PREFIX,
+    input::{capability::Capability, composite_device::client::CompositeDeviceClient},
     udev::device::UdevDevice,
 };
 use std::error::Error;
@@ -37,13 +39,11 @@ impl SourceDeviceCompatible for LedDevice {
 
     async fn run(self) -> Result<(), Box<dyn Error>> {
         match self {
-            LedDevice::MultiColor(source_driver) => source_driver.run().await,
+            LedDevice::MultiColor(mut source_driver) => source_driver.run().await,
         }
     }
 
-    fn get_capabilities(
-        &self,
-    ) -> Result<Vec<crate::input::capability::Capability>, super::InputError> {
+    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
         match self {
             LedDevice::MultiColor(source_driver) => source_driver.get_capabilities(),
         }

--- a/src/input/source/led/multicolor.rs
+++ b/src/input/source/led/multicolor.rs
@@ -1,8 +1,7 @@
 use crate::{
     input::{
-        capability::Capability,
         output_event::OutputEvent,
-        source::{InputError, OutputError, SourceInputDevice, SourceOutputDevice},
+        source::{OutputError, SourceInputDevice, SourceOutputDevice},
     },
     udev::device::UdevDevice,
 };
@@ -251,18 +250,10 @@ impl Debug for LedMultiColor {
     }
 }
 
-impl SourceInputDevice for LedMultiColor {
-    fn poll(&mut self) -> Result<Vec<crate::input::event::native::NativeEvent>, InputError> {
-        Ok(Vec::new())
-    }
-
-    fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
-        Ok(Vec::new())
-    }
-}
+impl SourceInputDevice for LedMultiColor {}
 
 impl SourceOutputDevice for LedMultiColor {
-    fn write_event(&mut self, event: OutputEvent) -> Result<(), OutputError> {
+    async fn write_event(&mut self, event: OutputEvent) -> Result<(), OutputError> {
         log::trace!("Received output event: {event:?}");
         match event {
             OutputEvent::DualSense(report) => {


### PR DESCRIPTION
This change refactors source devices to so they can be implemented asynchronously. 

> [!IMPORTANT]  
> Since this change is a decently sized refactor, extensive testing should be completed before this is merged in.

With this change, we can move towards using `io_uring` or `epoll` based event processing instead of spawning a thread per source device and sleeping for a specific polling interval. This change should, theoretically, provide lower latency and processing if events are processed in this way and use a single thread per composite device. Testing and benchmarking are required to confirm this.