### PR TITLE
fix(Service): use 'ProtectSystem=full' in service definition

### DIFF
--- a/rootfs/usr/lib/systemd/system/inputplumber.service
+++ b/rootfs/usr/lib/systemd/system/inputplumber.service
@@ -6,6 +6,7 @@ Type=dbus
 BusName=org.shadowblip.InputPlumber
 Environment=LOG_LEVEL=info
 ExecStart=/usr/bin/inputplumber
+ProtectSystem=full
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change adds `ProtectSystem=full` to give InputPlumber a read-only view of important parts of the filesystem. InputPlumber should not have to write anything to most parts of the filesystem.