### PR TITLE
fix(LED): use valid dbus path for LED devices

### DIFF
--- a/src/input/source/led.rs
+++ b/src/input/source/led.rs
@@ -99,6 +99,6 @@ impl LedDevice {
 }
 /// Returns the DBus path for an [LedDevice] from a device id (E.g. leds://input7__numlock)
 pub fn get_dbus_path(id: String) -> String {
-    let name = id.replace(':', "_");
+    let name = id.replace(':', "_").replace("-", "_");
     format!("{}/{}", BUS_SOURCES_PREFIX, name)
 }


### PR DESCRIPTION
In some cases, there are LED devices with a `-` in the name, which is not a valid character for a DBus path. This small change accounts for this.