### PR TITLE
chore(docs): update force feedback binding with enable property

### DIFF
--- a/bindings/dbus-xml/org.shadowblip.Output.ForceFeedback.xml
+++ b/bindings/dbus-xml/org.shadowblip.Output.ForceFeedback.xml
@@ -40,13 +40,16 @@
      Send a simple rumble event
      -->
     <method name="Rumble">
-      <arg name="value" type="i" direction="in"/>
+      <arg name="value" type="d" direction="in"/>
     </method>
-
     <!--
      Stop all currently playing force feedback effects
      -->
     <method name="Stop">
     </method>
+    <!--
+     Whether or not the device should send force feedback events
+     -->
+    <property name="Enabled" type="b" access="readwrite"/>
   </interface>
 </node>


### PR DESCRIPTION
This change updates the XML docs for the force feedback interface since it was forgotten in the last PR.