### PR TITLE
fix: Clear the input state (e.g. send release events, center axes, etc.) on target devices on source disconnect

### DIFF
--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -1525,6 +1525,10 @@ impl CompositeDevice {
         // Signal to DBus that source devices have changed
         self.signal_sources_changed().await;
 
+        // Clear the state of target devices in case the source device was
+        // disconnected in the middle of an input.
+        self.targets.schedule_clear_state();
+
         log::debug!(
             "Current source device paths: {:?}",
             self.source_device_paths


### PR DESCRIPTION
Related to @pastaq 's comments on #423, this change will clear the input state (e.g. send button release events, center joystick axes, etc.) on all target devices whenever a source device is disconnected from a composite device.