### PR TITLE
feat: refactor RPM to be closer to a fedora package

### DIFF
--- a/pkg/rpm/inputplumber.spec
+++ b/pkg/rpm/inputplumber.spec
@@ -32,7 +32,7 @@ InputPlumber is an open source input routing and control daemon for Linux. It ca
 make build
 
 %install
-PREFIX=%{buildroot}/usr make install
+make install PREFIX=%{buildroot}/usr NO_RELOAD=true
 
 %post
 %systemd_post inputplumber.service


### PR DESCRIPTION
This basically just cleans up the RPM package a bit, less stuff
specific to the RPM, so less maintenance IG, also it uses better macros
for things now :)

Upon checking the rootfses, I get this result:

```
[root@e957e20caa3b tmp]# diff new.txt old.txt
3d2
< ./inputplumber-0.69.1-0.fc43.x86_64.rpm.cpio
8,10d6
< ./usr/lib/.build-id
< ./usr/lib/.build-id/75
< ./usr/lib/.build-id/75/3bee4f8b84531764692d561c9041abc5a27db2
26,28d21
< ./usr/share/doc
< ./usr/share/doc/inputplumber
< ./usr/share/doc/inputplumber/README.md
```
`README.md` is now there and everything else is the exact same
