### PR TITLE
fix(Tester): set dbus path to allow debug interface to emit events

### DIFF
--- a/src/input/target/debug.rs
+++ b/src/input/target/debug.rs
@@ -180,6 +180,7 @@ impl TargetInputDevice for DebugDevice {
     ) {
         let iface = TargetDebugInterface::new();
         dbus.register(iface);
+        self.dbus_path = Some(dbus.path().to_string());
     }
 
     fn on_composite_device_attached(


### PR DESCRIPTION
This change fixes the CLI input tester which was broken in v0.60.4.

Fixes #409 