### PR TITLE
feat(security): polkit support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ authors = [
 assets = [
   { source = "target/release/inputplumber", dest = "/usr/bin/inputplumber", mode = "755" },
   { source = "rootfs/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf", dest = "/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf", mode = "644" },
+  { source = "rootfs/usr/share/polkit-1/actions/org.shadowblip.InputPlumber.policy", dest = "/usr/share/polkit-1/actions/org.shadowblip.InputPlumber.policy", mode = "644" },
   { source = "rootfs/usr/lib/systemd/system/inputplumber.service", dest = "/usr/lib/systemd/system/inputplumber.service", mode = "644" },
   { source = "rootfs/usr/lib/systemd/system/inputplumber-suspend.service", dest = "/usr/lib/systemd/system/inputplumber-suspend.service", mode = "644" },
   { source = "rootfs/usr/share/inputplumber/devices/*.yaml", dest = "/usr/share/inputplumber/devices/", mode = "644" },
@@ -52,6 +53,11 @@ assets = [
   [
     "rootfs/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf",
     "usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf",
+    "644",
+  ],
+  [
+    "rootfs/usr/share/polkit-1/actions/org.shadowblip.InputPlumber.policy",
+    "usr/share/polkit-1/actions/org.shadowblip.InputPlumber.policy",
     "644",
   ],
   [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,9 @@ assets = [
   ],
 ]
 
+[features]
+polkit = []
+
 [[bin]]
 name = "generate"
 path = "./src/generate.rs"

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,8 @@ install: build ## Install inputplumber to the given prefix (default: PREFIX=/usr
 		$(PREFIX)/bin/$(NAME)
 	install -D -m 644 rootfs/usr/share/dbus-1/system.d/$(DBUS_NAME).conf \
 		$(PREFIX)/share/dbus-1/system.d/$(DBUS_NAME).conf
+	install -D -m 644 -t $(PREFIX)/share/polkit-1/actions/ \
+		rootfs/usr/share/polkit-1/actions/*
 	install -D -m 644 -t $(PREFIX)/lib/systemd/system/ \
 		rootfs/usr/lib/systemd/system/*
 	install -D -m 644 -t $(PREFIX)/lib/udev/hwdb.d/ \
@@ -77,6 +79,7 @@ install: build ## Install inputplumber to the given prefix (default: PREFIX=/usr
 uninstall: ## Uninstall inputplumber
 	rm $(PREFIX)/bin/$(NAME)
 	rm $(PREFIX)/share/dbus-1/system.d/$(DBUS_NAME).conf
+	rm $(PREFIX)/share/polkit-1/actions/$(DBUS_NAME).policy
 	rm $(PREFIX)/lib/systemd/system/$(NAME).service
 	rm $(PREFIX)/lib/systemd/system/$(NAME)-suspend.service
 	rm $(PREFIX)/lib/udev/hwdb.d/59-inputplumber.hwdb

--- a/bindings/dbus-xml/org.shadowblip.Input.CompositeDevice.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.CompositeDevice.xml
@@ -2,47 +2,6 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
-  <interface name="org.shadowblip.Input.CompositeDevice">
-    <!--
-     Load the device profile from the given path
-     -->
-    <method name="LoadProfilePath">
-      <arg name="path" type="s" direction="in"/>
-    </method>
-    <!--
-     List of capabilities that all source devices implement
-     -->
-    <property name="Capabilities" type="as" access="read"/>
-    <!--
-     Target dbus devices that this [CompositeDevice] is managing
-     -->
-    <property name="DbusDevices" type="as" access="read"/>
-    <!--
-     The intercept mode of the composite device.
-     -->
-    <property name="InterceptMode" type="u" access="readwrite"/>
-    <!--
-     Name of the composite device
-     -->
-    <property name="Name" type="s" access="read"/>
-    <!--
-     Name of the currently loaded profile
-     -->
-    <property name="ProfileName" type="s" access="read"/>
-    <!--
-     List of source devices that this composite device is processing inputs for
-     -->
-    <property name="SourceDevicePaths" type="as" access="read"/>
-    <!--
-     Target devices that this [CompositeDevice] is managing
-     -->
-    <property name="TargetDevices" type="as" access="read"/>
-  </interface>
-  <interface name="org.freedesktop.DBus.Introspectable">
-    <method name="Introspect">
-      <arg type="s" direction="out"/>
-    </method>
-  </interface>
   <interface name="org.freedesktop.DBus.Properties">
     <method name="Get">
       <arg name="interface_name" type="s" direction="in"/>
@@ -58,9 +17,6 @@
       <arg name="interface_name" type="s" direction="in"/>
       <arg type="a{sv}" direction="out"/>
     </method>
-    <!--
-     Emits the `org.freedesktop.DBus.Properties.PropertiesChanged` signal.
-     -->
     <signal name="PropertiesChanged">
       <arg name="interface_name" type="s"/>
       <arg name="changed_properties" type="a{sv}"/>
@@ -73,6 +29,89 @@
     <method name="GetMachineId">
       <arg type="s" direction="out"/>
     </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg type="s" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.shadowblip.Input.CompositeDevice">
+    <!--
+     Name of the composite device
+     -->
+    <property name="Name" type="s" access="read"/>
+    <!--
+     Name of the currently loaded profile
+     -->
+    <property name="ProfileName" type="s" access="read"/>
+    <!--
+     Optional path to the currently loaded profile
+     -->
+    <property name="ProfilePath" type="s" access="read"/>
+    <!--
+     Stop the composite device and all target devices
+     -->
+    <method name="Stop">
+    </method>
+    <!--
+     Returns the currently loaded profile encoded in YAML format
+     -->
+    <method name="GetProfileYaml">
+    </method>
+    <!--
+     Load the device profile from the given path
+     -->
+    <method name="LoadProfilePath">
+      <arg name="path" type="s" direction="in"/>
+    </method>
+    <!--
+     Load the device profile from the given YAML/JSON string
+     -->
+    <method name="LoadProfileFromYaml">
+      <arg name="profile" type="s" direction="in"/>
+    </method>
+
+    <!-- I couldn't be bothered to copy the docs for these. See src/dbus/interface/composite_device.rs -->
+    <method name="SendEvent">
+      <arg name="event" type="s" direction="in"/>
+      <arg name="value" type="v" direction="in"/>
+    </method>
+    <method name="SendButtonChord">
+      <arg name="events" type="as" direction="in"/>
+    </method>
+    <method name="SetInterceptActivation">
+      <arg name="activation_events" type="as" direction="in"/>
+      <arg name="target_event" type="s" direction="in"/>
+    </method>
+
+    <!--
+     List of capabilities that all source devices implement
+     -->
+    <property name="Capabilities" type="as" access="read"/>
+    <!--
+     List of capabilities that all output devices implement
+     -->
+    <property name="OutputCapabilities" type="as" access="read"/>
+    <!--
+     List of capabilities that all target devices implement
+     -->
+    <property name="TargetCapabilities" type="as" access="read"/>
+    <!--
+     List of source devices that this composite device is processing inputs for
+     -->
+    <property name="SourceDevicePaths" type="as" access="read"/>
+    <!--
+     The intercept mode of the composite device.
+     -->
+    <property name="InterceptMode" type="u" access="readwrite"/>
+    <!--
+     Target devices that this [CompositeDevice] is managing
+     -->
+    <property name="TargetDevices" type="as" access="readwrite"/>
+    <!--
+     Target dbus devices that this [CompositeDevice] is managing
+     -->
+    <property name="DbusDevices" type="as" access="read"/>
   </interface>
 </node>
 

--- a/bindings/dbus-xml/org.shadowblip.Input.DBusDevice.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.DBusDevice.xml
@@ -2,31 +2,6 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
-  <interface name="org.freedesktop.DBus.Introspectable">
-    <method name="Introspect">
-      <arg type="s" direction="out"/>
-    </method>
-  </interface>
-  <interface name="org.shadowblip.Input.DBusDevice">
-    <!--
-     Emitted when an input event occurs
-     -->
-    <signal name="InputEvent">
-      <arg name="event" type="s"/>
-      <arg name="value" type="d"/>
-    </signal>
-    <!--
-     Name of the DBus device
-     -->
-    <property name="Name" type="s" access="read"/>
-  </interface>
-  <interface name="org.freedesktop.DBus.Peer">
-    <method name="Ping">
-    </method>
-    <method name="GetMachineId">
-      <arg type="s" direction="out"/>
-    </method>
-  </interface>
   <interface name="org.freedesktop.DBus.Properties">
     <method name="Get">
       <arg name="interface_name" type="s" direction="in"/>
@@ -42,14 +17,49 @@
       <arg name="interface_name" type="s" direction="in"/>
       <arg type="a{sv}" direction="out"/>
     </method>
-    <!--
-     Emits the `org.freedesktop.DBus.Properties.PropertiesChanged` signal.
-     -->
     <signal name="PropertiesChanged">
       <arg name="interface_name" type="s"/>
       <arg name="changed_properties" type="a{sv}"/>
       <arg name="invalidated_properties" type="as"/>
     </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg type="s" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Peer">
+    <method name="Ping">
+    </method>
+    <method name="GetMachineId">
+      <arg type="s" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.shadowblip.Input.DBusDevice">
+    <!--
+     Emitted when an input event occurs
+     -->
+    <signal name="InputEvent">
+      <arg name="event" type="s"/>
+      <arg name="value" type="d"/>
+    </signal>
+
+    <!--
+     Emitted when a touch event occurs
+     -->
+    <signal name="TouchEvent">
+      <arg name="event" type="s"/>
+      <arg name="index" type="u"/>
+      <arg name="is_touching" type="b"/>
+      <arg name="pressure" type="d"/>
+      <arg name="x" type="d"/>
+      <arg name="y" type="d"/>
+    </signal>
+
+    <!--
+     Name of the DBus device
+     -->
+    <property name="Name" type="s" access="read"/>
   </interface>
 </node>
 

--- a/bindings/dbus-xml/org.shadowblip.Input.Debug.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.Debug.xml
@@ -35,20 +35,18 @@
       <arg type="s" direction="out"/>
     </method>
   </interface>
-  <interface name="org.shadowblip.Input.Mouse">
-    <!--
-     Name of the composite device
+  <interface name="org.shadowblip.Input.Debug">
+    <!-- 
+     Returns the input capability report data that can be used to decode
+     the values from the input report.
      -->
-    <property name="Name" type="s" access="read"/>
+    <property name="InputCapabilityReport" type="s" access="read"/>
 
     <!--
-     Move the virtual mouse by the given amount relative to the cursor's
-     current position.
+     Emitted when a input is emitted.
      -->
-    <method name="MoveCursor">
-      <arg name="x" type="i" direction="in"/>
-      <arg name="y" type="i" direction="in"/>
-    </method>
+    <signal name="InputReport">
+    </signal>
   </interface>
 </node>
 

--- a/bindings/dbus-xml/org.shadowblip.Input.Gamepad.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.Gamepad.xml
@@ -2,13 +2,6 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
-  <interface name="org.freedesktop.DBus.Peer">
-    <method name="Ping">
-    </method>
-    <method name="GetMachineId">
-      <arg type="s" direction="out"/>
-    </method>
-  </interface>
   <interface name="org.freedesktop.DBus.Properties">
     <method name="Get">
       <arg name="interface_name" type="s" direction="in"/>
@@ -24,9 +17,6 @@
       <arg name="interface_name" type="s" direction="in"/>
       <arg type="a{sv}" direction="out"/>
     </method>
-    <!--
-     Emits the `org.freedesktop.DBus.Properties.PropertiesChanged` signal.
-     -->
     <signal name="PropertiesChanged">
       <arg name="interface_name" type="s"/>
       <arg name="changed_properties" type="a{sv}"/>
@@ -35,6 +25,13 @@
   </interface>
   <interface name="org.freedesktop.DBus.Introspectable">
     <method name="Introspect">
+      <arg type="s" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Peer">
+    <method name="Ping">
+    </method>
+    <method name="GetMachineId">
       <arg type="s" direction="out"/>
     </method>
   </interface>

--- a/bindings/dbus-xml/org.shadowblip.Input.Keyboard.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.Keyboard.xml
@@ -2,11 +2,6 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
-  <interface name="org.freedesktop.DBus.Introspectable">
-    <method name="Introspect">
-      <arg type="s" direction="out"/>
-    </method>
-  </interface>
   <interface name="org.freedesktop.DBus.Properties">
     <method name="Get">
       <arg name="interface_name" type="s" direction="in"/>
@@ -22,14 +17,23 @@
       <arg name="interface_name" type="s" direction="in"/>
       <arg type="a{sv}" direction="out"/>
     </method>
-    <!--
-     Emits the `org.freedesktop.DBus.Properties.PropertiesChanged` signal.
-     -->
     <signal name="PropertiesChanged">
       <arg name="interface_name" type="s"/>
       <arg name="changed_properties" type="a{sv}"/>
       <arg name="invalidated_properties" type="as"/>
     </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg type="s" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Peer">
+    <method name="Ping">
+    </method>
+    <method name="GetMachineId">
+      <arg type="s" direction="out"/>
+    </method>
   </interface>
   <interface name="org.shadowblip.Input.Keyboard">
     <!--
@@ -43,13 +47,6 @@
      Name of the composite device
      -->
     <property name="Name" type="s" access="read"/>
-  </interface>
-  <interface name="org.freedesktop.DBus.Peer">
-    <method name="Ping">
-    </method>
-    <method name="GetMachineId">
-      <arg type="s" direction="out"/>
-    </method>
   </interface>
 </node>
 

--- a/bindings/dbus-xml/org.shadowblip.Input.Manager.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.Manager.xml
@@ -2,22 +2,6 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
-  <interface name="org.shadowblip.InputManager">
-    <!--
-     Create a composite device using the give composite device config. The
-     path should be the absolute path to a composite device configuration file.
-     -->
-    <method name="CreateCompositeDevice">
-      <arg name="config_path" type="s" direction="in"/>
-      <arg type="s" direction="out"/>
-    </method>
-    <property name="InterceptMode" type="s" access="read"/>
-  </interface>
-  <interface name="org.freedesktop.DBus.Introspectable">
-    <method name="Introspect">
-      <arg type="s" direction="out"/>
-    </method>
-  </interface>
   <interface name="org.freedesktop.DBus.Properties">
     <method name="Get">
       <arg name="interface_name" type="s" direction="in"/>
@@ -33,9 +17,6 @@
       <arg name="interface_name" type="s" direction="in"/>
       <arg type="a{sv}" direction="out"/>
     </method>
-    <!--
-     Emits the `org.freedesktop.DBus.Properties.PropertiesChanged` signal.
-     -->
     <signal name="PropertiesChanged">
       <arg name="interface_name" type="s"/>
       <arg name="changed_properties" type="a{sv}"/>
@@ -48,6 +29,68 @@
     <method name="GetMachineId">
       <arg type="s" direction="out"/>
     </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg type="s" direction="out"/>
+    </method>
+  </interface>
+  <interface name="org.shadowblip.InputManager">
+    <!--
+     Create a composite device using the given composite device config. The
+     path should be the absolute path to a composite device configuration file.
+     -->
+    <method name="CreateCompositeDevice">
+      <arg name="config_path" type="s" direction="in"/>
+      <arg type="s" direction="out"/>
+    </method>
+    <!--
+     Create a target device of the given type. Returns the DBus path to
+     the created target device.
+     -->
+    <method name="CreateTargetDevice">
+      <arg name="kind" type="s" direction="in"/>
+      <arg type="s" direction="out"/>
+    </method>
+    <!--
+     Stop the given target device
+     -->
+    <method name="StopTargetDevice">
+      <arg name="path" type="s" direction="in"/>
+    </method>
+    <!--
+     Attach the given target device to the given composite device
+     -->
+    <method name="AttachTargetDevice">
+      <arg name="target_path" type="s" direction="in"/>
+      <arg name="composite_path" type="s" direction="in"/>
+    </method>
+    <!--
+     Used to prepare InputPlumber for system suspend
+     -->
+    <method name="HookSleep">
+    </method>
+    <!--
+     Used to prepare InputPlumber for resume from system suspend
+     -->
+    <method name="HookWake">
+    </method>
+    <property name="GamepadOrder" type="as" access="readwrite"/>
+    <!--
+     If set to 'true', InputPlumber will try to manage all input devices
+     on the system that have a Composite Device configuration.
+     -->
+    <property name="ManageAllDevices" type="b" access="readwrite"/>
+    <!--
+     Returns a list of supported target device ids. E.g. ["xb360", "deck"]
+     -->
+    <property name="SupportedTargetDeviceIds" type="as" access="read"/>
+    <!--
+     Returns a list of supported target device names. E.g. ["InputPlumber Mouse", "Microsoft
+     XBox 360 Gamepad"]
+     -->
+    <property name="SupportedTargetDevices" type="as" access="read"/>
+    <property name="Version" type="s" access="read"/>
   </interface>
 </node>
 

--- a/bindings/dbus-xml/org.shadowblip.Input.Metrics.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.Metrics.xml
@@ -29,26 +29,12 @@
     </method>
   </interface>
   <interface name="org.freedesktop.DBus.Peer">
-    <method name="Ping">
-    </method>
-    <method name="GetMachineId">
-      <arg type="s" direction="out"/>
-    </method>
-  </interface>
-  <interface name="org.shadowblip.Input.Mouse">
-    <!--
-     Name of the composite device
-     -->
-    <property name="Name" type="s" access="read"/>
+    <property name="Enabled" type="b" access="readwrite"/>
 
-    <!--
-     Move the virtual mouse by the given amount relative to the cursor's
-     current position.
-     -->
-    <method name="MoveCursor">
-      <arg name="x" type="i" direction="in"/>
-      <arg name="y" type="i" direction="in"/>
-    </method>
+    <signal name="EventMetrics">
+      <arg name="capability" type="s"/>
+    </signal>
+  </interface>
+  <interface name="org.shadowblip.Input.Metrics">
   </interface>
 </node>
-

--- a/bindings/dbus-xml/org.shadowblip.Input.Source.HIDRawDevice.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.Source.HIDRawDevice.xml
@@ -2,16 +2,6 @@
 <!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
  "http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
 <node>
-  <interface name="org.shadowblip.Input.Source.HIDRawDevice">
-    <property name="InterfaceNumber" type="i" access="read"/>
-    <property name="Manufacturer" type="s" access="read"/>
-    <property name="Path" type="s" access="read"/>
-    <property name="Product" type="s" access="read"/>
-    <property name="ProductId" type="s" access="read"/>
-    <property name="ReleaseNumber" type="s" access="read"/>
-    <property name="SerialNumber" type="s" access="read"/>
-    <property name="VendorId" type="s" access="read"/>
-  </interface>
   <interface name="org.freedesktop.DBus.Properties">
     <method name="Get">
       <arg name="interface_name" type="s" direction="in"/>
@@ -27,9 +17,6 @@
       <arg name="interface_name" type="s" direction="in"/>
       <arg type="a{sv}" direction="out"/>
     </method>
-    <!--
-     Emits the `org.freedesktop.DBus.Properties.PropertiesChanged` signal.
-     -->
     <signal name="PropertiesChanged">
       <arg name="interface_name" type="s"/>
       <arg name="changed_properties" type="a{sv}"/>
@@ -47,6 +34,17 @@
     <method name="GetMachineId">
       <arg type="s" direction="out"/>
     </method>
+  </interface>
+  <interface name="org.shadowblip.Input.Source.HIDRawDevice">
+    <property name="Name" type="s" access="read"/>
+    <property name="DevPath" type="s" access="read"/>
+    <property name="IdProduct" type="s" access="read"/>
+    <property name="IdVendor" type="s" access="read"/>
+    <property name="InterfaceNumber" type="i" access="read"/>
+    <property name="Manufacturer" type="s" access="read"/>
+    <property name="Product" type="s" access="read"/>
+    <property name="SerialNumber" type="s" access="read"/>
+    <property name="SysfsPath" type="s" access="read"/>
   </interface>
 </node>
 

--- a/bindings/dbus-xml/org.shadowblip.Input.Source.IIOIMUDevice.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.Source.IIOIMUDevice.xml
@@ -35,20 +35,27 @@
       <arg type="s" direction="out"/>
     </method>
   </interface>
-  <interface name="org.shadowblip.Input.Mouse">
+  <interface name="org.shadowblip.Input.Source.IIOIMUDevice">
     <!--
-     Name of the composite device
+     Returns the human readable name of the device (e.g. XBox 360 Pad)
      -->
-    <property name="Name" type="s" access="read"/>
+    <property name="Id" type="s" access="read"/>
 
-    <!--
-     Move the virtual mouse by the given amount relative to the cursor's
-     current position.
-     -->
-    <method name="MoveCursor">
-      <arg name="x" type="i" direction="in"/>
-      <arg name="y" type="i" direction="in"/>
-    </method>
+    <property name="AccelSampleRate" type="s" access="readwrite"/>
+
+    <property name="AccelSampleRatesAvail" type="s" access="read"/>
+
+    <property name="AngvelSampleRate" type="s" access="readwrite"/>
+
+    <property name="AngvelSampleRatesAvail" type="s" access="read"/>
+
+    <property name="AccelScale" type="s" access="readwrite"/>
+
+    <property name="AccelScalesAvail" type="s" access="read"/>
+
+    <property name="AngvelScale" type="s" access="readwrite"/>
+
+    <property name="AngvelScalesAvail" type="s" access="read"/>
   </interface>
 </node>
 

--- a/bindings/dbus-xml/org.shadowblip.Input.Source.LEDDevice.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.Source.LEDDevice.xml
@@ -35,20 +35,11 @@
       <arg type="s" direction="out"/>
     </method>
   </interface>
-  <interface name="org.shadowblip.Input.Mouse">
+  <interface name="org.shadowblip.Input.Source.LEDDevice">
     <!--
-     Name of the composite device
+     Returns the human readable name of the device (e.g. XBox 360 Pad)
      -->
-    <property name="Name" type="s" access="read"/>
-
-    <!--
-     Move the virtual mouse by the given amount relative to the cursor's
-     current position.
-     -->
-    <method name="MoveCursor">
-      <arg name="x" type="i" direction="in"/>
-      <arg name="y" type="i" direction="in"/>
-    </method>
+    <property name="Id" type="s" access="read"/>
   </interface>
 </node>
 

--- a/bindings/dbus-xml/org.shadowblip.Input.Touchscreen.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.Touchscreen.xml
@@ -35,20 +35,12 @@
       <arg type="s" direction="out"/>
     </method>
   </interface>
-  <interface name="org.shadowblip.Input.Mouse">
+  <interface name="org.shadowblip.Input.Touchscreen">
     <!--
-     Name of the composite device
+     Name of the target device
      -->
     <property name="Name" type="s" access="read"/>
-
-    <!--
-     Move the virtual mouse by the given amount relative to the cursor's
-     current position.
-     -->
-    <method name="MoveCursor">
-      <arg name="x" type="i" direction="in"/>
-      <arg name="y" type="i" direction="in"/>
-    </method>
+    </signal>
   </interface>
 </node>
 

--- a/bindings/dbus-xml/org.shadowblip.Input.UdevDevice.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.UdevDevice.xml
@@ -35,11 +35,7 @@
       <arg type="s" direction="out"/>
     </method>
   </interface>
-  <interface name="org.shadowblip.Input.Source.EventDevice">
-    <!--
-     Returns the detected device class of the device (e.g. "joystick", "touchscreen", etc.)
-     -->
-    <property name="DeviceClass" type="s" access="read"/>
+  <interface name="org.shadowblip.Input.Source.UdevDevice">
     <!--
      Returns the full device node path to the device (e.g. /dev/input/event3)
      -->
@@ -69,50 +65,13 @@
      -->
     <property name="PhysPath" type="s" access="read"/>
     <!--
-     Returns the set of supported "absolute axes" reported by the device.
-
-     These are most typically supported by joysticks and touchpads.
+     Returns the udev device properties of the device
      -->
-    <property name="SupportedAbsoluteAxes" type="aq" access="read"/>
+    <property name="Properties" type="a{ss}" access="read"/>
     <!--
-     Returns the set of supported force feedback effects supported by a device.
+     Returns the subsystem that the device belongs to. E.g. "input", "hidraw"
      -->
-    <property name="SupportedFf" type="aq" access="read"/>
-    <!--
-     Returns the set of supported keys reported by the device.
-
-     For keyboards, this is the set of all possible keycodes the keyboard may emit. Controllers,
-     mice, and other peripherals may also report buttons as keys.
-     -->
-    <property name="SupportedKeys" type="aq" access="read"/>
-    <!--
-     Returns a set of supported LEDs on the device.
-
-     Most commonly these are state indicator lights for things like Scroll Lock, but they
-     can also be found in cameras and other devices.
-     -->
-    <property name="SupportedLeds" type="aq" access="read"/>
-    <!--
-     Returns the set of supported "relative axes" reported by the device.
-
-     Standard mice will generally report `REL_X` and `REL_Y` along with wheel if supported.
-     -->
-    <property name="SupportedRelativeAxes" type="aq" access="read"/>
-    <!--
-     Returns the set of supported simple sounds supported by a device.
-
-     You can use these to make really annoying beep sounds come from an internal self-test
-     speaker, for instance.
-     -->
-    <property name="SupportedSounds" type="aq" access="read"/>
-    <!--
-     Returns the set of supported switches reported by the device.
-
-     These are typically used for things like software switches on laptop lids (which the
-     system reacts to by suspending or locking), or virtual switches to indicate whether a
-     headphone jack is plugged in (used to disable external speakers).
-     -->
-    <property name="SupportedSwitches" type="aq" access="read"/>
+    <property name="Subsystem" type="s" access="read"/>
     <!--
      Returns the full sysfs path of the device (e.g. /sys/devices/pci0000:00)
      -->
@@ -123,4 +82,3 @@
     <property name="UniqueId" type="s" access="read"/>
   </interface>
 </node>
-

--- a/bindings/dbus-xml/org.shadowblip.Output.ForceFeedback.xml
+++ b/bindings/dbus-xml/org.shadowblip.Output.ForceFeedback.xml
@@ -35,20 +35,18 @@
       <arg type="s" direction="out"/>
     </method>
   </interface>
-  <interface name="org.shadowblip.Input.Mouse">
+  <interface name="org.shadowblip.Output.ForceFeedback">
     <!--
-     Name of the composite device
+     Send a simple rumble event
      -->
-    <property name="Name" type="s" access="read"/>
+    <method name="Rumble">
+      <arg name="value" type="i" direction="in"/>
+    </method>
 
     <!--
-     Move the virtual mouse by the given amount relative to the cursor's
-     current position.
+     Stop all currently playing force feedback effects
      -->
-    <method name="MoveCursor">
-      <arg name="x" type="i" direction="in"/>
-      <arg name="y" type="i" direction="in"/>
+    <method name="Stop">
     </method>
   </interface>
 </node>
-

--- a/pkg/archlinux/PKGBUILD
+++ b/pkg/archlinux/PKGBUILD
@@ -8,6 +8,7 @@ arch=('x86_64')
 url="https://github.com/ShadowBlip/inputplumber"
 license=('GPL')
 depends=('dbus' 'libevdev' 'libiio')
+optdepends=('polkit')
 provides=('inputplumber')
 conflicts=('inputplumber-git')
 source=(inputplumber-$pkgver.tar.gz::https://github.com/ShadowBlip/inputplumber/releases/download/$pkgver/inputplumber-x86_64.tar.gz)

--- a/pkg/rpm/inputplumber.spec
+++ b/pkg/rpm/inputplumber.spec
@@ -10,7 +10,7 @@ URL:            https://github.com/ShadowBlip/InputPlumber
 
 BuildRequires:  libevdev-devel libiio-devel git make cargo libudev-devel llvm-devel clang-devel
 Requires:       libevdev libiio
-Recommends:     steam gamescope-session linuxconsoletools
+Recommends:     steam gamescope-session linuxconsoletools polkit
 Provides:       inputplumber
 Conflicts:      hhd
 
@@ -36,6 +36,7 @@ mkdir -p %{buildroot}/usr/share/inputplumber/capability_maps
 mkdir -p %{buildroot}/usr/share/inputplumber/devices
 mkdir -p %{buildroot}/usr/share/inputplumber/profiles
 mkdir -p %{buildroot}/usr/share/inputplumber/schema
+mkdir -p %{buildroot}/usr/share/polkit-1/actions
 
 install -D -m 755 %{_builddir}/InputPlumber/target/%{_arch}-unknown-linux-gnu/release/inputplumber %{buildroot}/usr/bin/inputplumber
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf %{buildroot}/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf
@@ -47,6 +48,7 @@ install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/share/inputplumber/capabi
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/share/inputplumber/devices/* %{buildroot}/usr/share/inputplumber/devices/
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/share/inputplumber/profiles/* %{buildroot}/usr/share/inputplumber/profiles/
 install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/share/inputplumber/schema/* %{buildroot}/usr/share/inputplumber/schema/
+install -D -m 644 %{_builddir}/InputPlumber/rootfs/usr/share/polkit-1/actions/org.shadowblip.InputPlumber.policy %{buildroot}/usr/share/polkit-1/actions/org.shadowblip.InputPlumber.policy
 
 %post
 udevadm control --reload-rules
@@ -71,6 +73,7 @@ systemctl disable inputplumber.service
 /usr/share/inputplumber/devices/*.yaml
 /usr/share/inputplumber/profiles/*.yaml
 /usr/share/inputplumber/schema/*.json
+/usr/share/polkit-1/actions/org.shadowblip.InputPlumber.policy
 
 %changelog
 * Tue Aug 6 2024 William Edwards [0.33.1-0]

--- a/rootfs/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf
+++ b/rootfs/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf
@@ -4,10 +4,15 @@
 <busconfig>
   <!-- Only root can own the service -->
   <policy user="root">
+    <allow receive_sender="org.shadowblip.InputPlumber"/>
     <allow own="org.shadowblip.InputPlumber"/>
   </policy>
-  <!-- Anyone can send messages to the owner of org.shadowblip.InputPlumber -->
+  <!--
+   Anyone can send messages to the owner of org.shadowblip.InputPlumber,
+   but deny receiving signals by default as it leaks timing information
+   -->
   <policy context="default">
+    <deny receive_sender="org.shadowblip.InputPlumber"/>
     <allow send_destination="org.shadowblip.InputPlumber"/>
   </policy>
 </busconfig>

--- a/rootfs/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf
+++ b/rootfs/usr/share/dbus-1/system.d/org.shadowblip.InputPlumber.conf
@@ -12,7 +12,9 @@
    but deny receiving signals by default as it leaks timing information
    -->
   <policy context="default">
-    <deny receive_sender="org.shadowblip.InputPlumber"/>
+    <!-- For the time being, allow receiving signals anyway for backwards compatibilty. -->
+    <!-- TODO: Uncomment this when an alternative API is made available -->
+    <!-- <deny receive_sender="org.shadowblip.InputPlumber"/> -->
     <allow send_destination="org.shadowblip.InputPlumber"/>
   </policy>
 </busconfig>

--- a/rootfs/usr/share/polkit-1/actions/org.shadowblip.InputPlumber.policy
+++ b/rootfs/usr/share/polkit-1/actions/org.shadowblip.InputPlumber.policy
@@ -1,0 +1,865 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policyconfig PUBLIC
+  "-//freedesktop//DTD PolicyKit Policy Configuration 1.0//EN"
+  "https://specifications.freedesktop.org/PolicyKit/1.0/policyconfig.dtd">
+<policyconfig>
+  <action id="org.shadowblip.Input.CompositeDevice.LoadProfilePath">
+    <description>Load the device profile from the given path</description>
+    <message>Authorization required to load device profile from a specified path.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.CompositeDevice.LoadProfileFromYaml">
+    <description>Load the device profile from the given YAML/JSON string</description>
+    <message>Authorization required to load device profile from a given YAML/JSON string.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.CompositeDevice.Stop">
+    <description>Stop the composite device and all target devices</description>
+    <message>Authorization required to stop the composite device and target devices.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.CompositeDevice.SendEvent">
+    <description>Send an event to the composite device</description>
+    <message>Authorization required to send an event to the composite device.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.CompositeDevice.SendButtonChord">
+    <description>Send a button chord to the composite device</description>
+    <message>Authorization required to send a button chord to the composite device.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.CompositeDevice.SetInterceptActivation">
+    <description>Set intercept activation for the composite device</description>
+    <message>Authorization required to set intercept activation for the composite device.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.CompositeDevice.SetInterceptMode">
+    <description>Modify intercept mode of the composite device</description>
+    <message>Authorization required to modify the intercept mode of the composite device.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.CompositeDevice.SetTargetDevices">
+    <description>Modify target devices managed by the composite device</description>
+    <message>Authorization required to modify target devices managed by the composite device.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.CompositeDevice.DbusDevices">
+    <description>Read target D-Bus devices managed by the composite device</description>
+    <message>Authorization required to read target D-Bus devices managed by the composite device.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.DBusDevice.InputEvent">
+    <description>Emit an input event from the DBus device</description>
+    <message>Authorization required to emit an input event from the DBus device.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.DBusDevice.TouchEvent">
+    <description>Emit a touch event from the DBus device</description>
+    <message>Authorization required to emit a touch event from the DBus device.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.DBusDevice.Name">
+    <description>Read the name of the DBus device</description>
+    <message>Authorization required to read the name of the DBus device.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Gamepad.Name">
+    <description>Read the name of the Gamepad DBus device</description>
+    <message>Authorization required to read the name of the Gamepad DBus device.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Keyboard.SendKey">
+    <description>Send the given key to the virtual keyboard</description>
+    <message>Authorization required to send a key to the virtual keyboard.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Keyboard.Name">
+    <description>Read the name of the Keyboard DBus device</description>
+    <message>Authorization required to read the name of the Keyboard DBus device.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.InputPlumber.Version">
+    <description>Read InputPlumber Manager version</description>
+    <message>Authorization required to read the InputPlumber Manager version.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.InputPlumber.SupportedTargetDevices">
+    <description>Read supported target devices</description>
+    <message>Authorization required to read supported target devices.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.InputPlumber.SupportedTargetDeviceIds">
+    <description>Read supported target device IDs</description>
+    <message>Authorization required to read supported target device IDs.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.InputPlumber.SetGamepadOrder">
+    <description>Modify GamepadOrder</description>
+    <message>Authorization required to change the Gamepad order.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.InputPlumber.SetManageAllDevices">
+    <description>Modify ManageAllDevices flag</description>
+    <message>Authorization required to toggle managing all devices.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.InputPlumber.CreateCompositeDevice">
+    <description>Create a composite device</description>
+    <message>Authorization required to create a composite device.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.InputPlumber.CreateTargetDevice">
+    <description>Create a target device</description>
+    <message>Authorization required to create a target device.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.InputPlumber.StopTargetDevice">
+    <description>Stop a target device</description>
+    <message>Authorization required to stop a target device.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.InputPlumber.AttachTargetDevice">
+    <description>Attach a target device to a composite device</description>
+    <message>Authorization required to attach a target device.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.InputPlumber.HookSleep">
+    <description>Prepare for system sleep</description>
+    <message>Authorization required to hook into system suspend.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.InputPlumber.HookWake">
+    <description>Prepare for system wake</description>
+    <message>Authorization required to hook into system resume.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Mouse.MoveCursor">
+    <description>Move the virtual mouse cursor</description>
+    <message>Authorization required to move the virtual mouse cursor.</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Mouse.Name">
+    <description>Read the name of the Mouse DBus device</description>
+    <message>Authorization required to read the name of the Mouse DBus device.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.DeviceClass">
+    <description>Read the device class of the input device</description>
+    <message>Authorization required to read the device class.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.DevicePath">
+    <description>Read the device path of the input device</description>
+    <message>Authorization required to read the device path.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.IdBustype">
+    <description>Read the bus type ID of the input device</description>
+    <message>Authorization required to read the bus type ID.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.IdProduct">
+    <description>Read the product ID of the input device</description>
+    <message>Authorization required to read the product ID.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.IdVendor">
+    <description>Read the vendor ID of the input device</description>
+    <message>Authorization required to read the vendor ID.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.IdVersion">
+    <description>Read the version ID of the input device</description>
+    <message>Authorization required to read the version ID.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.Name">
+    <description>Read the name of the input device</description>
+    <message>Authorization required to read the device name.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.PhysPath">
+    <description>Read the physical path of the input device</description>
+    <message>Authorization required to read the physical path.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.SysfsPath">
+    <description>Read the sysfs path of the input device</description>
+    <message>Authorization required to read the sysfs path.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.UniqueId">
+    <description>Read the unique ID of the input device</description>
+    <message>Authorization required to read the unique ID.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.SupportedKeys">
+    <description>Read supported key codes of the input device</description>
+    <message>Authorization required to read supported key codes.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.SupportedRelativeAxes">
+    <description>Read supported relative axes of the input device</description>
+    <message>Authorization required to read supported relative axes.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.SupportedAbsoluteAxes">
+    <description>Read supported absolute axes of the input device</description>
+    <message>Authorization required to read supported absolute axes.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.SupportedSwitches">
+    <description>Read supported switches of the input device</description>
+    <message>Authorization required to read supported switches.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.SupportedLeds">
+    <description>Read supported LEDs of the input device</description>
+    <message>Authorization required to read supported LEDs.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.SupportedSounds">
+    <description>Read supported sounds of the input device</description>
+    <message>Authorization required to read supported sounds.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.EventDevice.SupportedFf">
+    <description>Read supported force-feedback effects of the input device</description>
+    <message>Authorization required to read supported force-feedback effects.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.HIDRawDevice.Name">
+    <description>Read the name of the HID raw device</description>
+    <message>Authorization required to read the HID raw device name.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.HIDRawDevice.DevPath">
+    <description>Read the device path of the HID raw device</description>
+    <message>Authorization required to read the HID raw device path.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.HIDRawDevice.IdProduct">
+    <description>Read the product ID of the HID raw device</description>
+    <message>Authorization required to read the HID raw device product ID.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.HIDRawDevice.IdVendor">
+    <description>Read the vendor ID of the HID raw device</description>
+    <message>Authorization required to read the HID raw device vendor ID.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.HIDRawDevice.InterfaceNumber">
+    <description>Read the interface number of the HID raw device</description>
+    <message>Authorization required to read the HID raw device interface number.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.HIDRawDevice.Manufacturer">
+    <description>Read the manufacturer of the HID raw device</description>
+    <message>Authorization required to read the HID raw device manufacturer.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.HIDRawDevice.Product">
+    <description>Read the product string of the HID raw device</description>
+    <message>Authorization required to read the HID raw device product string.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.HIDRawDevice.SerialNumber">
+    <description>Read the serial number of the HID raw device</description>
+    <message>Authorization required to read the HID raw device serial number.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.HIDRawDevice.SysfsPath">
+    <description>Read the sysfs path of the HID raw device</description>
+    <message>Authorization required to read the HID raw device sysfs path.</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.Id">
+    <description>Get the device ID</description>
+    <message>Authentication is required to get IIO IMU device ID</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.Name">
+    <description>Get the device name</description>
+    <message>Authentication is required to get IIO IMU device name</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.AccelSampleRate">
+    <description>Read accelerometer sample rate</description>
+    <message>Authentication is required to read accelerometer sample rate</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.AccelSampleRatesAvail">
+    <description>Read available accelerometer sample rates</description>
+    <message>Authentication is required to read available accelerometer sample rates</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.AngvelSampleRate">
+    <description>Read angular velocity sample rate</description>
+    <message>Authentication is required to read angular velocity sample rate</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.AngvelSampleRatesAvail">
+    <description>Read available angular velocity sample rates</description>
+    <message>Authentication is required to read available angular velocity sample rates</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.AccelScale">
+    <description>Read accelerometer scale</description>
+    <message>Authentication is required to read accelerometer scale</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.AccelScalesAvail">
+    <description>Read available accelerometer scales</description>
+    <message>Authentication is required to read available accelerometer scales</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.AngvelScale">
+    <description>Read angular velocity scale</description>
+    <message>Authentication is required to read angular velocity scale</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.AngvelScalesAvail">
+    <description>Read available angular velocity scales</description>
+    <message>Authentication is required to read available angular velocity scales</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.SetAccelSampleRate">
+    <description>Set accelerometer sample rate</description>
+    <message>Authentication is required to set accelerometer sample rate</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.SetAngvelSampleRate">
+    <description>Set angular velocity sample rate</description>
+    <message>Authentication is required to set angular velocity sample rate</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.SetAccelScale">
+    <description>Set accelerometer scale</description>
+    <message>Authentication is required to set accelerometer scale</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.IIOIMUDevice.SetAngvelScale">
+    <description>Set angular velocity scale</description>
+    <message>Authentication is required to set angular velocity scale</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.LEDDevice.Id">
+    <description>Get the LED device ID</description>
+    <message>Authentication is required to get LED device ID</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.UdevDevice.DevicePath">
+    <description>Access device node path</description>
+    <message>Authentication required to get device node path</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.UdevDevice.IdBustype">
+    <description>Access device bus type</description>
+    <message>Authentication required to get device bus type</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.UdevDevice.IdProduct">
+    <description>Access device product ID</description>
+    <message>Authentication required to get device product ID</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.UdevDevice.IdVendor">
+    <description>Access device vendor ID</description>
+    <message>Authentication required to get device vendor ID</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.UdevDevice.IdVersion">
+    <description>Access device version</description>
+    <message>Authentication required to get device version</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.UdevDevice.Name">
+    <description>Access device name</description>
+    <message>Authentication required to get device name</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.UdevDevice.PhysPath">
+    <description>Access physical device path</description>
+    <message>Authentication required to get physical device path</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.UdevDevice.Subsystem">
+    <description>Access device subsystem</description>
+    <message>Authentication required to get device subsystem</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.UdevDevice.SysfsPath">
+    <description>Access device sysfs path</description>
+    <message>Authentication required to get device sysfs path</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.UdevDevice.UniqueId">
+    <description>Access device unique ID</description>
+    <message>Authentication required to get device unique ID</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Source.UdevDevice.Properties">
+    <description>Access device properties</description>
+    <message>Authentication required to get device properties</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Debug.InputCapabilityReport">
+    <description>Access input capability report data</description>
+    <message>Authentication required to get input capability report data</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Touchscreen.Name">
+    <description>Access the touchscreen device name</description>
+    <message>Authentication required to get the touchscreen device name</message>
+    <defaults>
+      <allow_any>yes</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>yes</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Output.ForceFeedback.Rumble">
+    <description>Allow sending force feedback rumble events</description>
+    <message>Authentication is required to send rumble events</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Output.ForceFeedback.Stop">
+    <description>Allow stopping all force feedback effects</description>
+    <message>Authentication is required to stop force feedback</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Metrics.Enabled">
+    <description>Get performance metrics enabled state</description>
+    <message>Authentication is required to query performance metrics enabled state</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+
+  <action id="org.shadowblip.Input.Metrics.SetEnabled">
+    <description>Set performance metrics enabled state</description>
+    <message>Authentication is required to change performance metrics enabled state</message>
+    <defaults>
+      <allow_any>no</allow_any>
+      <allow_inactive>no</allow_inactive>
+      <allow_active>auth_admin</allow_active>
+    </defaults>
+  </action>
+</policyconfig>

--- a/src/dbus/interface/manager.rs
+++ b/src/dbus/interface/manager.rs
@@ -109,7 +109,7 @@ impl ManagerInterface {
         Ok(supported.iter().map(|id| id.to_string()).collect())
     }
 
-    /// Create a composite device using the give composite device config. The
+    /// Create a composite device using the given composite device config. The
     /// path should be the absolute path to a composite device configuration file.
     async fn create_composite_device(&self, config_path: String) -> fdo::Result<String> {
         let device = CompositeDeviceConfig::from_yaml_file(config_path)

--- a/src/dbus/interface/source/hidraw.rs
+++ b/src/dbus/interface/source/hidraw.rs
@@ -1,7 +1,10 @@
-use zbus::fdo;
+use zbus::{fdo, message::Header};
 use zbus_macros::interface;
 
-use crate::{dbus::interface::Unregisterable, udev::device::UdevDevice};
+use crate::{
+    dbus::{interface::Unregisterable, polkit::check_polkit},
+    udev::device::UdevDevice,
+};
 
 /// DBusInterface exposing information about a HIDRaw device
 pub struct SourceHIDRawInterface {
@@ -17,47 +20,60 @@ impl SourceHIDRawInterface {
 #[interface(name = "org.shadowblip.Input.Source.HIDRawDevice")]
 impl SourceHIDRawInterface {
     #[zbus(property)]
-    async fn name(&self) -> fdo::Result<String> {
+    async fn name(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.HIDRawDevice.Name").await?;
         Ok(self.device.name())
     }
 
     #[zbus(property)]
-    async fn dev_path(&self) -> fdo::Result<String> {
+    async fn dev_path(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.HIDRawDevice.DevPath").await?;
         Ok(self.device.devnode())
     }
 
     #[zbus(property)]
-    async fn id_product(&self) -> fdo::Result<String> {
+    async fn id_product(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.HIDRawDevice.IdProduct").await?;
         Ok(format!("{:04x}", self.device.id_product()))
     }
 
     #[zbus(property)]
-    async fn id_vendor(&self) -> fdo::Result<String> {
+    async fn id_vendor(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.HIDRawDevice.IdVendor").await?;
         Ok(format!("{:04x}", self.device.id_vendor()))
     }
 
     #[zbus(property)]
-    async fn interface_number(&self) -> fdo::Result<i32> {
+    async fn interface_number(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<i32> {
+        check_polkit(
+            hdr,
+            "org.shadowblip.Input.Source.HIDRawDevice.InterfaceNumber",
+        )
+        .await?;
         Ok(self.device.interface_number())
     }
 
     #[zbus(property)]
-    async fn manufacturer(&self) -> fdo::Result<String> {
+    async fn manufacturer(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.HIDRawDevice.Manufacturer").await?;
         Ok(self.device.manufacturer())
     }
 
     #[zbus(property)]
-    async fn product(&self) -> fdo::Result<String> {
+    async fn product(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.HIDRawDevice.Product").await?;
         Ok(self.device.product())
     }
 
     #[zbus(property)]
-    async fn serial_number(&self) -> fdo::Result<String> {
+    async fn serial_number(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.HIDRawDevice.SerialNumber").await?;
         Ok(self.device.serial_number())
     }
 
     #[zbus(property)]
-    async fn sysfs_path(&self) -> fdo::Result<String> {
+    async fn sysfs_path(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.HIDRawDevice.SysfsPath").await?;
         Ok(self.device.devpath())
     }
 }

--- a/src/dbus/interface/source/iio_imu.rs
+++ b/src/dbus/interface/source/iio_imu.rs
@@ -1,8 +1,8 @@
 use crate::{
-    dbus::interface::Unregisterable,
+    dbus::{interface::Unregisterable, polkit::check_polkit},
     udev::device::{AttributeGetter, AttributeSetter, UdevDevice},
 };
-use zbus::fdo;
+use zbus::{fdo, message::Header};
 use zbus_macros::interface;
 
 /// DBusInterface exposing information about a HIDRaw device
@@ -20,18 +20,25 @@ impl SourceIioImuInterface {
 impl SourceIioImuInterface {
     /// Returns the human readable name of the device (e.g. XBox 360 Pad)
     #[zbus(property)]
-    fn id(&self) -> fdo::Result<String> {
+    async fn id(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.IIOIMUDevice.Id").await?;
         Ok(self.device.sysname())
     }
 
     /// Returns the human readable name of the device (e.g. XBox 360 Pad)
     #[zbus(property)]
-    fn name(&self) -> fdo::Result<String> {
+    async fn name(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.IIOIMUDevice.Name").await?;
         Ok(self.device.name())
     }
 
     #[zbus(property)]
-    async fn accel_sample_rate(&self) -> fdo::Result<f64> {
+    async fn accel_sample_rate(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<f64> {
+        check_polkit(
+            hdr,
+            "org.shadowblip.Input.Source.IIOIMUDevice.AccelSampleRate",
+        )
+        .await?;
         let Ok(dev) = self.device.get_device() else {
             return Ok(0.0);
         };
@@ -42,7 +49,15 @@ impl SourceIioImuInterface {
     }
 
     #[zbus(property)]
-    async fn accel_sample_rates_avail(&self) -> fdo::Result<Vec<f64>> {
+    async fn accel_sample_rates_avail(
+        &self,
+        #[zbus(header)] hdr: Option<Header<'_>>,
+    ) -> fdo::Result<Vec<f64>> {
+        check_polkit(
+            hdr,
+            "org.shadowblip.Input.Source.IIOIMUDevice.AccelSampleRatesAvail",
+        )
+        .await?;
         let Ok(dev) = self.device.get_device() else {
             return Ok(vec![0.0]);
         };
@@ -57,7 +72,15 @@ impl SourceIioImuInterface {
     }
 
     #[zbus(property)]
-    async fn angvel_sample_rate(&self) -> fdo::Result<f64> {
+    async fn angvel_sample_rate(
+        &self,
+        #[zbus(header)] hdr: Option<Header<'_>>,
+    ) -> fdo::Result<f64> {
+        check_polkit(
+            hdr,
+            "org.shadowblip.Input.Source.IIOIMUDevice.AngvelSampleRate",
+        )
+        .await?;
         let Ok(dev) = self.device.get_device() else {
             return Ok(0.0);
         };
@@ -68,7 +91,15 @@ impl SourceIioImuInterface {
     }
 
     #[zbus(property)]
-    async fn angvel_sample_rates_avail(&self) -> fdo::Result<Vec<f64>> {
+    async fn angvel_sample_rates_avail(
+        &self,
+        #[zbus(header)] hdr: Option<Header<'_>>,
+    ) -> fdo::Result<Vec<f64>> {
+        check_polkit(
+            hdr,
+            "org.shadowblip.Input.Source.IIOIMUDevice.AngvelSampleRatesAvail",
+        )
+        .await?;
         let Ok(dev) = self.device.get_device() else {
             return Ok(vec![0.0]);
         };
@@ -83,7 +114,16 @@ impl SourceIioImuInterface {
     }
 
     #[zbus(property)]
-    async fn set_accel_sample_rate(&self, sample_rate: f64) -> zbus::Result<()> {
+    async fn set_accel_sample_rate(
+        &self,
+        sample_rate: f64,
+        #[zbus(header)] hdr: Option<Header<'_>>,
+    ) -> zbus::Result<()> {
+        check_polkit(
+            hdr,
+            "org.shadowblip.Input.Source.IIOIMUDevice.SetAccelSampleRate",
+        )
+        .await?;
         let Ok(mut dev) = self.device.get_device() else {
             return Ok(());
         };
@@ -97,7 +137,16 @@ impl SourceIioImuInterface {
     }
 
     #[zbus(property)]
-    async fn set_angvel_sample_rate(&self, sample_rate: f64) -> zbus::Result<()> {
+    async fn set_angvel_sample_rate(
+        &self,
+        sample_rate: f64,
+        #[zbus(header)] hdr: Option<Header<'_>>,
+    ) -> zbus::Result<()> {
+        check_polkit(
+            hdr,
+            "org.shadowblip.Input.Source.IIOIMUDevice.SetAngvelSampleRate",
+        )
+        .await?;
         let Ok(mut dev) = self.device.get_device() else {
             return Ok(());
         };
@@ -111,7 +160,8 @@ impl SourceIioImuInterface {
     }
 
     #[zbus(property)]
-    async fn accel_scale(&self) -> fdo::Result<f64> {
+    async fn accel_scale(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<f64> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.IIOIMUDevice.AccelScale").await?;
         let Ok(dev) = self.device.get_device() else {
             return Ok(0.0);
         };
@@ -122,7 +172,15 @@ impl SourceIioImuInterface {
     }
 
     #[zbus(property)]
-    async fn accel_scales_avail(&self) -> fdo::Result<Vec<f64>> {
+    async fn accel_scales_avail(
+        &self,
+        #[zbus(header)] hdr: Option<Header<'_>>,
+    ) -> fdo::Result<Vec<f64>> {
+        check_polkit(
+            hdr,
+            "org.shadowblip.Input.Source.IIOIMUDevice.AccelScalesAvail",
+        )
+        .await?;
         let Ok(dev) = self.device.get_device() else {
             return Ok(vec![0.0]);
         };
@@ -137,7 +195,8 @@ impl SourceIioImuInterface {
     }
 
     #[zbus(property)]
-    async fn angvel_scale(&self) -> fdo::Result<f64> {
+    async fn angvel_scale(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<f64> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.IIOIMUDevice.AngvelScale").await?;
         let Ok(dev) = self.device.get_device() else {
             return Ok(0.0);
         };
@@ -148,7 +207,15 @@ impl SourceIioImuInterface {
     }
 
     #[zbus(property)]
-    async fn angvel_scales_avail(&self) -> fdo::Result<Vec<f64>> {
+    async fn angvel_scales_avail(
+        &self,
+        #[zbus(header)] hdr: Option<Header<'_>>,
+    ) -> fdo::Result<Vec<f64>> {
+        check_polkit(
+            hdr,
+            "org.shadowblip.Input.Source.IIOIMUDevice.AngvelScalesAvail",
+        )
+        .await?;
         let Ok(dev) = self.device.get_device() else {
             return Ok(vec![0.0]);
         };
@@ -163,7 +230,16 @@ impl SourceIioImuInterface {
     }
 
     #[zbus(property)]
-    async fn set_accel_scale(&self, scale: f64) -> zbus::Result<()> {
+    async fn set_accel_scale(
+        &self,
+        scale: f64,
+        #[zbus(header)] hdr: Option<Header<'_>>,
+    ) -> zbus::Result<()> {
+        check_polkit(
+            hdr,
+            "org.shadowblip.Input.Source.IIOIMUDevice.SetAccelScale",
+        )
+        .await?;
         let Ok(mut dev) = self.device.get_device() else {
             return Ok(());
         };
@@ -174,7 +250,16 @@ impl SourceIioImuInterface {
     }
 
     #[zbus(property)]
-    async fn set_angvel_scale(&self, scale: f64) -> zbus::Result<()> {
+    async fn set_angvel_scale(
+        &self,
+        scale: f64,
+        #[zbus(header)] hdr: Option<Header<'_>>,
+    ) -> zbus::Result<()> {
+        check_polkit(
+            hdr,
+            "org.shadowblip.Input.Source.IIOIMUDevice.SetAngvelScale",
+        )
+        .await?;
         let Ok(mut dev) = self.device.get_device() else {
             return Ok(());
         };

--- a/src/dbus/interface/source/led.rs
+++ b/src/dbus/interface/source/led.rs
@@ -1,6 +1,6 @@
-use crate::dbus::interface::Unregisterable;
+use crate::dbus::{interface::Unregisterable, polkit::check_polkit};
 use crate::udev::device::UdevDevice;
-use zbus::fdo;
+use zbus::{fdo, message::Header};
 use zbus_macros::interface;
 
 /// DBusInterface exposing information about a led device
@@ -18,7 +18,8 @@ impl SourceLedInterface {
 impl SourceLedInterface {
     /// Returns the human readable name of the device (e.g. XBox 360 Pad)
     #[zbus(property)]
-    fn id(&self) -> fdo::Result<String> {
+    async fn id(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.LEDDevice.Id").await?;
         Ok(self.device.sysname())
     }
 }

--- a/src/dbus/interface/source/udev.rs
+++ b/src/dbus/interface/source/udev.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 
-use zbus::fdo;
+use zbus::{fdo, message::Header};
 use zbus_macros::interface;
 
-use crate::{dbus::interface::Unregisterable, udev::device::UdevDevice};
+use crate::{
+    dbus::{interface::Unregisterable, polkit::check_polkit},
+    udev::device::UdevDevice,
+};
 
 /// The [SourceUdevDeviceInterface] provides a DBus interface to expose udev
 /// information over dbus
@@ -24,67 +27,81 @@ impl SourceUdevDeviceInterface {
 impl SourceUdevDeviceInterface {
     /// Returns the full device node path to the device (e.g. /dev/input/event3)
     #[zbus(property)]
-    pub fn device_path(&self) -> fdo::Result<String> {
+    async fn device_path(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.UdevDevice.DevicePath").await?;
         Ok(self.device.devnode())
     }
 
     /// Returns the bus type of the device
     #[zbus(property)]
-    async fn id_bustype(&self) -> fdo::Result<String> {
+    async fn id_bustype(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.UdevDevice.IdBustype").await?;
         Ok(format!("{}", self.device.id_bustype()))
     }
 
     /// Returns the product id of the device
     #[zbus(property)]
-    async fn id_product(&self) -> fdo::Result<String> {
+    async fn id_product(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.UdevDevice.IdProduct").await?;
         Ok(format!("{:04x}", self.device.id_product()))
     }
 
     /// Returns the vendor id of the device
     #[zbus(property)]
-    async fn id_vendor(&self) -> fdo::Result<String> {
+    async fn id_vendor(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.UdevDevice.IdVendor").await?;
         Ok(format!("{:04x}", self.device.id_vendor()))
     }
 
     /// Returns the version id of the device
     #[zbus(property)]
-    async fn id_version(&self) -> fdo::Result<String> {
+    async fn id_version(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.UdevDevice.IdVersion").await?;
         Ok(format!("{}", self.device.id_version()))
     }
 
     /// Returns the human readable name of the device (e.g. XBox 360 Pad)
     #[zbus(property)]
-    async fn name(&self) -> fdo::Result<String> {
+    async fn name(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.UdevDevice.Name").await?;
         Ok(self.device.name())
     }
 
     /// Returns the phys_path of the device (e.g usb-0000:07:00.3-2/input0)
     #[zbus(property)]
-    async fn phys_path(&self) -> fdo::Result<String> {
+    async fn phys_path(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.UdevDevice.PhysPath").await?;
         Ok(self.device.phys())
     }
 
     /// Returns the subsystem that the device belongs to. E.g. "input", "hidraw"
     #[zbus(property)]
-    pub fn subsystem(&self) -> fdo::Result<String> {
+    async fn subsystem(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.UdevDevice.Subsystem").await?;
         Ok(self.device.subsystem())
     }
 
     /// Returns the full sysfs path of the device (e.g. /sys/devices/pci0000:00)
     #[zbus(property)]
-    async fn sysfs_path(&self) -> fdo::Result<String> {
+    async fn sysfs_path(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.UdevDevice.SysfsPath").await?;
         Ok(self.device.devpath())
     }
 
     /// Returns the uniq of the device
     #[zbus(property)]
-    async fn unique_id(&self) -> fdo::Result<String> {
+    async fn unique_id(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.UdevDevice.UniqueId").await?;
         Ok(self.device.uniq())
     }
 
     /// Returns the udev device properties of the device
     #[zbus(property)]
-    async fn properties(&self) -> fdo::Result<HashMap<String, String>> {
+    async fn properties(
+        &self,
+        #[zbus(header)] hdr: Option<Header<'_>>,
+    ) -> fdo::Result<HashMap<String, String>> {
+        check_polkit(hdr, "org.shadowblip.Input.Source.UdevDevice.Properties").await?;
         Ok(self.device.get_properties())
     }
 }

--- a/src/dbus/interface/target/dbus.rs
+++ b/src/dbus/interface/target/dbus.rs
@@ -1,7 +1,8 @@
-use zbus::{fdo, object_server::SignalEmitter};
+use zbus::{fdo, message::Header, object_server::SignalEmitter};
 use zbus_macros::interface;
 
 use crate::dbus::interface::Unregisterable;
+use crate::dbus::polkit::check_polkit;
 
 /// The [TargetDBusInterface] provides a DBus interface that can be exposed for managing
 /// a [DBusDevice]. It works by sending command messages to a channel that the
@@ -24,7 +25,8 @@ impl Default for TargetDBusInterface {
 impl TargetDBusInterface {
     /// Name of the DBus device
     #[zbus(property)]
-    async fn name(&self) -> fdo::Result<String> {
+    async fn name(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.DBusDevice.Name").await?;
         Ok("DBusDevice".into())
     }
 

--- a/src/dbus/interface/target/debug.rs
+++ b/src/dbus/interface/target/debug.rs
@@ -1,8 +1,8 @@
-use zbus::{fdo, object_server::SignalEmitter};
+use zbus::{fdo, message::Header, object_server::SignalEmitter};
 use zbus_macros::interface;
 
 use crate::{
-    dbus::interface::Unregisterable,
+    dbus::{interface::Unregisterable, polkit::check_polkit},
     drivers::unified_gamepad::reports::input_capability_report::InputCapabilityReport,
 };
 
@@ -35,7 +35,11 @@ impl TargetDebugInterface {
     /// Returns the input capability report data that can be used to decode
     /// the values from the input report.
     #[zbus(property)]
-    pub async fn input_capability_report(&self) -> fdo::Result<Vec<u8>> {
+    pub async fn input_capability_report(
+        &self,
+        #[zbus(header)] hdr: Option<Header<'_>>,
+    ) -> fdo::Result<Vec<u8>> {
+        check_polkit(hdr, "org.shadowblip.Input.Debug.InputCapabilityReport").await?;
         let data = self
             .capability_report
             .pack_to_vec()

--- a/src/dbus/interface/target/gamepad.rs
+++ b/src/dbus/interface/target/gamepad.rs
@@ -1,7 +1,8 @@
-use zbus::fdo;
+use zbus::{fdo, message::Header};
 use zbus_macros::interface;
 
 use crate::dbus::interface::Unregisterable;
+use crate::dbus::polkit::check_polkit;
 
 /// The [TargetGamepadInterface] provides a DBus interface that can be exposed for managing
 /// a [GenericGamepad].
@@ -25,7 +26,8 @@ impl Default for TargetGamepadInterface {
 impl TargetGamepadInterface {
     /// Name of the DBus device
     #[zbus(property)]
-    async fn name(&self) -> fdo::Result<String> {
+    async fn name(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Gamepad.Name").await?;
         Ok(self.dev_name.clone())
     }
 }

--- a/src/dbus/interface/target/mouse.rs
+++ b/src/dbus/interface/target/mouse.rs
@@ -32,7 +32,7 @@ impl TargetMouseInterface {
     }
 
     /// Move the virtual mouse by the given amount relative to the cursor's
-    /// relative position.
+    /// current position.
     async fn move_cursor(&self, x: i32, y: i32) -> fdo::Result<()> {
         // Create a mouse motion event
         let value = InputValue::Vector2 {

--- a/src/dbus/interface/target/touchscreen.rs
+++ b/src/dbus/interface/target/touchscreen.rs
@@ -1,4 +1,5 @@
-use zbus::fdo;
+use crate::dbus::polkit::check_polkit;
+use zbus::{fdo, message::Header};
 use zbus_macros::interface;
 
 /// The [TargetTouchscreenInterface] provides a DBus interface that can be exposed for managing
@@ -22,7 +23,8 @@ impl Default for TargetTouchscreenInterface {
 impl TargetTouchscreenInterface {
     /// Name of the target device
     #[zbus(property)]
-    async fn name(&self) -> fdo::Result<String> {
+    async fn name(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.Touchscreen.Name").await?;
         Ok("Touchscreen".into())
     }
 }

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -1,1 +1,2 @@
 pub mod interface;
+pub mod polkit;

--- a/src/dbus/polkit.rs
+++ b/src/dbus/polkit.rs
@@ -1,11 +1,9 @@
-use std::collections::HashMap;
-use zbus::zvariant::{OwnedValue, Value};
-use zbus::{fdo, message::Header, Connection, Proxy};
+use zbus::{fdo, message::Header, Connection};
 
 pub async fn check_polkit(hdr: Option<Header<'_>>, action_id: &str) -> fdo::Result<()> {
     let connection = Connection::system()
         .await
-        .map_err(|e| fdo::Error::Failed(format!("Failed to acquire dbus connection: {}", e)))?;
+        .map_err(|e| fdo::Error::Failed(format!("Failed to acquire dbus connection: {e}")))?;
     check_polkit_with_connection(hdr, action_id, connection).await
 }
 
@@ -92,9 +90,9 @@ pub async fn check_polkit_with_connection(
 
 #[cfg(not(feature = "polkit"))]
 pub async fn check_polkit_with_connection(
-    hdr: Option<Header<'_>>,
-    action_id: &str,
-    connection: Connection,
+    _hdr: Option<Header<'_>>,
+    _action_id: &str,
+    _connection: Connection,
 ) -> fdo::Result<()> {
     Ok(())
 }

--- a/src/dbus/polkit.rs
+++ b/src/dbus/polkit.rs
@@ -9,6 +9,7 @@ pub async fn check_polkit(hdr: Option<Header<'_>>, action_id: &str) -> fdo::Resu
     check_polkit_with_connection(hdr, action_id, connection).await
 }
 
+#[cfg(feature = "polkit")]
 pub async fn check_polkit_with_connection(
     hdr: Option<Header<'_>>,
     action_id: &str,
@@ -87,4 +88,13 @@ pub async fn check_polkit_with_connection(
             action_id
         )))
     }
+}
+
+#[cfg(not(feature = "polkit"))]
+pub async fn check_polkit_with_connection(
+    hdr: Option<Header<'_>>,
+    action_id: &str,
+    connection: Connection,
+) -> fdo::Result<()> {
+    Ok(())
 }

--- a/src/dbus/polkit.rs
+++ b/src/dbus/polkit.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+use zbus::zvariant::{OwnedValue, Value};
+use zbus::{fdo, message::Header, Connection, Proxy};
+
+pub async fn check_polkit(hdr: Option<Header<'_>>, action_id: &str) -> fdo::Result<()> {
+    let connection = Connection::system()
+        .await
+        .map_err(|e| fdo::Error::Failed(format!("Failed to acquire dbus connection: {}", e)))?;
+    check_polkit_with_connection(hdr, action_id, connection).await
+}
+
+pub async fn check_polkit_with_connection(
+    hdr: Option<Header<'_>>,
+    action_id: &str,
+    connection: Connection,
+) -> fdo::Result<()> {
+    let hdr = hdr.ok_or_else(|| {
+        fdo::Error::InteractiveAuthorizationRequired(format!(
+            "Authentication required for {}",
+            action_id
+        ))
+    })?;
+
+    let sender = hdr
+        .sender()
+        .ok_or_else(|| fdo::Error::Failed("Missing sender".into()))?;
+
+    let pid: u32 = connection
+        .call_method(
+            Some("org.freedesktop.DBus"),
+            "/org/freedesktop/DBus",
+            Some("org.freedesktop.DBus"),
+            "GetConnectionUnixProcessID",
+            &(sender.as_str()),
+        )
+        .await
+        .map_err(|e| fdo::Error::Failed(format!("Failed to get process ID: {}", e)))?
+        .body()
+        .deserialize()?;
+
+    let mut subj_details: HashMap<String, OwnedValue> = HashMap::new();
+    subj_details.insert(
+        "pid".into(),
+        OwnedValue::try_from(Value::U32(pid))
+            .map_err(|e| fdo::Error::Failed(format!("Failed to get OwnedValue for pid: {}", e)))?,
+    );
+    subj_details.insert(
+        "start-time".into(),
+        OwnedValue::try_from(Value::U64(0)).map_err(|e| {
+            fdo::Error::Failed(format!("Failed to get OwnedValue for start: {}", e))
+        })?,
+    );
+    let subject = ("unix-process".to_string(), subj_details);
+
+    let proxy = Proxy::new(
+        &connection,
+        "org.freedesktop.PolicyKit1",
+        "/org/freedesktop/PolicyKit1/Authority",
+        "org.freedesktop.PolicyKit1.Authority",
+    )
+    .await
+    .map_err(|e| fdo::Error::Failed(e.to_string()))?;
+
+    let call_details: HashMap<String, String> = HashMap::new();
+    let flags: u32 = 0x0000_0001;
+    let cancellation_id = "";
+
+    let (is_authorized, is_challenge, _details): (bool, bool, HashMap<String, String>) = proxy
+        .call_method(
+            "CheckAuthorization",
+            &(subject, action_id, &call_details, flags, cancellation_id),
+        )
+        .await
+        .map_err(|e| fdo::Error::Failed(e.to_string()))?
+        .body()
+        .deserialize()?;
+    if is_authorized {
+        Ok(())
+    } else if is_challenge {
+        Err(fdo::Error::InteractiveAuthorizationRequired(format!(
+            "Authentication required for {}",
+            action_id
+        )))
+    } else {
+        Err(fdo::Error::Failed(format!(
+            "Not authorized for {}",
+            action_id
+        )))
+    }
+}


### PR DESCRIPTION
Addresses the use case described in https://github.com/ShadowBlip/InputPlumber/issues/202 (even if inputplumber itself still has to be run as root for the most part)

Stuff TODO:

- [x] Add missing `dbus-xml` files/entries
  - [x] `org.shadowblip.Input.Source.IIOIMUDevice`
  - [x] `org.shadowblip.Input.Source.LEDDevice`
  - [x] `org.shadowblip.Input.Source.UdevDevice`
  - [x] `org.shadowblip.Input.Debug`
  - [x] `org.shadowblip.Input.Touchscreen`
  - [x] `org.shadowblip.Output.ForceFeedback`
  - [x] `org.shadowblip.Input.Metrics`
  - [x] The ones I did before opening this PR
- [x] Add missing actions to the polkit actions file
  - [x] `org.shadowblip.Input.Source.IIOIMUDevice`
  - [x] `org.shadowblip.Input.Source.LEDDevice`
  - [x] `org.shadowblip.Input.Source.UdevDevice`
  - [x] `org.shadowblip.Input.Debug`
  - [x] `org.shadowblip.Input.Touchscreen`
  - [x] `org.shadowblip.Output.ForceFeedback`
  - [x] `org.shadowblip.Input.Metrics`
  - [x] The ones I did before opening this PR
- [x] Add missing polkit checks
  - [x] `org.shadowblip.Input.Source.IIOIMUDevice`
  - [x] `org.shadowblip.Input.Source.LEDDevice`
  - [x] `org.shadowblip.Input.Source.UdevDevice`
  - [x] `org.shadowblip.Input.Debug`
  - [x] `org.shadowblip.Input.Touchscreen`
  - [x] `org.shadowblip.Output.ForceFeedback`
  - [x] `org.shadowblip.Input.Metrics`
  - [x] `org.shadowblip.Input.Source.EventDevice`
  - [x] `org.shadowblip.Input.Source.HIDRawDevice`
  - [x] `org.shadowblip.Input.Mouse`
  - [x] `org.shadowblip.Input.Manager`
  - [x] `org.shadowblip.Input.Keyboard`
  - [x] `org.shadowblip.Input.Gamepad`
  - [x] `org.shadowblip.Input.DBusDevice`
  - [x] `org.shadowblip.Input.CompositeDevice`
- [x] Fix commit messages