### PR TITLE
add valve product id for rog ally/x

### DIFF
--- a/src/input/target/steam_deck.rs
+++ b/src/input/target/steam_deck.rs
@@ -55,7 +55,7 @@ pub enum ProductId {
     SteamDeck = 0x1205,
     Generic = 0x12f0,
     ZotacZone = 0x12fc,
-    AsusRogAlly,
+    AsusRogAlly = 0x12fd,
     LenovoLegionGo,
     LenovoLegionGoS,
 }

--- a/src/input/target/steam_deck.rs
+++ b/src/input/target/steam_deck.rs
@@ -56,8 +56,8 @@ pub enum ProductId {
     Generic = 0x12f0,
     ZotacZone = 0x12fc,
     AsusRogAlly = 0x12fd,
-    LenovoLegionGo,
-    LenovoLegionGoS,
+    LenovoLegionGo = 0x12fe,
+    LenovoLegionGoS = 0x12ff,
 }
 
 impl ProductId {


### PR DESCRIPTION
pulled from dmesg

```
[ 2092.962805] usb 9-1: new high-speed USB device number 3 using vhci_hcd
[ 2093.075798] usb 9-1: SetAddress Request (3) to port 0
[ 2093.108661] usb 9-1: New USB device found, idVendor=28de, idProduct=12fd, bcdDevice= 3.00
[ 2093.108671] usb 9-1: New USB device strings: Mfr=1, Product=2, SerialNumber=0
[ 2093.108677] usb 9-1: Product: ROG Ally X Controller
[ 2093.108682] usb 9-1: Manufacturer: ASUS

[ 2093.121077] input: ASUS ROG Ally X Controller as /devices/platform/vhci_hcd.0/usb9/9-1/9-1:1.0/0003:28DE:12FD.000C/input/input33
[ 2093.129491] input: ASUS ROG Ally X Controller as /devices/platform/vhci_hcd.0/usb9/9-1/9-1:1.1/0003:28DE:12FD.000D/input/input34

[ 2093.121241] hid-generic 0003:28DE:12FD.000C: input,hidraw7: USB HID v1.10 Mouse [ASUS ROG Ally X Controller] on usb-vhci_hcd.0-1/input0
[ 2093.179869] hid-generic 0003:28DE:12FD.000D: input,hidraw8: USB HID v1.10 Keyboard [ASUS ROG Ally X Controller] on usb-vhci_hcd.0-1/input1
[ 2093.190842] hid-generic 0003:28DE:12FD.000E: hidraw9: USB HID v10.00 Device [ROG Ally X Controller] on 
```