### PR TITLE
Fix(Hardware Support): Passthrough Ayn Volume Events

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_max.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_max.yaml
@@ -28,6 +28,7 @@ source_devices:
       phys_path: usb-0000:74:00.0-1/input0
       handler: event*
   - group: keyboard
+    passthrough: true
     evdev:
       name: AT Translated Set 2 keyboard
       phys_path: isa0060/serio0/input0

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_mini_pro.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_mini_pro.yaml
@@ -28,6 +28,7 @@ source_devices:
       phys_path: usb-0000:04:00.4-2/input0
       handler: event*
   - group: keyboard
+    passthrough: true
     evdev:
       name: AT Translated Set 2 keyboard
       phys_path: isa0060/serio0/input0

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_loki_zero.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_loki_zero.yaml
@@ -28,6 +28,7 @@ source_devices:
       phys_path: usb-0000:04:00.3-4/input0
       handler: event*
   - group: keyboard
+    passthrough: true
     evdev:
       name: AT Translated Set 2 keyboard
       phys_path: isa0060/serio0/input0


### PR DESCRIPTION
Users on SteamOS are reporting that volume keys do not work on Ayn devices. Steamos-manager currently only creates a deck-uhid target so the keyboard events produced have no target device to emit from. Passthrough the events to reintroduce this functionality.