### PR TITLE
feat(DBus): add support for custom arbitrary dbus events

### DIFF
--- a/rootfs/usr/share/inputplumber/schema/device_profile_v1.json
+++ b/rootfs/usr/share/inputplumber/schema/device_profile_v1.json
@@ -266,7 +266,7 @@
         },
         "dbus": {
           "type": "string",
-          "enum": [
+          "examples": [
             "ui_guide",
             "ui_quick",
             "ui_context",

--- a/src/input/event/dbus.rs
+++ b/src/input/event/dbus.rs
@@ -35,6 +35,7 @@ pub enum Action {
     Keyboard,
     Screenshot,
     Touch,
+    Custom(String),
 }
 
 impl Action {
@@ -66,10 +67,14 @@ impl Action {
             Action::Keyboard => "ui_osk",
             Action::Screenshot => "ui_screenshot",
             Action::Touch => "ui_touch",
+            Action::Custom(_str) => "custom",
         }
     }
 
     pub fn as_string(&self) -> String {
+        if let Action::Custom(str) = self {
+            return str.clone();
+        }
         self.as_str().to_string()
     }
 }
@@ -105,7 +110,7 @@ impl FromStr for Action {
             "ui_osk" => Ok(Action::Keyboard),
             "ui_screenshot" => Ok(Action::Screenshot),
             "ui_touch" => Ok(Action::Touch),
-            _ => Err(()),
+            _ => Ok(Action::Custom(s.to_string())),
         }
     }
 }


### PR DESCRIPTION
This change updates dbus events to include a new `Action::Custom` variant which can be used to send dbus events with arbitrary names instead of statically defined list (e.g. `ui_left`, `ui_quick`, etc.). This can mainly be used as part of an input profile to translate inputs into arbitrary dbus events.