### PR TITLE
Fix(Hardware Support): Passthrough Zotac Zone Touchpads

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-zotac-zone.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-zotac-zone.yaml
@@ -41,12 +41,13 @@ source_devices:
       product_id: "1590"
       handler: event*
     capability_map_id: zone1
-  - group: mouse
-    evdev:
-      name: ZOTAC Gaming Zone Mouse
-      vendor_id: "1ee9"
-      product_id: "1590"
-      handler: event*
+  # TODO: Reevaluate if new firmware with ABS mode is added.
+  #- group: mouse
+  #  evdev:
+  #    name: ZOTAC Gaming Zone Mouse
+  #    vendor_id: "1ee9"
+  #    product_id: "1590"
+  #    handler: event*
   - group: mouse
     evdev:
       name: ZOTAC Gaming Zone Dials


### PR DESCRIPTION
Users on SteamOS are reporting that touchpads do not work on the Zotac Zone. Steamos-manager currently only creates a deck-uhid target so the rel events produced have no target device to emit from. Passthrough the events to reintroduce this functionality. This may need to be changed in the future if touchpad firmware is updated to include an abs event mode, though it would likely have a different report descriptor and name at that point.