### PR TITLE
fix(DualSense): adjust device matching to work with older controller firmware

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ dist/$(NAME)-$(ARCH).tar.gz: build $(ALL_ROOTFS)
 dist-deb: dist/$(NAME)_$(VERSION)-1_$(ARCH_DEB).deb ## Build a redistributable deb package
 dist/$(NAME)_$(VERSION)-1_$(ARCH_DEB).deb: target/$(TARGET_ARCH)/release/$(NAME)
 	mkdir -p dist
-	cargo install --version 3.2.1 cargo-deb
+	cargo install --version 3.3.0 cargo-deb
 	cargo deb --target $(TARGET_ARCH)
 	cp ./target/$(TARGET_ARCH)/debian/$(NAME)_$(VERSION)-1_$(ARCH_DEB).deb dist
 	cd dist && sha256sum $(NAME)_$(VERSION)-1_$(ARCH_DEB).deb > $(NAME)_$(VERSION)-1_$(ARCH_DEB).deb.sha256.txt

--- a/rootfs/usr/share/inputplumber/devices/60-ps5_ds-edge_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-ps5_ds-edge_gamepad.yaml
@@ -26,21 +26,21 @@ source_devices:
   - group: gamepad
     blocked: true
     evdev:
-      name: "{Sony Interactive Entertainment DualSense Edge Wireless Controller,DualSense Edge Wireless Controller}"
+      name: "*Wireless Controller"
       vendor_id: 054c
       product_id: 0df2
       handler: event*
   - group: gamepad
     blocked: true
     evdev:
-      name: "{Sony Interactive Entertainment DualSense Edge Wireless Controller Touchpad,DualSense Edge Wireless Controller Touchpad}"
+      name: "*Wireless Controller Touchpad"
       vendor_id: 054c
       product_id: 0df2
       handler: event*
   - group: gamepad
     blocked: true
     evdev:
-      name: "{Sony Interactive Entertainment DualSense Edge Wireless Controller Motion Sensors,DualSense Edge Wireless Controller Motion Sensors}"
+      name: "*Wireless Controller Motion Sensors"
       vendor_id: 054c
       product_id: 0df2
       handler: event*

--- a/rootfs/usr/share/inputplumber/devices/60-ps5_ds_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-ps5_ds_gamepad.yaml
@@ -26,21 +26,21 @@ source_devices:
   - group: gamepad
     blocked: true
     evdev:
-      name: "*DualSense Wireless Controller"
+      name: "*Wireless Controller"
       vendor_id: 054c
       product_id: 0ce6
       handler: event*
   - group: gamepad
     blocked: true
     evdev:
-      name: "*DualSense Wireless Controller Touchpad"
+      name: "*Wireless Controller Touchpad"
       vendor_id: 054c
       product_id: 0ce6
       handler: event*
   - group: gamepad
     blocked: true
     evdev:
-      name: "*DualSense Wireless Controller Motion Sensors"
+      name: "*Wireless Controller Motion Sensors"
       vendor_id: 054c
       product_id: 0ce6
       handler: event*


### PR DESCRIPTION
In some cases, the DualSense wireless controller will show up as "Wireless Controller" instead of "DualSense Wireless Controller" when using older controller firmware. This change updates the name matching to match both varieties.