### PR TITLE
fix: remove quick access capability from source dualsense

### DIFF
--- a/src/input/source/hidraw/dualsense.rs
+++ b/src/input/source/hidraw/dualsense.rs
@@ -469,7 +469,6 @@ pub const CAPABILITIES: &[Capability] = &[
     Capability::Gamepad(Gamepad::Button(GamepadButton::LeftStickTouch)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::LeftTrigger)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::North)),
-    Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::RightBumper)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::RightPaddle1)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::RightPaddle2)),

--- a/src/input/source/hidraw/dualsense.rs
+++ b/src/input/source/hidraw/dualsense.rs
@@ -469,6 +469,7 @@ pub const CAPABILITIES: &[Capability] = &[
     Capability::Gamepad(Gamepad::Button(GamepadButton::LeftStickTouch)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::LeftTrigger)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::North)),
+    Capability::Gamepad(Gamepad::Button(GamepadButton::Mute)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::RightBumper)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::RightPaddle1)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::RightPaddle2)),


### PR DESCRIPTION
the dualsense gamepad doesn't have such key and this only causes problems for apps that rely on checking for this capability

unsure how the key-combo use case of that capability behaves now (as I have not tested that), I believe however the target driver should work as expected