### PR TITLE
feat(Event): add event context with performance metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ ALL_RS := $(shell find src -name '*.rs')
 ALL_ROOTFS := $(shell find rootfs -type f)
 PREFIX ?= /usr
 CACHE_DIR := .cache
+ENABLE_METRICS ?= 1
 
 # Build variables
 BUILD_TYPE ?= release
@@ -99,7 +100,7 @@ all: build debug ## Build release and debug builds
 
 .PHONY: run
 run: debug ## Build and run
-	sudo LOG_LEVEL=$(LOG_LEVEL) ./target/$(TARGET_ARCH)/debug/$(NAME)
+	sudo LOG_LEVEL=$(LOG_LEVEL) ENABLE_METRICS=$(ENABLE_METRICS) ./target/$(TARGET_ARCH)/debug/$(NAME)
 
 .PHONY: clean
 clean: ## Remove build artifacts

--- a/src/cli/ui/menu.rs
+++ b/src/cli/ui/menu.rs
@@ -1,5 +1,7 @@
+pub mod device_performance_menu;
 pub mod device_test_menu;
 
+use device_performance_menu::DevicePerformanceMenu;
 use device_test_menu::DeviceTestMenu;
 use ratatui::{
     crossterm::event::{KeyCode, KeyEvent},
@@ -26,6 +28,7 @@ pub trait MenuWidget {
 #[derive(Debug)]
 pub enum Menu {
     DeviceTest(DeviceTestMenu),
+    DevicePerformance(DevicePerformanceMenu),
 }
 
 impl Widget for &Menu {
@@ -34,7 +37,8 @@ impl Widget for &Menu {
         Self: Sized,
     {
         match self {
-            Menu::DeviceTest(device_test_menu) => device_test_menu.render(area, buf),
+            Menu::DeviceTest(menu) => menu.render(area, buf),
+            Menu::DevicePerformance(menu) => menu.render(area, buf),
         }
     }
 }
@@ -42,13 +46,15 @@ impl Widget for &Menu {
 impl MenuWidget for Menu {
     fn update(&mut self) -> Vec<InterfaceCommand> {
         match self {
-            Menu::DeviceTest(device_test_menu) => device_test_menu.update(),
+            Menu::DeviceTest(menu) => menu.update(),
+            Menu::DevicePerformance(menu) => menu.update(),
         }
     }
 
     fn handle_key_event(&mut self, key_event: KeyEvent) -> Vec<InterfaceCommand> {
         match self {
-            Menu::DeviceTest(device_test_menu) => device_test_menu.handle_key_event(key_event),
+            Menu::DeviceTest(menu) => menu.handle_key_event(key_event),
+            Menu::DevicePerformance(menu) => menu.handle_key_event(key_event),
         }
     }
 }
@@ -56,5 +62,11 @@ impl MenuWidget for Menu {
 impl From<DeviceTestMenu> for Menu {
     fn from(value: DeviceTestMenu) -> Self {
         Self::DeviceTest(value)
+    }
+}
+
+impl From<DevicePerformanceMenu> for Menu {
+    fn from(value: DevicePerformanceMenu) -> Self {
+        Self::DevicePerformance(value)
     }
 }

--- a/src/cli/ui/menu/device_performance_menu.rs
+++ b/src/cli/ui/menu/device_performance_menu.rs
@@ -1,0 +1,388 @@
+use std::{
+    collections::{HashMap, VecDeque},
+    error::Error,
+    time::Duration,
+};
+
+use futures::StreamExt;
+use ratatui::{
+    crossterm::event::KeyCode,
+    layout::{Constraint, Direction, Layout},
+    prelude::*,
+    symbols::border,
+    widgets::{Axis, Block, Chart, Dataset, GraphType, List, ListDirection, ListItem, Widget},
+};
+use style::palette::tailwind::GRAY;
+use tokio::sync::mpsc;
+use zbus::{fdo::ObjectManagerProxy, Connection};
+
+use crate::{
+    cli::ui::InterfaceCommand,
+    constants::{BUS_NAME, BUS_PREFIX},
+    dbus::interface::performance::PerformanceInterfaceProxy,
+    input::event::context::SerializedSpan,
+};
+
+use super::MenuWidget;
+
+const NUM_SAMPLES: usize = 1000;
+const NORMAL_ROW_BG: Color = GRAY.c950;
+const ALT_ROW_BG_COLOR: Color = GRAY.c900;
+
+/// Menu for testing an input device
+#[derive(Debug)]
+pub struct DevicePerformanceMenu {
+    spans: HashMap<String, VecDeque<u64>>,
+    events: VecDeque<String>,
+    conn: Connection,
+    rx_disconnect: mpsc::Receiver<()>,
+    rx_reports: mpsc::Receiver<(String, Vec<SerializedSpan>)>,
+    device_path: String,
+}
+
+impl DevicePerformanceMenu {
+    pub async fn new(conn: &Connection, dbus_path: &str) -> Result<Self, Box<dyn Error>> {
+        // Get a reference to the device to debug
+        let device = PerformanceInterfaceProxy::builder(conn)
+            .path(dbus_path)?
+            .build()
+            .await?;
+
+        // Enable metrics
+        if let Err(e) = device.set_enabled(true).await {
+            println!("Unable to enable device metrics. Was inputplumber started with `ENABLE_METRICS=1` environment variable?");
+            return Err(e.into());
+        }
+
+        // Create channels to listen for metrics
+        let (tx_reports, rx_reports) = mpsc::channel(2048);
+        let (tx_disconnect, rx_disconnect) = mpsc::channel(1);
+
+        // Spawn a task to listen for metrics
+        let conn_clone = conn.clone();
+        let path_clone = dbus_path.to_string();
+        tokio::task::spawn(async move {
+            let _ =
+                Self::listen_for_signals(&conn_clone, path_clone, tx_disconnect, tx_reports).await;
+        });
+
+        Ok(Self {
+            spans: HashMap::with_capacity(5),
+            events: VecDeque::with_capacity(NUM_SAMPLES),
+            conn: conn.clone(),
+            device_path: dbus_path.to_string(),
+            rx_disconnect,
+            rx_reports,
+        })
+    }
+
+    // Stop the test, restoring the device state
+    fn stop(&self) {
+        // Restore the state of the device
+        let conn = self.conn.clone();
+        let dbus_path = self.device_path.clone();
+        tokio::task::spawn(async move {
+            // Create a reference to the metrics interface
+            let device = PerformanceInterfaceProxy::builder(&conn)
+                .path(dbus_path)
+                .unwrap()
+                .build()
+                .await
+                .unwrap();
+
+            // Disable metrics
+            device.set_enabled(false).await.unwrap();
+        });
+
+        // Wait a beat
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+}
+
+impl DevicePerformanceMenu {
+    /// Listen for device signals over dbus
+    async fn listen_for_signals(
+        conn: &Connection,
+        dbus_path: String,
+        tx_disconnect: mpsc::Sender<()>,
+        tx_reports: mpsc::Sender<(String, Vec<SerializedSpan>)>,
+    ) -> Result<(), Box<dyn Error>> {
+        // Get a reference to the device to debug
+        let device = PerformanceInterfaceProxy::builder(conn)
+            .path(dbus_path.as_str())?
+            .build()
+            .await?;
+
+        // Listen for metrics
+        let mut receive_report = device.receive_event_metrics().await?;
+        tokio::task::spawn(async move {
+            while let Some(signal) = receive_report.next().await {
+                let Ok(args) = signal.args() else { break };
+                let _ = tx_reports.send((args.capability, args.spans)).await;
+            }
+        });
+
+        // Get a reference to the object manager to listen for controller disconnects
+        let object_manager = ObjectManagerProxy::builder(conn)
+            .destination(BUS_NAME)?
+            .path(BUS_PREFIX)?
+            .build()
+            .await?;
+        let mut ifaces_removed = object_manager.receive_interfaces_removed().await?;
+        tokio::task::spawn(async move {
+            while let Some(change) = ifaces_removed.next().await {
+                let Ok(args) = change.args() else { break };
+                let path = args.object_path.to_string();
+                if path != dbus_path {
+                    continue;
+                }
+                let _ = tx_disconnect.send(()).await;
+            }
+        });
+
+        Ok(())
+    }
+
+    fn render_graph(&self, title: &str, area: Rect, buf: &mut Buffer, data: &VecDeque<u64>) {
+        // Create a block
+        let block = Block::bordered()
+            .title(title)
+            .border_set(border::ROUNDED)
+            .border_style(Style::new().red());
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        // Get the average from the data
+        let avg = {
+            let sum: u64 = data.iter().sum();
+            if !data.is_empty() {
+                sum / data.len() as u64
+            } else {
+                0
+            }
+        };
+        let avg_latency = Duration::from_micros(avg);
+
+        // Get the maximum value from the data
+        let max = data.iter().max().cloned().unwrap_or(20000);
+        let max_latency = Duration::from_micros(max);
+        let mid = max / 2;
+        let mid_latency = Duration::from_micros(mid);
+        let min = data.iter().min().cloned().unwrap_or_default();
+        let min_latency = Duration::from_micros(min);
+
+        // Get the general unit to use in the legend
+        let unit = if max > 1000 { "ms" } else { "µs" };
+
+        // Convert the data into (x, y) values
+        let data: Vec<(f64, f64)> = data
+            .iter()
+            .enumerate()
+            .map(|(i, value)| (i as f64, *value as f64))
+            .collect();
+
+        // Create a dataset from the given data
+        let dataset = Dataset::default()
+            .name("Latency")
+            .marker(symbols::Marker::Braille)
+            .graph_type(GraphType::Bar)
+            .data(data.as_slice());
+
+        // Create the X axis and define its properties
+        let latency_label =
+            format!("Min: {min_latency:?}, Average: {avg_latency:?}, Max: {max_latency:?}");
+        let x_axis = Axis::default()
+            .title("Number of events".red())
+            .style(Style::default().white())
+            .bounds([0.0, NUM_SAMPLES as f64])
+            .labels(["", latency_label.as_str(), ""]);
+
+        // Create the Y axis and define its properties
+        let min_label = format!("0{unit}");
+        let mid_label = format!("{mid_latency:?}");
+        let max_label = format!("{max_latency:?}");
+        let y_axis = Axis::default()
+            .title("Latency".red())
+            .style(Style::default().white())
+            .bounds([0.0, max as f64])
+            .labels([min_label.as_str(), mid_label.as_str(), max_label.as_str()]);
+
+        // Render the chart using the dataset
+        let widget = Chart::new(vec![dataset]).x_axis(x_axis).y_axis(y_axis);
+        widget.render(inside_block, buf);
+    }
+
+    fn render_events(&self, area: Rect, buf: &mut Buffer) {
+        // Create a block
+        let block = Block::bordered()
+            .title("Events")
+            .border_set(border::ROUNDED)
+            .border_style(Style::new().red());
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        // Iterate through all elements in the `items` and stylize them.
+        let items: Vec<ListItem> = self
+            .events
+            .iter()
+            .enumerate()
+            .map(|(i, item)| {
+                let color = if i % 2 == 0 {
+                    NORMAL_ROW_BG
+                } else {
+                    ALT_ROW_BG_COLOR
+                };
+
+                // Get the corresponding time information for the event
+                let duration = self
+                    .spans
+                    .get("root")
+                    .unwrap()
+                    .get(i)
+                    .cloned()
+                    .unwrap_or_default();
+                let duration = Duration::from_micros(duration);
+                let text = format!("{item} {duration:?}");
+
+                ListItem::from(text).bg(color)
+            })
+            .collect();
+
+        // Create and render the list
+        let widget = List::new(items).direction(ListDirection::BottomToTop);
+        Widget::render(widget, inside_block, buf);
+    }
+}
+
+impl MenuWidget for DevicePerformanceMenu {
+    fn update(&mut self) -> Vec<InterfaceCommand> {
+        if self.rx_reports.is_closed() || self.rx_disconnect.is_closed() {
+            self.stop();
+            return vec![InterfaceCommand::Quit];
+        }
+
+        // Check to see if the device has disconnected
+        if !self.rx_disconnect.is_empty() {
+            self.stop();
+            return vec![InterfaceCommand::Quit];
+        }
+
+        // Check for any input metrics
+        while !self.rx_reports.is_empty() {
+            let Some((capability, spans)) = self.rx_reports.blocking_recv() else {
+                self.stop();
+                return vec![InterfaceCommand::Quit];
+            };
+
+            // Collect the name of the input event
+            self.events.push_front(capability.clone());
+            if self.events.len() > NUM_SAMPLES {
+                self.events.pop_back();
+            }
+
+            // Collect the individual spans
+            for span in spans {
+                let _parent_span_id = span.0.as_str();
+                let span_id = span.1;
+                let duration = span.2;
+
+                self.spans
+                    .entry(span_id)
+                    .and_modify(|spans| {
+                        spans.push_front(duration);
+                        if spans.len() > NUM_SAMPLES {
+                            spans.pop_back();
+                        }
+                    })
+                    .or_insert({
+                        let mut spans = VecDeque::with_capacity(NUM_SAMPLES);
+                        spans.push_front(duration);
+                        spans
+                    });
+            }
+        }
+
+        vec![]
+    }
+
+    fn handle_key_event(
+        &mut self,
+        key_event: ratatui::crossterm::event::KeyEvent,
+    ) -> Vec<InterfaceCommand> {
+        let commands = match key_event.code {
+            KeyCode::Char('q') => vec![InterfaceCommand::Quit],
+            _ => vec![],
+        };
+        if commands.is_empty() {
+            return commands;
+        }
+
+        self.stop();
+
+        commands
+    }
+}
+
+impl Widget for &DevicePerformanceMenu {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        // Create a block
+        let block = Block::bordered()
+            .title_bottom(Line::from("Press 'q' to quit").centered())
+            .border_set(border::ROUNDED);
+        let inside_block = block.inner(area);
+        block.render(area, buf);
+
+        // Split the area into two parts vertically
+        let outer_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(inside_block);
+
+        // Top layout
+        let top_layout = outer_layout[0];
+        let empty_data = VecDeque::new();
+        let data = match self.spans.get("root") {
+            Some(data) => data,
+            None => &empty_data,
+        };
+        self.render_graph("Input Latency", top_layout, buf, data);
+
+        // Bottom layout
+        let bottom_layout = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints(vec![Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(outer_layout[1]);
+
+        // Bottom Left
+        let bottom_left_layout = bottom_layout[0];
+        self.render_events(bottom_left_layout, buf);
+
+        // Bottom Right
+        let bottom_right_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints(vec![
+                Constraint::Percentage(20), // source_poll
+                Constraint::Percentage(20), // source_send
+                Constraint::Percentage(20), // composite_device
+                Constraint::Percentage(20), // target_send
+                Constraint::Percentage(20), // target_write
+            ])
+            .split(bottom_layout[1]);
+
+        // Function for rendering each span
+        let mut render_span_graph = |key: &str, area: Rect| {
+            let data = match self.spans.get(key) {
+                Some(data) => data,
+                None => &empty_data,
+            };
+            self.render_graph(key, area, buf, data);
+        };
+
+        // Render a graph section for each span
+        render_span_graph("source_poll", bottom_right_layout[0]);
+        render_span_graph("source_send", bottom_right_layout[1]);
+        render_span_graph("composite_device", bottom_right_layout[2]);
+        render_span_graph("target_send", bottom_right_layout[3]);
+        render_span_graph("target_write", bottom_right_layout[4]);
+    }
+}

--- a/src/dbus/interface/mod.rs
+++ b/src/dbus/interface/mod.rs
@@ -1,4 +1,5 @@
 pub mod composite_device;
 pub mod manager;
+pub mod performance;
 pub mod source;
 pub mod target;

--- a/src/dbus/interface/performance.rs
+++ b/src/dbus/interface/performance.rs
@@ -1,0 +1,81 @@
+use std::error::Error;
+
+use zbus::{fdo, object_server::SignalEmitter, Connection};
+use zbus_macros::interface;
+
+use crate::input::{
+    capability::Capability,
+    event::context::{EventContext, SerializedSpan},
+};
+
+/// The [PerformanceInterface] provides a simple dbus interface for collecting
+/// latency and performance metrics from a running device.
+pub struct PerformanceInterface {
+    enabled: bool,
+}
+
+impl PerformanceInterface {
+    pub fn new() -> PerformanceInterface {
+        PerformanceInterface { enabled: false }
+    }
+}
+
+#[interface(
+    name = "org.shadowblip.Input.Metrics",
+    proxy(
+        default_service = "org.shadowblip.InputPlumber",
+        default_path = "/org/shadowblip/InputPlumber/Manager"
+    )
+)]
+impl PerformanceInterface {
+    #[zbus(property)]
+    fn enabled(&self) -> fdo::Result<bool> {
+        Ok(self.enabled)
+    }
+
+    #[zbus(property)]
+    fn set_enabled(&mut self, value: bool) {
+        self.enabled = value;
+    }
+
+    #[zbus(signal)]
+    pub async fn event_metrics(
+        emitter: &SignalEmitter<'_>,
+        capability: String,
+        spans: Vec<SerializedSpan>,
+    ) -> zbus::Result<()>;
+}
+
+impl PerformanceInterface {
+    pub async fn emit_metrics(
+        conn: &Connection,
+        path: &str,
+        capability: Capability,
+        context: &EventContext,
+    ) -> Result<(), Box<dyn Error>> {
+        // Get the object instance at the given path so we can send DBus signal
+        // updates
+        let iface_ref = conn
+            .object_server()
+            .interface::<_, PerformanceInterface>(path)
+            .await?;
+        let enabled = iface_ref.get().await.enabled()?;
+        if !enabled {
+            return Ok(());
+        }
+
+        // Serialize and emit the spans for this event
+        let cap = format!("{capability:?}");
+        let counter = context.metrics();
+        let spans: Vec<SerializedSpan> = counter.iter().map(|span| span.into()).collect();
+        iface_ref.event_metrics(cap, spans).await?;
+
+        Ok(())
+    }
+}
+
+impl Default for PerformanceInterface {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -653,9 +653,21 @@ impl CompositeDevice {
         log::trace!("Received event: {:?} from {device_id}", raw_event);
 
         // Convert the event into a NativeEvent
-        let Event::Native(event) = raw_event;
+        let Event::Native(mut event) = raw_event;
         let cap = event.as_capability();
         log::trace!("Event capability: {:?}", cap);
+
+        if let Some(context) = event.get_context_mut() {
+            context
+                .metrics_mut()
+                .get_mut("source_send")
+                .unwrap()
+                .finish();
+            context
+                .metrics_mut()
+                .create_child_span("root", "composite_device")
+                .start();
+        }
 
         // Only send valid events to the target device(s)
         if cap == Capability::NotImplemented {

--- a/src/input/event/context.rs
+++ b/src/input/event/context.rs
@@ -1,0 +1,159 @@
+use std::{
+    slice::Iter,
+    time::{Duration, Instant},
+};
+
+/// [EventContext] provides context around who sent a particular event, and
+/// timing information around it.
+#[derive(Debug, Clone)]
+pub struct EventContext {
+    /// Performance counter with spans for measuring event latency
+    metrics: PerformanceCounter,
+}
+
+impl EventContext {
+    /// Create new context for an event
+    pub fn new() -> Self {
+        Self {
+            metrics: PerformanceCounter::new(),
+        }
+    }
+
+    /// Return performance metrics counter for the event
+    pub fn metrics(&self) -> &PerformanceCounter {
+        &self.metrics
+    }
+
+    /// Return performance metrics counter for the event
+    pub fn metrics_mut(&mut self) -> &mut PerformanceCounter {
+        &mut self.metrics
+    }
+}
+
+impl Default for EventContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// [PerformanceCounter] keeps an array of spans to keep track of how long
+/// different points of the input pipeline took.
+#[derive(Debug, Clone)]
+pub struct PerformanceCounter {
+    spans: Vec<Span>,
+}
+
+impl PerformanceCounter {
+    pub fn new() -> Self {
+        Self::with_capacity(8)
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            spans: Vec::with_capacity(capacity),
+        }
+    }
+
+    /// Create a span with the given identifier
+    pub fn create_span(&mut self, id: &'static str) -> &mut Span {
+        let span = Span::new(id);
+        self.spans.push(span);
+        self.spans.last_mut().unwrap()
+    }
+
+    /// Create a span that is a child of the given span `parent_id` with the
+    /// given identifier.
+    pub fn create_child_span(&mut self, parent_id: &'static str, id: &'static str) -> &mut Span {
+        let span = self.create_span(id);
+        span.parent_id = Some(parent_id);
+        span
+    }
+
+    /// Return the span with the given span id
+    #[allow(dead_code)]
+    pub fn get(&self, id: &'static str) -> Option<&Span> {
+        self.spans.iter().find(|span| span.id() == id)
+    }
+
+    /// Returns the span with the given span id
+    pub fn get_mut(&mut self, id: &'static str) -> Option<&mut Span> {
+        self.spans.iter_mut().find(|span| span.id() == id)
+    }
+
+    pub fn iter(&self) -> Iter<'_, Span> {
+        self.spans.iter()
+    }
+}
+
+impl Default for PerformanceCounter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// A [Span] keeps track of a start time and end time in order to calculate how
+/// long an operation took.
+#[derive(Debug, Clone, Copy)]
+pub struct Span {
+    id: &'static str,
+    parent_id: Option<&'static str>,
+    start_time: Option<Instant>,
+    duration: Option<Duration>,
+}
+
+impl Span {
+    /// Create a new unstarted span. Requires calling `start()` in order to
+    /// record the start time.
+    fn new(id: &'static str) -> Self {
+        Self {
+            id,
+            parent_id: None,
+            start_time: None,
+            duration: None,
+        }
+    }
+
+    /// Identifier of the span
+    pub fn id(&self) -> &str {
+        self.id
+    }
+
+    /// Identifier of the parent span
+    pub fn parent_id(&self) -> Option<&str> {
+        self.parent_id
+    }
+
+    /// Start the span
+    pub fn start(&mut self) {
+        self.start_time = Some(Instant::now());
+    }
+
+    /// Finish the span and calculate the elapsed duration since start
+    pub fn finish(&mut self) {
+        // Don't do anything if this span has already finished
+        if self.duration.is_some() {
+            return;
+        }
+        let Some(start_time) = self.start_time.as_ref() else {
+            return;
+        };
+        self.duration = Some(start_time.elapsed());
+    }
+
+    /// Return the elapsed time since the span started and finished
+    pub fn elapsed(&self) -> Option<Duration> {
+        self.duration
+    }
+}
+
+/// Serialized version of a [Span], in the form of (parent_id, id, elapsed_micro_sec)
+pub type SerializedSpan = (String, String, u64);
+
+impl From<&Span> for SerializedSpan {
+    fn from(value: &Span) -> Self {
+        let parent_id = value.parent_id().unwrap_or_default().to_string();
+        let id = value.id().to_string();
+        let elapsed = value.elapsed().unwrap_or_default().as_micros() as u64;
+        (parent_id, id, elapsed)
+    }
+}

--- a/src/input/event/mod.rs
+++ b/src/input/event/mod.rs
@@ -1,3 +1,4 @@
+pub mod context;
 pub mod dbus;
 pub mod evdev;
 pub mod native;

--- a/src/input/event/native.rs
+++ b/src/input/event/native.rs
@@ -4,7 +4,7 @@ use evdev::AbsoluteAxisCode;
 
 use crate::input::capability::{Capability, Gamepad, GamepadButton};
 
-use super::{evdev::EvdevEvent, value::InputValue};
+use super::{context::EventContext, evdev::EvdevEvent, value::InputValue};
 
 /// A native event represents an InputPlumber event
 #[derive(Debug, Clone)]
@@ -19,6 +19,10 @@ pub struct NativeEvent {
     source_capability: Option<Capability>,
     /// The value of the input event.
     value: InputValue,
+    /// The event context contains additional information related to the event, such
+    /// as performance metrics and metadata. `Box<>` is used to allocate the
+    /// context on the heap to reduce the size of [NativeEvent].
+    context: Option<Box<EventContext>>,
 }
 
 impl NativeEvent {
@@ -28,6 +32,7 @@ impl NativeEvent {
             capability,
             value,
             source_capability: None,
+            context: None,
         }
     }
 
@@ -42,6 +47,7 @@ impl NativeEvent {
             capability,
             source_capability: Some(source_capability),
             value,
+            context: None,
         }
     }
 
@@ -59,6 +65,22 @@ impl NativeEvent {
     /// capability defined.
     pub fn is_translated(&self) -> bool {
         self.source_capability.is_some()
+    }
+
+    /// Returns the current context of the event
+    pub fn get_context(&self) -> Option<&EventContext> {
+        self.context.as_deref()
+    }
+
+    /// Returns the current context of the event
+    pub fn get_context_mut(&mut self) -> Option<&mut EventContext> {
+        self.context.as_deref_mut()
+    }
+
+    /// Add the given event context to the event. Calling this method will
+    /// allocate the given [EventContext] on the heap.
+    pub fn set_context(&mut self, context: EventContext) {
+        self.context = Some(Box::new(context));
     }
 
     /// Set the source capability of the event if this is a translated event
@@ -116,6 +138,7 @@ impl NativeEvent {
             capability,
             value,
             source_capability: None,
+            context: None,
         }
     }
 }
@@ -129,6 +152,7 @@ impl From<EvdevEvent> for NativeEvent {
             capability,
             value,
             source_capability: None,
+            context: None,
         }
     }
 }


### PR DESCRIPTION
This change adds a new `EventContext` property of the `NativeEvent` which can hold performance metrics and metadata related to an input event. Performance metrics can be used to show the processing latency for each event.

Performance/latency can be monitored with the CLI:

```bash
inputplumber device 0 target monitor xbox-series
```

Where "xbox-series" is the target device type to monitor.

![image](https://github.com/user-attachments/assets/f2b60d06-b709-4fb5-bfc8-b60a1e8c3764)

