### PR TITLE
fix(Target Device): use type id instead of string for better idempotence and error handling

### DIFF
--- a/src/dbus/interface/composite_device.rs
+++ b/src/dbus/interface/composite_device.rs
@@ -106,8 +106,15 @@ impl CompositeDeviceInterface {
     /// current virtual devices for the composite device and create and attach
     /// new target devices.
     async fn set_target_devices(&self, target_device_types: Vec<String>) -> fdo::Result<()> {
+        let mut target_device_type_ids = Vec::with_capacity(target_device_types.len());
+        for kind in target_device_types {
+            let type_id = kind.as_str().try_into().map_err(|_| {
+                fdo::Error::InvalidArgs(format!("Invalid target device type: {kind}"))
+            })?;
+            target_device_type_ids.push(type_id);
+        }
         self.composite_device
-            .set_target_devices(target_device_types)
+            .set_target_devices(target_device_type_ids)
             .await
             .map_err(|e| fdo::Error::Failed(e.to_string()))
     }

--- a/src/dbus/interface/manager.rs
+++ b/src/dbus/interface/manager.rs
@@ -126,6 +126,11 @@ impl ManagerInterface {
     /// Create a target device of the given type. Returns the DBus path to
     /// the created target device.
     async fn create_target_device(&self, kind: String) -> fdo::Result<String> {
+        let Ok(kind) = TargetDeviceTypeId::try_from(kind.as_str()) else {
+            return Err(fdo::Error::InvalidArgs(format!(
+                "Invalid target device type: {kind}."
+            )));
+        };
         let (sender, mut receiver) = mpsc::channel(1);
         self.tx
             .send_timeout(

--- a/src/input/composite_device/client.rs
+++ b/src/input/composite_device/client.rs
@@ -5,6 +5,7 @@ use tokio::sync::mpsc::{channel, error::SendError, Sender};
 use crate::config::CompositeDeviceConfig;
 use crate::input::event::native::NativeEvent;
 use crate::input::target::client::TargetDeviceClient;
+use crate::input::target::TargetDeviceTypeId;
 use crate::input::{capability::Capability, event::Event, output_event::OutputEvent};
 use crate::udev::device::UdevDevice;
 
@@ -225,7 +226,10 @@ impl CompositeDeviceClient {
     /// Set the given target devices on the composite device. This will create
     /// new target devices, attach them to this device, and stop/remove any
     /// existing devices.
-    pub async fn set_target_devices(&self, devices: Vec<String>) -> Result<(), ClientError> {
+    pub async fn set_target_devices(
+        &self,
+        devices: Vec<TargetDeviceTypeId>,
+    ) -> Result<(), ClientError> {
         self.tx
             .send(CompositeCommand::SetTargetDevices(devices))
             .await?;

--- a/src/input/composite_device/command.rs
+++ b/src/input/composite_device/command.rs
@@ -8,7 +8,7 @@ use crate::{
         capability::Capability,
         event::{native::NativeEvent, Event},
         output_event::OutputEvent,
-        target::client::TargetDeviceClient,
+        target::{client::TargetDeviceClient, TargetDeviceTypeId},
     },
     udev::device::UdevDevice,
 };
@@ -26,6 +26,7 @@ pub enum CompositeCommand {
     GetDBusDevicePaths(mpsc::Sender<Vec<String>>),
     GetInterceptMode(mpsc::Sender<InterceptMode>),
     GetName(mpsc::Sender<String>),
+    #[allow(dead_code)]
     GetProfileName(mpsc::Sender<String>),
     GetSourceDevicePaths(mpsc::Sender<Vec<String>>),
     GetTargetCapabilities(mpsc::Sender<HashSet<Capability>>),
@@ -38,10 +39,11 @@ pub enum CompositeCommand {
     RemoveRecentEvent(Capability),
     SetInterceptActivation(Vec<Capability>, Capability),
     SetInterceptMode(InterceptMode),
-    SetTargetDevices(Vec<String>),
+    SetTargetDevices(Vec<TargetDeviceTypeId>),
     SourceDeviceAdded(UdevDevice),
     SourceDeviceRemoved(UdevDevice),
     SourceDeviceStopped(UdevDevice),
+    #[allow(dead_code)]
     UpdateSourceCapabilities(String, HashSet<Capability>),
     UpdateTargetCapabilities(String, HashSet<Capability>),
     WriteChordEvent(Vec<NativeEvent>),

--- a/src/input/manager.rs
+++ b/src/input/manager.rs
@@ -85,7 +85,7 @@ pub enum ManagerCommand {
         config: CompositeDeviceConfig,
     },
     CreateTargetDevice {
-        kind: String,
+        kind: TargetDeviceTypeId,
         sender: mpsc::Sender<Result<String, ManagerError>>,
     },
     StopTargetDevice {

--- a/src/input/target/client.rs
+++ b/src/input/target/client.rs
@@ -10,7 +10,7 @@ use crate::input::{
     event::native::NativeEvent,
 };
 
-use super::command::TargetCommand;
+use super::{command::TargetCommand, TargetDeviceTypeId};
 
 /// Possible errors for a target device client
 #[derive(Error, Debug)]
@@ -84,7 +84,7 @@ impl TargetDeviceClient {
 
     /// Returns a string identifier of the type of target device. This identifier
     /// should be the same text identifier used in device and input configs.
-    pub async fn get_type(&self) -> Result<String, ClientError> {
+    pub async fn get_type(&self) -> Result<TargetDeviceTypeId, ClientError> {
         let (tx, mut rx) = channel(1);
         self.tx.send(TargetCommand::GetType(tx)).await?;
         if let Some(value) = rx.recv().await {

--- a/src/input/target/command.rs
+++ b/src/input/target/command.rs
@@ -5,6 +5,8 @@ use crate::input::{
     event::native::NativeEvent,
 };
 
+use super::TargetDeviceTypeId;
+
 /// A [TargetCommand] is a message that can be sent to a [TargetDevice] over
 /// a channel.
 #[derive(Debug, Clone)]
@@ -16,7 +18,7 @@ pub enum TargetCommand {
     /// Return the input capabilities of the target device
     GetCapabilities(Sender<Vec<Capability>>),
     /// Return the type of target input device
-    GetType(Sender<String>),
+    GetType(Sender<TargetDeviceTypeId>),
     /// Clear all local state on the target device
     ClearState,
     /// Stop the target device

--- a/src/input/target/mod.rs
+++ b/src/input/target/mod.rs
@@ -481,7 +481,7 @@ impl<T: TargetInputDevice + TargetOutputDevice + Send + 'static> TargetDriver<T>
 
                     // Receive commands/input events
                     if let Err(e) = TargetDriver::receive_commands(
-                        self.type_id.as_str(),
+                        &self.type_id,
                         &mut composite_device,
                         &mut rx,
                         &mut implementation,
@@ -539,7 +539,7 @@ impl<T: TargetInputDevice + TargetOutputDevice + Send + 'static> TargetDriver<T>
     /// Read commands sent to this device from the channel until it is
     /// empty.
     fn receive_commands(
-        type_id: &str,
+        type_id: &TargetDeviceTypeId,
         composite_device: &mut Option<CompositeDeviceClient>,
         rx: &mut mpsc::Receiver<TargetCommand>,
         implementation: &mut MutexGuard<'_, T>,
@@ -561,7 +561,7 @@ impl<T: TargetInputDevice + TargetOutputDevice + Send + 'static> TargetDriver<T>
                         sender.blocking_send(capabilities)?;
                     }
                     TargetCommand::GetType(sender) => {
-                        sender.blocking_send(type_id.to_string())?;
+                        sender.blocking_send(*type_id)?;
                     }
                     TargetCommand::ClearState => {
                         implementation.clear_state();


### PR DESCRIPTION
This change updates all associated methods to use `TargetDeviceTypeId` instead of `String` to better enforce valid target device types and provide better error handling.

It also fixes idempotency issues where setting the `ds5` target multiple times would create multiple DualSense controllers:

```
$ inputplumber device 1 targets set "mouse" "keyboard" "ds5"
Set target devices to: ["mouse", "keyboard", "ds5"]

$ inputplumber device 1 targets list
╭──────────┬──────────────────────────────────────────────────────────────╮
│ Target Devices                                                          │
├──────────┼──────────────────────────────────────────────────────────────┤
│ Id       │ Name                                                         │
├──────────┼──────────────────────────────────────────────────────────────┤
│ ds5      │ Sony Interactive Entertainment DualSense Wireless Controller │
├──────────┼──────────────────────────────────────────────────────────────┤
│ ds5      │ Sony Interactive Entertainment DualSense Wireless Controller │
├──────────┼──────────────────────────────────────────────────────────────┤
│ mouse    │ InputPlumber Mouse                                           │
├──────────┼──────────────────────────────────────────────────────────────┤
│ keyboard │ InputPlumber Keyboard                                        │
├──────────┼──────────────────────────────────────────────────────────────┤
│ ds5      │ Sony Interactive Entertainment DualSense Wireless Controller │
╰──────────┴──────────────────────────────────────────────────────────────╯
```

Fixes #219