### PR TITLE
xpad uhid d-pad fix

### DIFF
--- a/src/drivers/xpad_uhid/driver.rs
+++ b/src/drivers/xpad_uhid/driver.rs
@@ -249,7 +249,7 @@ impl Driver {
                 let left = [
                     DPadDirection::Left,
                     DPadDirection::DownLeft,
-                    DPadDirection::DownRight,
+                    DPadDirection::UpLeft,
                 ]
                 .contains(&state.dpad_state);
                 let right = [


### PR DESCRIPTION
I noticed that the d-pad on my xbox series x controller was not working correctly when connected via bluetooth with xpad.

There was a typo/oopsie in the state transition code mixing up a direction.