### PR TITLE
feat(Hardware Support): Add Ayaneo 1S DS Support

### DIFF
--- a/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
+++ b/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
@@ -35,6 +35,7 @@ dmi:*svnAYANEO:pnAIRPlus:*rnAB05-Mendocino:*
 dmi:*svnAYANEO:pnAIRPro:*
 # AYANEO Flip
 dmi:*svnAYANEO:pnFLIPDS:*
+dmi:*svnAYANEO:pnFLIP1SDS:*
 dmi:*svnAYANEO:pnFLIPKB:*
 # AYANEO Kun
 dmi:*svnAYANEO:pnAYANEOKUN:*

--- a/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type8.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type8.yaml
@@ -1,0 +1,49 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CapabilityMap
+
+# Name for the device event map
+name: AYANEO Type 8
+
+# Unique identifier of the capability mapping
+id: aya8
+
+# List of mapped events that are activated by a specific set of activation keys.
+mapping:
+  - name: LC
+    source_events:
+      - keyboard: KeyF21
+    target_event:
+      gamepad:
+        button: LeftTop #LeftPaddle1
+  - name: RC
+    source_events:
+      - keyboard: KeyF22
+    target_event:
+      gamepad:
+        button: RightTop #RightPaddle1
+  - name: Aya Space
+    source_events:
+      - keyboard: KeyF23
+    target_event:
+      gamepad:
+        button: QuickAccess
+  - name: Custom Right
+    source_events:
+      - keyboard: KeyLeftMeta
+      - keyboard: KeyD
+    target_event:
+      gamepad:
+        button: RightPaddle2
+  - name: Custom Left
+    source_events:
+      - keyboard: KeyF18
+    target_event:
+      gamepad:
+        button: LeftPaddle2
+
+# List of events to filter from the source devices
+filtered_events: []

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip_1s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_flip_1s.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: AYANEO Flip 1S
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches:
+  - dmi_data:
+      product_name: FLIP 1S DS
+      sys_vendor: AYANEO
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: gamepad
+    evdev:
+      name: Microsoft X-Box 360 pad
+      phys_path: usb-0000:c7:00.0-1/input0
+      handler: event*
+  - group: gamepad
+    evdev:
+      name: AYANEO COMPOSITE DEVICE
+      phys_path: usb-0000:c7:00.0-4/input1
+      handler: event*
+  - group: keyboard
+    evdev:
+      name: AT Translated Set 2 keyboard
+      phys_path: isa0060/serio0/input0
+      handler: event*
+  - group: imu
+    iio:
+       name: bmi323-imu
+       mount_matrix:
+         x: [0, 1, 0]
+         y: [0, 0, 1]
+         z: [1, 0, 0]
+  - group: touchscreen
+    udev:
+      properties:
+        - name: ID_INPUT_TOUCHSCREEN
+          value: "1"
+      attributes:
+        - name: id/vendor
+          value: "0416"
+        - name: id/product
+          value: "1001"
+      sys_name: "event*"
+      subsystem: input
+    config:
+      touchscreen:
+        orientation: "normal"
+        override_source_size: true
+        width: 1200
+        height: 1920
+
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
+# The target input device(s) to emulate by default
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+  - touchscreen
+
+# The ID of a device event mapping in the 'event_maps' folder
+capability_map_id: aya8


### PR DESCRIPTION
Adds Ayaneo Flip 1S DS device config. Unlike most AYANEO devices, this one has a dedicated "guide" button, so we only need to map a quick access key. Map the extra face buttons on the left and right as paddles so they can be easily mapped in steaminput or OGUI. LC/RC are standard for Ayaneo.

Dual touchscreen still needs info and validation, along with gyro specifics.

Closes #434 
