### PR TITLE
fix: always call write_set_report_reply to avoid timeout and fail in response to SetReport

### DIFF
--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -1099,6 +1099,10 @@ impl TargetOutputDevice for DualSenseDevice {
                 data,
             } => {
                 log::debug!("Received SetReport event: id: {id}, num: {report_number}, type: {:?}, data: {:?}", report_type, data);
+                if let Err(e) = self.device.write_set_report_reply(id, 0) {
+                    log::warn!("Failed to write set report reply: {:?}", e);
+                    return Err(e.to_string().into());
+                }
                 Ok(vec![])
             }
         };

--- a/src/input/target/horipad_steam.rs
+++ b/src/input/target/horipad_steam.rs
@@ -433,6 +433,10 @@ impl TargetOutputDevice for HoripadSteamDevice {
                 data,
             } => {
                 log::debug!("Received SetReport event: id: {id}, num: {report_number}, type: {:?}, data: {:?}", report_type, data);
+                if let Err(e) = self.device.write_set_report_reply(id, 0) {
+                    log::warn!("Failed to write set report reply: {:?}", e);
+                    return Err(e.to_string().into());
+                }
                 Ok(vec![])
             }
         };

--- a/src/input/target/unified_gamepad.rs
+++ b/src/input/target/unified_gamepad.rs
@@ -368,6 +368,10 @@ impl TargetOutputDevice for UnifiedGamepadDevice {
                 data,
             } => {
                 log::debug!("Received SetReport event: id: {id}, num: {report_number}, type: {:?}, data: {:?}", report_type, data);
+                if let Err(e) = self.device.write_set_report_reply(id, 0) {
+                    log::warn!("Failed to write set report reply: {:?}", e);
+                    return Err(e.to_string().into());
+                }
                 Ok(vec![])
             }
         };


### PR DESCRIPTION
Fixes #459 where games stop reading from controller because IOCTL_HID_SET_FEATURE times out and fails.

(The issue with `Unable to create initialized UdevDevice` is separate and I haven't figured that one out yet.)