### PR TITLE
fix(MSI Claw): use updated key combo in newer firmware revisions

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/msiclaw_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/msiclaw_type1.yaml
@@ -25,6 +25,14 @@ mapping:
     target_event:
       gamepad:
         button: QuickAccess
+  # Newer firmware uses Win+G
+  - name: QuickAccess
+    source_events:
+      - keyboard: KeyLeftMeta
+      - keyboard: KeyG
+    target_event:
+      gamepad:
+        button: QuickAccess
 
 # List of events to filter from the source devices
 filtered_events: []


### PR DESCRIPTION
This change updates the capability map for the MSI Claw to use the new combo used by the latest firmware.