### PR TITLE
Turn off auto_manage for flydigi

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/60-flydigi_vader_4_pro.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-flydigi_vader_4_pro.yaml
@@ -49,4 +49,4 @@ target_devices:
 capability_map_id: flydigi-vader-4-pro
 
 options:
-  auto_manage: true
+  auto_manage: false


### PR DESCRIPTION
Steam has an integrated driver for the Flydigi, and the pull request for the udev rules was accepted so there's no reason to use the inputplumber driver anymore unless spoofing - turning auto_manage off will be a more consistent experience for most folk.