### PR TITLE
fix(Xbox One): use evdev for force feedback events

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/60-xbox_one_bt_gamepad.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-xbox_one_bt_gamepad.yaml
@@ -22,7 +22,6 @@ maximum_sources: 2
 # from these devices will be watched and translated according to the key map.
 source_devices:
   - group: gamepad
-    blocked: true
     udev:
       attributes:
         - name: name
@@ -33,6 +32,10 @@ source_devices:
       driver: microsoft
       sys_name: "event*"
       subsystem: input
+    events:
+      # Block input events, but use device for output events
+      exclude:
+        - "*"
   - group: gamepad
     udev:
       # NOTE: This might also capture other non-xbox microsoft devices :(


### PR DESCRIPTION
This change enables force feedback support for Xbox One gamepads over bluetooth. Instead of re-implementing force feedback support in the InputPlumber driver, it will use the evdev device for force feedback and block all input events.