### PR TITLE
fix(Intercept Mode): don't clear gamepad states if mode does not change

### DIFF
--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -1238,7 +1238,11 @@ impl CompositeDevice {
 
     /// Sets the intercept mode to the given value
     async fn set_intercept_mode(&mut self, mode: InterceptMode) {
-        log::debug!("Setting intercept mode to: {:?}", mode);
+        log::debug!("Setting intercept mode to: {mode:?}");
+        if self.intercept_mode == mode {
+            log::debug!("Intercept is already set to: {mode:?}");
+            return;
+        }
         self.intercept_mode = mode;
 
         // Nothing else is required when turning off input interception.


### PR DESCRIPTION
This change makes setting the intercept mode a no-op if the target intercept mode is the same as the current intercept mode. This fixes an issue where the target gamepad state would be cleared in cases where a client erroneously tries to set the intercept mode when it does not have to.