### PR TITLE
feat(Composite Device): expose serial for a persistent identifier

### DIFF
--- a/bindings/dbus-xml/org.shadowblip.Input.CompositeDevice.xml
+++ b/bindings/dbus-xml/org.shadowblip.Input.CompositeDevice.xml
@@ -41,6 +41,10 @@
      -->
     <property name="Name" type="s" access="read"/>
     <!--
+     Persistent identifier for the device
+     -->
+    <property name="Serial" type="s" access="read"/>
+    <!--
      Name of the currently loaded profile
      -->
     <property name="ProfileName" type="s" access="read"/>

--- a/src/dbus/interface/composite_device.rs
+++ b/src/dbus/interface/composite_device.rs
@@ -58,6 +58,16 @@ impl CompositeDeviceInterface {
             .map_err(|e| fdo::Error::Failed(e.to_string()))
     }
 
+    /// Unique identifier of the device based on source device(s)
+    #[zbus(property)]
+    async fn serial(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {
+        check_polkit(hdr, "org.shadowblip.Input.CompositeDevice.Serial").await?;
+        self.composite_device
+            .get_serial()
+            .await
+            .map_err(|e| fdo::Error::Failed(e.to_string()))
+    }
+
     /// Name of the currently loaded profile
     #[zbus(property)]
     async fn profile_name(&self, #[zbus(header)] hdr: Option<Header<'_>>) -> fdo::Result<String> {

--- a/src/input/composite_device/client.rs
+++ b/src/input/composite_device/client.rs
@@ -231,6 +231,16 @@ impl CompositeDeviceClient {
         Err(ClientError::ChannelClosed)
     }
 
+    /// Get the serial for the composite device
+    pub async fn get_serial(&self) -> Result<String, ClientError> {
+        let (tx, rx) = channel(1);
+        self.tx.send(CompositeCommand::GetSerial(tx)).await?;
+        if let Some(serial) = Self::recv(rx).await {
+            return Ok(serial);
+        }
+        Err(ClientError::ChannelClosed)
+    }
+
     /// Get the source device paths of the composite device
     pub async fn get_source_device_paths(&self) -> Result<Vec<String>, ClientError> {
         let (tx, rx) = channel(1);

--- a/src/input/composite_device/command.rs
+++ b/src/input/composite_device/command.rs
@@ -30,6 +30,7 @@ pub enum CompositeCommand {
     GetName(mpsc::Sender<String>),
     #[allow(dead_code)]
     GetProfileName(mpsc::Sender<String>),
+    GetSerial(mpsc::Sender<String>),
     GetSourceDevicePaths(mpsc::Sender<Vec<String>>),
     GetTargetCapabilities(mpsc::Sender<HashSet<Capability>>),
     GetTargetDevicePaths(mpsc::Sender<Vec<String>>),

--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -130,6 +130,9 @@ pub struct CompositeDevice {
     source_device_paths: Vec<String>,
     /// All currently running source device threads
     source_device_tasks: JoinSet<()>,
+    /// List of unique identifiers for each source device.
+    /// E.g. {"evdev://event0": Some("abc123")}
+    source_device_serials: HashMap<String, Option<String>>,
     /// Unique identifiers for running source devices. E.g. ["evdev://event0"]
     source_devices_used: Vec<String>,
     /// State of target devices attached to the composite device
@@ -199,6 +202,7 @@ impl CompositeDevice {
             source_devices_blocked: HashSet::new(),
             source_device_paths: Vec::new(),
             source_device_tasks: JoinSet::new(),
+            source_device_serials: HashMap::new(),
             source_devices_used: Vec::new(),
             targets: CompositeDeviceTargets::new(conn, dbus_path, tx.into(), manager),
             ff_enabled: true,
@@ -538,6 +542,12 @@ impl CompositeDevice {
                         log::debug!("Checking if device is suspended: {is_suspended}");
                         if let Err(e) = sender.send(is_suspended).await {
                             log::error!("Failed to send suspended response: {e:?}");
+                        }
+                    }
+                    CompositeCommand::GetSerial(sender) => {
+                        let serial = self.get_serial().await.unwrap_or_default();
+                        if let Err(e) = sender.send(serial).await {
+                            log::error!("Failed to send serial response: {e}");
                         }
                     }
                 }
@@ -1607,6 +1617,7 @@ impl CompositeDevice {
             self.source_devices_used.remove(idx);
         };
         self.source_devices_blocked.remove(&id);
+        self.source_device_serials.remove(&id);
 
         // Signal to DBus that source devices have changed
         self.signal_sources_changed().await;
@@ -1697,6 +1708,7 @@ impl CompositeDevice {
 
         // Get the capabilities of the source device.
         let id = source_device.get_id();
+        let serial = source_device.get_serial();
         if !is_blocked {
             // Get the input capabilities of the source device and keep track
             // of them.
@@ -1753,7 +1765,8 @@ impl CompositeDevice {
         let device_path = source_device.get_device_path();
         self.source_devices_discovered.push(source_device);
         self.source_device_paths.push(device_path);
-        self.source_devices_used.push(id);
+        self.source_devices_used.push(id.clone());
+        self.source_device_serials.insert(id, serial);
 
         Ok(())
     }
@@ -2062,5 +2075,20 @@ impl CompositeDevice {
                 log::error!("Failed to send source devices changed signal: {e:?}");
             }
         });
+    }
+
+    /// Returns a serial number that can be used to uniquely identify the device
+    async fn get_serial(&self) -> Option<String> {
+        // Find a source device with a valid persistent identifier
+        let mut keys: Vec<&String> = self.source_device_serials.keys().collect();
+        keys.sort();
+        for key in keys {
+            let Some(serial) = self.source_device_serials.get(key) else {
+                continue;
+            };
+            return serial.clone();
+        }
+
+        None
     }
 }

--- a/src/input/source/mod.rs
+++ b/src/input/source/mod.rs
@@ -341,7 +341,7 @@ impl<T: SourceInputDevice + SourceOutputDevice + Send + 'static> SourceDriver<T>
     }
 
     /// Returns udev device information about the device as a reference
-    pub fn info_ref(&self) -> DeviceInfoRef {
+    pub fn info_ref(&self) -> DeviceInfoRef<'_> {
         match &self.device_info {
             DeviceInfo::Udev(device) => device.into(),
         }
@@ -501,10 +501,40 @@ impl<T: SourceInputDevice + SourceOutputDevice + Send + 'static> SourceDriver<T>
 
 pub(crate) trait SourceDeviceCompatible {
     /// Returns a copy of the UdevDevice
-    fn get_device_ref(&self) -> DeviceInfoRef;
+    fn get_device_ref(&self) -> DeviceInfoRef<'_>;
 
     /// Returns a unique identifier for the source device.
     fn get_id(&self) -> String;
+
+    /// Returns a persistent identifier to uniquely identify the source device
+    fn get_serial(&self) -> Option<String> {
+        match self.get_device_ref() {
+            DeviceInfoRef::Udev(device) => {
+                const PROPERTIES_TO_CHECK: &[&str] = &[
+                    "ID_SERIAL",
+                    "ID_USB_SERIAL",
+                    "ID_SERIAL_SHORT",
+                    "ID_USB_SERIAL_SHORT",
+                ];
+
+                for property in PROPERTIES_TO_CHECK {
+                    let Some(serial) = device.get_property(property) else {
+                        continue;
+                    };
+                    return Some(serial);
+                }
+
+                for property in PROPERTIES_TO_CHECK {
+                    let Some(serial) = device.get_property_from_tree(property) else {
+                        continue;
+                    };
+                    return Some(serial);
+                }
+
+                None
+            }
+        }
+    }
 
     /// Returns a client channel that can be used to send events to this device
     fn client(&self) -> SourceDeviceClient;
@@ -533,7 +563,7 @@ pub enum SourceDevice {
 
 impl SourceDevice {
     /// Returns a copy of the DeviceInfo
-    pub fn get_device_ref(&self) -> DeviceInfoRef {
+    pub fn get_device_ref(&self) -> DeviceInfoRef<'_> {
         match self {
             SourceDevice::Event(device) => device.get_device_ref(),
             SourceDevice::HidRaw(device) => device.get_device_ref(),
@@ -549,6 +579,16 @@ impl SourceDevice {
             SourceDevice::HidRaw(device) => device.get_id(),
             SourceDevice::Iio(device) => device.get_id(),
             SourceDevice::Led(device) => device.get_id(),
+        }
+    }
+
+    /// Returns a persistent identifier to uniquely identify the source device
+    pub fn get_serial(&self) -> Option<String> {
+        match self {
+            SourceDevice::Event(device) => device.get_serial(),
+            SourceDevice::HidRaw(device) => device.get_serial(),
+            SourceDevice::Iio(_) => None,
+            SourceDevice::Led(_) => None,
         }
     }
 


### PR DESCRIPTION
This change exposes a new `Serial` property on the `CompositeDevice` dbus interface which can be used to retrieve a persistent unique identifier that can be used to identify a specific device. This field is meant to be used for things like profile traveling, where you can correctly identify a specific controller and apply some settings to it.

 This should provide a good starting point for being able to uniquely identify a specific controller, but there are some challenges we will need to think about:
 
 1. Composite devices can have multiple source devices; which serial number should we use?
 2. Source devices may change during runtime; how should we handle this exactly?
 3. Some poorly implemented hardware may have no serial number at all; should we try to use some semi-unique identifier like product id + vendor id?