### PR TITLE
fix(Ally X): add limited functionality if asus_ally_hid driver is not available

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml
@@ -1,0 +1,116 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+# Schema version number
+version: 2
+
+# The type of configuration schema
+kind: CapabilityMap
+
+# Name for the device event map
+name: Ally Type 2
+
+# Unique identifier of the capability mapping
+id: aly2
+
+# List of mapped events that are activated by a specific set of activation keys.
+mapping:
+  - name: Start
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_TR
+          value_type: button
+    target_event:
+      gamepad:
+        button: Start
+
+  - name: Select
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_TL
+          value_type: button
+    target_event:
+      gamepad:
+        button: Select
+
+  - name: X button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_C
+          value_type: button
+    target_event:
+      gamepad:
+        button: North
+
+  - name: Y button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_NORTH
+          value_type: button
+    target_event:
+      gamepad:
+        button: West
+
+  - name: LB button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_WEST
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftBumper
+
+  - name: RB button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_Z
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightBumper
+
+  - name: Left Stick Click
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_TL2
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftStick
+
+  - name: Right Stick Click
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_TR2
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightStick
+
+  - name: Left Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_Z
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: LeftTrigger
+
+  - name: Right Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_RZ
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: RightTrigger

--- a/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-rog_ally_x.yaml
@@ -38,6 +38,19 @@ source_devices:
       vendor_id: 0b05
       product_id: 1b4c
       handler: event*
+  - group: gamepad # Gamepad in dinput mode without `asus_ally_hid` driver
+    udev:
+      attributes:
+        - name: name
+          value: "Asus Keyboard"
+        - name: "id/product"
+          value: "1b4c"
+      properties:
+        - name: ID_INPUT_JOYSTICK
+          value: "1"
+      subsystem: input
+      sys_name: event*
+    capability_map_id: aly2
   - group: keyboard
     unique: false
     evdev:
@@ -70,8 +83,6 @@ source_devices:
         x: [1, 0, 0]
         y: [0, -1, 0]
         z: [0, 0, -1]
-
-  #RGB
   - group: led
     udev:
       sys_name: ally:rgb:joystick_rings


### PR DESCRIPTION
This change adds limited support for the Ally X controller if Luke Jone's `asus_ally_hid` driver is not present. 