### PR TITLE
QOL: centralize normalize/denormalize functions in src/input/event/value.rs

### DIFF
--- a/src/input/event/value.rs
+++ b/src/input/event/value.rs
@@ -60,6 +60,73 @@ pub enum InputValue {
     },
 }
 
+/// Returns a value between -1.0 and 1.0 based on the given value with its
+/// minimum and maximum values.
+pub fn normalize_signed_value(raw_value: f64, min: f64, max: f64) -> f64 {
+    let mid = (max + min) / 2.0;
+    let event_value = raw_value - mid;
+
+    // Normalize the value
+    if event_value >= 0.0 {
+        let maximum = max - mid;
+        event_value / maximum
+    } else {
+        let minimum = min - mid;
+        let value = event_value / minimum;
+        -value
+    }
+}
+
+/// Convert the given normalized signed value to the real value based on the given
+/// minimum and maximum axis range.
+pub fn denormalize_signed_value_i16(normal_value: f64, min: f64, max: f64) -> i16 {
+    let mid = (max + min) / 2.0;
+    let normal_value_abs = normal_value.abs();
+    if normal_value >= 0.0 {
+        let maximum = max - mid;
+        let value = normal_value * maximum + mid;
+        value as i16
+    } else {
+        let minimum = min - mid;
+        let value = normal_value_abs * minimum + mid;
+        value as i16
+    }
+}
+
+/// Convert the given normalized signed value to the real value based on the given
+/// minimum and maximum axis range.
+pub fn denormalize_signed_value_u8(normal_value: f64, min: f64, max: f64) -> u8 {
+    let mid = (max + min) / 2.0;
+    let normal_value_abs = normal_value.abs();
+    if normal_value >= 0.0 {
+        let maximum = max - mid;
+        let value = normal_value * maximum + mid;
+        value as u8
+    } else {
+        let minimum = min - mid;
+        let value = normal_value_abs * minimum + mid;
+        value as u8
+    }
+}
+
+// Returns a value between 0.0 and 1.0 based on the given value with its
+// maximum.
+pub fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
+    raw_value / max
+}
+
+/// De-normalizes the given value from 0.0 - 1.0 into a real value based on
+/// the maximum axis range.
+pub fn denormalize_unsigned_value_u16(normal_value: f64, max: f64) -> u16 {
+    (normal_value * max).round() as u16
+}
+
+/// De-normalizes the given value from 0.0 - 1.0 into a real value based on
+/// the maximum axis range.
+pub fn denormalize_unsigned_value_u8(normal_value: f64, max: f64) -> u8 {
+    (normal_value * max).round() as u8
+}
+
 impl InputValue {
     /// Returns whether or not the value is "pressed"
     pub fn pressed(&self) -> bool {

--- a/src/input/source/hidraw/dualsense.rs
+++ b/src/input/source/hidraw/dualsense.rs
@@ -14,7 +14,11 @@ use crate::{
             Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger, Touch, TouchButton,
             Touchpad,
         },
-        event::{native::NativeEvent, value::InputValue},
+        event::{
+            native::NativeEvent,
+            value::InputValue,
+            value::{normalize_signed_value, normalize_unsigned_value},
+        },
         output_event::OutputEvent,
         source::{InputError, OutputError, SourceInputDevice, SourceOutputDevice},
     },
@@ -366,29 +370,6 @@ fn translate_event(event: dualsense::event::Event) -> NativeEvent {
             ),
         },
     }
-}
-
-/// Returns a value between -1.0 and 1.0 based on the given value with its
-/// minimum and maximum values.
-fn normalize_signed_value(raw_value: f64, min: f64, max: f64) -> f64 {
-    let mid = (max + min) / 2.0;
-    let event_value = raw_value - mid;
-
-    // Normalize the value
-    if event_value >= 0.0 {
-        let maximum = max - mid;
-        event_value / maximum
-    } else {
-        let minimum = min - mid;
-        let value = event_value / minimum;
-        -value
-    }
-}
-
-// Returns a value between 0.0 and 1.0 based on the given value with its
-// maximum.
-fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
-    raw_value / max
 }
 
 /// Normalize the value to something between -1.0 and 1.0 based on the DualSense's

--- a/src/input/source/hidraw/flydigi_vader_4_pro.rs
+++ b/src/input/source/hidraw/flydigi_vader_4_pro.rs
@@ -7,7 +7,11 @@ use crate::{
     },
     input::{
         capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger},
-        event::{native::NativeEvent, value::InputValue},
+        event::{
+            native::NativeEvent,
+            value::InputValue,
+            value::{normalize_signed_value, normalize_unsigned_value},
+        },
         source::{InputError, SourceInputDevice, SourceOutputDevice},
     },
     udev::device::UdevDevice,
@@ -53,29 +57,6 @@ impl Debug for Vader4Pro {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Vader4Pro").finish()
     }
-}
-
-/// Returns a value between -1.0 and 1.0 based on the given value with its
-/// minimum and maximum values.
-fn normalize_signed_value(raw_value: f64, min: f64, max: f64) -> f64 {
-    let mid = (max + min) / 2.0;
-    let event_value = raw_value - mid;
-
-    // Normalize the value
-    if event_value >= 0.0 {
-        let maximum = max - mid;
-        event_value / maximum
-    } else {
-        let minimum = min - mid;
-        let value = event_value / minimum;
-        -value
-    }
-}
-
-// Returns a value between 0.0 and 1.0 based on the given value with its
-// maximum.
-fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
-    raw_value / max
 }
 
 /// Normalize the value to something between -1.0 and 1.0 based on the

--- a/src/input/source/hidraw/fts3528.rs
+++ b/src/input/source/hidraw/fts3528.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     input::{
         capability::{Capability, Touch},
-        event::{native::NativeEvent, value::InputValue},
+        event::{native::NativeEvent, value::normalize_unsigned_value, value::InputValue},
         source::{InputError, SourceInputDevice, SourceOutputDevice},
     },
     udev::device::UdevDevice,
@@ -51,20 +51,14 @@ impl Debug for Fts3528Touchscreen {
     }
 }
 
-// Returns a value between 0.0 and 1.0 based on the given value with its
-// maximum.
-fn normalize_unsigned_value(raw_value: u16, max: u16) -> f64 {
-    raw_value as f64 / max as f64
-}
-
 /// Normalizes the given input into an input value
 fn normalize_axis_value(touch: TouchAxisInput) -> InputValue {
     // Normalize the x, y values if touching
     let (x, y) = match touch.is_touching {
         true => {
             // NOTE: X and Y are flipped due to panel rotation.
-            let x = normalize_unsigned_value(touch.y, TOUCHSCREEN_Y_MAX);
-            let y = 1.0 - normalize_unsigned_value(touch.x, TOUCHSCREEN_X_MAX);
+            let x = normalize_unsigned_value(touch.y as f64, TOUCHSCREEN_Y_MAX as f64);
+            let y = 1.0 - normalize_unsigned_value(touch.x as f64, TOUCHSCREEN_X_MAX as f64);
             (Some(x), Some(y))
         }
         false => (None, None),

--- a/src/input/source/hidraw/horipad_steam.rs
+++ b/src/input/source/hidraw/horipad_steam.rs
@@ -7,7 +7,11 @@ use crate::{
     },
     input::{
         capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger},
-        event::{native::NativeEvent, value::InputValue},
+        event::{
+            native::NativeEvent,
+            value::InputValue,
+            value::{normalize_signed_value, normalize_unsigned_value},
+        },
         source::{InputError, SourceInputDevice, SourceOutputDevice},
     },
     udev::device::UdevDevice,
@@ -47,29 +51,6 @@ impl Debug for HoripadSteam {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("HoripadSteam").finish()
     }
-}
-
-/// Returns a value between -1.0 and 1.0 based on the given value with its
-/// minimum and maximum values.
-fn normalize_signed_value(raw_value: f64, min: f64, max: f64) -> f64 {
-    let mid = (max + min) / 2.0;
-    let event_value = raw_value - mid;
-
-    // Normalize the value
-    if event_value >= 0.0 {
-        let maximum = max - mid;
-        event_value / maximum
-    } else {
-        let minimum = min - mid;
-        let value = event_value / minimum;
-        -value
-    }
-}
-
-// Returns a value between 0.0 and 1.0 based on the given value with its
-// maximum.
-fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
-    raw_value / max
 }
 
 /// Normalize the value to something between -1.0 and 1.0 based on the

--- a/src/input/source/hidraw/legion_go.rs
+++ b/src/input/source/hidraw/legion_go.rs
@@ -13,7 +13,11 @@ use crate::{
             Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger, Mouse, MouseButton,
             Source, Touch, TouchButton, Touchpad,
         },
-        event::{native::NativeEvent, value::InputValue},
+        event::{
+            native::NativeEvent,
+            value::InputValue,
+            value::{normalize_signed_value, normalize_unsigned_value},
+        },
         source::{InputError, SourceInputDevice, SourceOutputDevice},
     },
     udev::device::UdevDevice,
@@ -260,29 +264,6 @@ impl Debug for LegionGoController {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LegionController").finish()
     }
-}
-
-/// Returns a value between -1.0 and 1.0 based on the given value with its
-/// minimum and maximum values.
-fn normalize_signed_value(raw_value: f64, min: f64, max: f64) -> f64 {
-    let mid = (max + min) / 2.0;
-    let event_value = raw_value - mid;
-
-    // Normalize the value
-    if event_value >= 0.0 {
-        let maximum = max - mid;
-        event_value / maximum
-    } else {
-        let minimum = min - mid;
-        let value = event_value / minimum;
-        -value
-    }
-}
-
-// Returns a value between 0.0 and 1.0 based on the given value with its
-// maximum.
-fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
-    raw_value / max
 }
 
 /// Normalize the value to something between -1.0 and 1.0 based on the

--- a/src/input/source/hidraw/legos_touchpad.rs
+++ b/src/input/source/hidraw/legos_touchpad.rs
@@ -4,7 +4,7 @@ use crate::{
     drivers::legos::{event, touchpad_driver::TouchpadDriver, PAD_FORCE_MAX, PAD_MOTION_MAX},
     input::{
         capability::{Capability, Gamepad, GamepadTrigger, Touch, TouchButton, Touchpad},
-        event::{native::NativeEvent, value::InputValue},
+        event::{native::NativeEvent, value::normalize_unsigned_value, value::InputValue},
         output_event::OutputEvent,
         source::{InputError, OutputError, SourceInputDevice, SourceOutputDevice},
     },
@@ -52,12 +52,6 @@ impl Debug for LegionSTouchpadController {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LegionSController").finish()
     }
-}
-
-// Returns a value between 0.0 and 1.0 based on the given value with its
-// maximum.
-fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
-    raw_value / max
 }
 
 /// Normalize the value to something between -1.0 and 1.0 based on the

--- a/src/input/source/hidraw/legos_xinput.rs
+++ b/src/input/source/hidraw/legos_xinput.rs
@@ -14,7 +14,11 @@ use crate::{
     },
     input::{
         capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger},
-        event::{native::NativeEvent, value::InputValue},
+        event::{
+            native::NativeEvent,
+            value::InputValue,
+            value::{normalize_signed_value, normalize_unsigned_value},
+        },
         output_event::OutputEvent,
         source::{InputError, OutputError, SourceInputDevice, SourceOutputDevice},
     },
@@ -191,29 +195,6 @@ impl Debug for LegionSXInputController {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LegionSController").finish()
     }
-}
-
-/// Returns a value between -1.0 and 1.0 based on the given value with its
-/// minimum and maximum values.
-fn normalize_signed_value(raw_value: f64, min: f64, max: f64) -> f64 {
-    let mid = (max + min) / 2.0;
-    let event_value = raw_value - mid;
-
-    // Normalize the value
-    if event_value >= 0.0 {
-        let maximum = max - mid;
-        event_value / maximum
-    } else {
-        let minimum = min - mid;
-        let value = event_value / minimum;
-        -value
-    }
-}
-
-// Returns a value between 0.0 and 1.0 based on the given value with its
-// maximum.
-fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
-    raw_value / max
 }
 
 /// Normalize the value to something between -1.0 and 1.0 based on the Deck's

--- a/src/input/source/hidraw/opineo.rs
+++ b/src/input/source/hidraw/opineo.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     input::{
         capability::{Capability, Gamepad, GamepadTrigger, Touch, TouchButton, Touchpad},
-        event::{native::NativeEvent, value::InputValue},
+        event::{native::NativeEvent, value::normalize_unsigned_value, value::InputValue},
         output_capability::OutputCapability,
         source::{InputError, OutputError, SourceInputDevice, SourceOutputDevice},
     },
@@ -83,12 +83,6 @@ impl Debug for OrangePiNeoTouchpad {
             .field("side", &self.side)
             .finish()
     }
-}
-
-// Returns a value between 0.0 and 1.0 based on the given value with its
-// maximum.
-fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
-    raw_value / max
 }
 
 /// Normalize the value to something between -1.0 and 1.0 based on the Deck's

--- a/src/input/source/hidraw/steam_deck.rs
+++ b/src/input/source/hidraw/steam_deck.rs
@@ -24,7 +24,11 @@ use crate::{
             Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger, Touch, TouchButton,
             Touchpad,
         },
-        event::{native::NativeEvent, value::InputValue},
+        event::{
+            native::NativeEvent,
+            value::InputValue,
+            value::{normalize_signed_value, normalize_unsigned_value},
+        },
         output_capability::{Haptic, OutputCapability},
         output_event::OutputEvent,
         source::{InputError, OutputError, SourceInputDevice, SourceOutputDevice},
@@ -290,29 +294,6 @@ impl Debug for DeckController {
             .field("ff_evdev_effects", &self.ff_evdev_effects)
             .finish()
     }
-}
-
-/// Returns a value between -1.0 and 1.0 based on the given value with its
-/// minimum and maximum values.
-fn normalize_signed_value(raw_value: f64, min: f64, max: f64) -> f64 {
-    let mid = (max + min) / 2.0;
-    let event_value = raw_value - mid;
-
-    // Normalize the value
-    if event_value >= 0.0 {
-        let maximum = max - mid;
-        event_value / maximum
-    } else {
-        let minimum = min - mid;
-        let value = event_value / minimum;
-        -value
-    }
-}
-
-// Returns a value between 0.0 and 1.0 based on the given value with its
-// maximum.
-fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
-    raw_value / max
 }
 
 /// Normalize the value to something between -1.0 and 1.0 based on the Deck's

--- a/src/input/source/hidraw/xpad_uhid.rs
+++ b/src/input/source/hidraw/xpad_uhid.rs
@@ -9,7 +9,11 @@ use crate::{
     },
     input::{
         capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger},
-        event::{native::NativeEvent, value::InputValue},
+        event::{
+            native::NativeEvent,
+            value::InputValue,
+            value::{normalize_signed_value, normalize_unsigned_value},
+        },
         output_capability::OutputCapability,
         output_event::OutputEvent,
         source::{InputError, OutputError, SourceInputDevice, SourceOutputDevice},
@@ -190,29 +194,6 @@ impl Debug for XpadUhid {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("XpadUhid").finish()
     }
-}
-
-/// Returns a value between -1.0 and 1.0 based on the given value with its
-/// minimum and maximum values.
-fn normalize_signed_value(raw_value: f64, min: f64, max: f64) -> f64 {
-    let mid = (max + min) / 2.0;
-    let event_value = raw_value - mid;
-
-    // Normalize the value
-    if event_value >= 0.0 {
-        let maximum = max - mid;
-        event_value / maximum
-    } else {
-        let minimum = min - mid;
-        let value = event_value / minimum;
-        -value
-    }
-}
-
-// Returns a value between 0.0 and 1.0 based on the given value with its
-// maximum.
-fn normalize_unsigned_value(raw_value: f64, max: f64) -> f64 {
-    raw_value / max
 }
 
 /// Normalize the value to something between -1.0 and 1.0 based on the

--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -35,6 +35,7 @@ use crate::{
         event::{
             native::{NativeEvent, ScheduledNativeEvent},
             value::InputValue,
+            value::{denormalize_signed_value_u8, denormalize_unsigned_value_u8},
         },
         output_capability::{OutputCapability, LED},
         output_event::OutputEvent,
@@ -439,11 +440,13 @@ impl DualSenseDevice {
                     GamepadAxis::LeftStick => {
                         if let InputValue::Vector2 { x, y } = value {
                             if let Some(x) = x {
-                                let value = denormalize_signed_value(x, STICK_X_MIN, STICK_X_MAX);
+                                let value =
+                                    denormalize_signed_value_u8(x, STICK_X_MIN, STICK_X_MAX);
                                 state.joystick_l_x = value
                             }
                             if let Some(y) = y {
-                                let value = denormalize_signed_value(y, STICK_Y_MIN, STICK_Y_MAX);
+                                let value =
+                                    denormalize_signed_value_u8(y, STICK_Y_MIN, STICK_Y_MAX);
                                 state.joystick_l_y = value
                             }
                         }
@@ -451,11 +454,13 @@ impl DualSenseDevice {
                     GamepadAxis::RightStick => {
                         if let InputValue::Vector2 { x, y } = value {
                             if let Some(x) = x {
-                                let value = denormalize_signed_value(x, STICK_X_MIN, STICK_X_MAX);
+                                let value =
+                                    denormalize_signed_value_u8(x, STICK_X_MIN, STICK_X_MAX);
                                 state.joystick_r_x = value
                             }
                             if let Some(y) = y {
-                                let value = denormalize_signed_value(y, STICK_Y_MIN, STICK_Y_MAX);
+                                let value =
+                                    denormalize_signed_value_u8(y, STICK_Y_MIN, STICK_Y_MAX);
                                 state.joystick_r_y = value
                             }
                         }
@@ -463,7 +468,7 @@ impl DualSenseDevice {
                     GamepadAxis::Hat0 => {
                         if let InputValue::Vector2 { x, y } = value {
                             if let Some(x) = x {
-                                let value = denormalize_signed_value(x, -1.0, 1.0);
+                                let value = denormalize_signed_value_u8(x, -1.0, 1.0);
                                 match value.cmp(&0) {
                                     Ordering::Less => match state.dpad {
                                         Direction::North => state.dpad = Direction::NorthWest,
@@ -487,7 +492,7 @@ impl DualSenseDevice {
                                 }
                             }
                             if let Some(y) = y {
-                                let value = denormalize_signed_value(y, -1.0, 1.0);
+                                let value = denormalize_signed_value_u8(y, -1.0, 1.0);
                                 match value.cmp(&0) {
                                     Ordering::Less => match state.dpad {
                                         Direction::East => state.dpad = Direction::NorthEast,
@@ -519,7 +524,7 @@ impl DualSenseDevice {
                 Gamepad::Trigger(trigger) => match trigger {
                     GamepadTrigger::LeftTrigger => {
                         if let InputValue::Float(normal_value) = value {
-                            let value = denormalize_unsigned_value(normal_value, TRIGGER_MAX);
+                            let value = denormalize_unsigned_value_u8(normal_value, TRIGGER_MAX);
                             state.l2_trigger = value
                         }
                     }
@@ -527,7 +532,7 @@ impl DualSenseDevice {
                     GamepadTrigger::LeftStickForce => (),
                     GamepadTrigger::RightTrigger => {
                         if let InputValue::Float(normal_value) = value {
-                            let value = denormalize_unsigned_value(normal_value, TRIGGER_MAX);
+                            let value = denormalize_unsigned_value_u8(normal_value, TRIGGER_MAX);
                             state.r2_trigger = value
                         }
                     }
@@ -1125,29 +1130,6 @@ impl Debug for DualSenseDevice {
             .field("hardware", &self.hardware)
             .finish()
     }
-}
-
-/// Convert the given normalized value between -1.0 - 1.0 to the real value
-/// based on the given minimum and maximum axis range. Playstation gamepads
-/// use a range from 0-255, with 127 being the "nuetral" point.
-fn denormalize_signed_value(normal_value: f64, min: f64, max: f64) -> u8 {
-    let mid = (max + min) / 2.0;
-    let normal_value_abs = normal_value.abs();
-    if normal_value >= 0.0 {
-        let maximum = max - mid;
-        let value = normal_value * maximum + mid;
-        value as u8
-    } else {
-        let minimum = min - mid;
-        let value = normal_value_abs * minimum + mid;
-        value as u8
-    }
-}
-
-/// De-normalizes the given value from 0.0 - 1.0 into a real value based on
-/// the maximum axis range.
-fn denormalize_unsigned_value(normal_value: f64, max: f64) -> u8 {
-    (normal_value * max).round() as u8
 }
 
 /// De-normalizes the given value from 0.0 - 1.0 into a real value based on

--- a/src/input/target/horipad_steam.rs
+++ b/src/input/target/horipad_steam.rs
@@ -16,6 +16,7 @@ use crate::{
         event::{
             native::{NativeEvent, ScheduledNativeEvent},
             value::InputValue,
+            value::{denormalize_signed_value_u8, denormalize_unsigned_value_u8},
         },
         output_capability::OutputCapability,
         output_event::OutputEvent,
@@ -125,11 +126,13 @@ impl HoripadSteamDevice {
                     GamepadAxis::LeftStick => {
                         if let InputValue::Vector2 { x, y } = value {
                             if let Some(x) = x {
-                                let value = denormalize_signed_value(x, JOY_AXIS_MIN, JOY_AXIS_MAX);
+                                let value =
+                                    denormalize_signed_value_u8(x, JOY_AXIS_MIN, JOY_AXIS_MAX);
                                 self.state.joystick_l_x = value
                             }
                             if let Some(y) = y {
-                                let value = denormalize_signed_value(y, JOY_AXIS_MIN, JOY_AXIS_MAX);
+                                let value =
+                                    denormalize_signed_value_u8(y, JOY_AXIS_MIN, JOY_AXIS_MAX);
                                 self.state.joystick_l_y = value
                             }
                         }
@@ -137,11 +140,13 @@ impl HoripadSteamDevice {
                     GamepadAxis::RightStick => {
                         if let InputValue::Vector2 { x, y } = value {
                             if let Some(x) = x {
-                                let value = denormalize_signed_value(x, JOY_AXIS_MIN, JOY_AXIS_MAX);
+                                let value =
+                                    denormalize_signed_value_u8(x, JOY_AXIS_MIN, JOY_AXIS_MAX);
                                 self.state.joystick_r_x = value
                             }
                             if let Some(y) = y {
-                                let value = denormalize_signed_value(y, JOY_AXIS_MIN, JOY_AXIS_MAX);
+                                let value =
+                                    denormalize_signed_value_u8(y, JOY_AXIS_MIN, JOY_AXIS_MAX);
                                 self.state.joystick_r_y = value
                             }
                         }
@@ -149,7 +154,7 @@ impl HoripadSteamDevice {
                     GamepadAxis::Hat0 => {
                         if let InputValue::Vector2 { x, y } = value {
                             if let Some(x) = x {
-                                let value = denormalize_signed_value(x, -1.0, 1.0);
+                                let value = denormalize_signed_value_u8(x, -1.0, 1.0);
                                 match value.cmp(&0) {
                                     Ordering::Less => {
                                         self.state.dpad =
@@ -168,7 +173,7 @@ impl HoripadSteamDevice {
                                 }
                             }
                             if let Some(y) = y {
-                                let value = denormalize_signed_value(y, -1.0, 1.0);
+                                let value = denormalize_signed_value_u8(y, -1.0, 1.0);
                                 match value.cmp(&0) {
                                     Ordering::Less => {
                                         self.state.dpad =
@@ -195,7 +200,8 @@ impl HoripadSteamDevice {
                 Gamepad::Trigger(trigger) => match trigger {
                     GamepadTrigger::LeftTrigger => {
                         if let InputValue::Float(normal_value) = value {
-                            let value = denormalize_unsigned_value(normal_value, TRIGGER_AXIS_MAX);
+                            let value =
+                                denormalize_unsigned_value_u8(normal_value, TRIGGER_AXIS_MAX);
                             self.state.lt_analog = value
                         }
                     }
@@ -203,7 +209,8 @@ impl HoripadSteamDevice {
                     GamepadTrigger::LeftStickForce => (),
                     GamepadTrigger::RightTrigger => {
                         if let InputValue::Float(normal_value) = value {
-                            let value = denormalize_unsigned_value(normal_value, TRIGGER_AXIS_MAX);
+                            let value =
+                                denormalize_unsigned_value_u8(normal_value, TRIGGER_AXIS_MAX);
                             self.state.rt_analog = value
                         }
                     }
@@ -455,29 +462,6 @@ impl Debug for HoripadSteamDevice {
             .field("timestamp", &self.timestamp)
             .finish()
     }
-}
-
-/// Convert the given normalized value between -1.0 - 1.0 to the real value
-/// based on the given minimum and maximum axis range. Horipad gamepads
-/// use a range from 0-255, with 127 being the "nuetral" point.
-fn denormalize_signed_value(normal_value: f64, min: f64, max: f64) -> u8 {
-    let mid = (max + min) / 2.0;
-    let normal_value_abs = normal_value.abs();
-    if normal_value >= 0.0 {
-        let maximum = max - mid;
-        let value = normal_value * maximum + mid;
-        value as u8
-    } else {
-        let minimum = min - mid;
-        let value = normal_value_abs * minimum + mid;
-        value as u8
-    }
-}
-
-/// De-normalizes the given value from 0.0 - 1.0 into a real value based on
-/// the maximum axis range.
-fn denormalize_unsigned_value(normal_value: f64, max: f64) -> u8 {
-    (normal_value * max).round() as u8
 }
 
 /// De-normalizes the given value in meters per second into a real value that

--- a/src/input/target/steam_deck_uhid.rs
+++ b/src/input/target/steam_deck_uhid.rs
@@ -34,6 +34,7 @@ use crate::{
         event::{
             native::{NativeEvent, ScheduledNativeEvent},
             value::InputValue,
+            value::{denormalize_signed_value_i16, denormalize_unsigned_value_u16},
         },
         output_capability::{Haptic, OutputCapability},
         output_event::OutputEvent,
@@ -42,10 +43,7 @@ use crate::{
 };
 
 use super::{
-    steam_deck::{
-        denormalize_signed_value, denormalize_unsigned_to_signed_value, denormalize_unsigned_value,
-        SteamDeckConfig,
-    },
+    steam_deck::{denormalize_unsigned_to_signed_value, SteamDeckConfig},
     InputError, OutputError, TargetInputDevice, TargetOutputDevice,
 };
 
@@ -166,11 +164,13 @@ impl SteamDeckUhidDevice {
                     GamepadAxis::LeftStick => {
                         if let InputValue::Vector2 { x, y } = value {
                             if let Some(x) = x {
-                                let value = denormalize_signed_value(x, STICK_X_MIN, STICK_X_MAX);
+                                let value =
+                                    denormalize_signed_value_i16(x, STICK_X_MIN, STICK_X_MAX);
                                 self.state.l_stick_x = Integer::from_primitive(value);
                             }
                             if let Some(y) = y {
-                                let value = denormalize_signed_value(y, STICK_Y_MIN, STICK_Y_MAX);
+                                let value =
+                                    denormalize_signed_value_i16(y, STICK_Y_MIN, STICK_Y_MAX);
                                 self.state.l_stick_y = Integer::from_primitive(value);
                             }
                         }
@@ -178,11 +178,13 @@ impl SteamDeckUhidDevice {
                     GamepadAxis::RightStick => {
                         if let InputValue::Vector2 { x, y } = value {
                             if let Some(x) = x {
-                                let value = denormalize_signed_value(x, STICK_X_MIN, STICK_X_MAX);
+                                let value =
+                                    denormalize_signed_value_i16(x, STICK_X_MIN, STICK_X_MAX);
                                 self.state.r_stick_x = Integer::from_primitive(value);
                             }
                             if let Some(y) = y {
-                                let value = denormalize_signed_value(y, STICK_Y_MIN, STICK_Y_MAX);
+                                let value =
+                                    denormalize_signed_value_i16(y, STICK_Y_MIN, STICK_Y_MAX);
                                 self.state.r_stick_y = Integer::from_primitive(value);
                             }
                         }
@@ -190,7 +192,7 @@ impl SteamDeckUhidDevice {
                     GamepadAxis::Hat0 => {
                         if let InputValue::Vector2 { x, y } = value {
                             if let Some(x) = x {
-                                let value = denormalize_signed_value(x, -1.0, 1.0);
+                                let value = denormalize_signed_value_i16(x, -1.0, 1.0);
                                 match value.cmp(&0) {
                                     Ordering::Less => {
                                         self.state.left = true;
@@ -207,7 +209,7 @@ impl SteamDeckUhidDevice {
                                 }
                             }
                             if let Some(y) = y {
-                                let value = denormalize_signed_value(y, -1.0, 1.0);
+                                let value = denormalize_signed_value_i16(y, -1.0, 1.0);
                                 match value.cmp(&0) {
                                     Ordering::Less => {
                                         self.state.up = true;
@@ -233,38 +235,38 @@ impl SteamDeckUhidDevice {
                     GamepadTrigger::LeftTrigger => {
                         if let InputValue::Float(value) = value {
                             self.state.l2 = value > 0.8;
-                            let value = denormalize_unsigned_value(value, TRIGG_MAX);
+                            let value = denormalize_unsigned_value_u16(value, TRIGG_MAX);
                             self.state.l_trigg = Integer::from_primitive(value);
                         }
                     }
                     GamepadTrigger::LeftTouchpadForce => {
                         if let InputValue::Float(value) = value {
-                            let value = denormalize_unsigned_value(value, PAD_FORCE_MAX);
+                            let value = denormalize_unsigned_value_u16(value, PAD_FORCE_MAX);
                             self.state.l_pad_force = Integer::from_primitive(value);
                         }
                     }
                     GamepadTrigger::LeftStickForce => {
                         if let InputValue::Float(value) = value {
-                            let value = denormalize_unsigned_value(value, STICK_FORCE_MAX);
+                            let value = denormalize_unsigned_value_u16(value, STICK_FORCE_MAX);
                             self.state.l_stick_force = Integer::from_primitive(value);
                         }
                     }
                     GamepadTrigger::RightTrigger => {
                         if let InputValue::Float(value) = value {
                             self.state.r2 = value > 0.8;
-                            let value = denormalize_unsigned_value(value, TRIGG_MAX);
+                            let value = denormalize_unsigned_value_u16(value, TRIGG_MAX);
                             self.state.r_trigg = Integer::from_primitive(value);
                         }
                     }
                     GamepadTrigger::RightTouchpadForce => {
                         if let InputValue::Float(value) = value {
-                            let value = denormalize_unsigned_value(value, PAD_FORCE_MAX);
+                            let value = denormalize_unsigned_value_u16(value, PAD_FORCE_MAX);
                             self.state.r_pad_force = Integer::from_primitive(value);
                         }
                     }
                     GamepadTrigger::RightStickForce => {
                         if let InputValue::Float(value) = value {
-                            let value = denormalize_unsigned_value(value, STICK_FORCE_MAX);
+                            let value = denormalize_unsigned_value_u16(value, STICK_FORCE_MAX);
                             self.state.r_stick_force = Integer::from_primitive(value);
                         }
                     }

--- a/src/input/target/touchpad.rs
+++ b/src/input/target/touchpad.rs
@@ -10,7 +10,7 @@ use nix::fcntl::{FcntlArg, OFlag};
 use crate::input::{
     capability::{Capability, Touch, TouchButton, Touchpad},
     composite_device::client::CompositeDeviceClient,
-    event::{native::NativeEvent, value::InputValue},
+    event::{native::NativeEvent, value::denormalize_unsigned_value_u16, value::InputValue},
     output_event::OutputEvent,
 };
 
@@ -282,8 +282,8 @@ impl TouchpadDevice {
         }
 
         // Denormalize the x, y values based on the pad size
-        let x = x.map(|val| denormalize_unsigned_value(val, self.config.width as f64));
-        let y = y.map(|val| denormalize_unsigned_value(val, self.config.height as f64));
+        let x = x.map(|val| denormalize_unsigned_value_u16(val, self.config.width as f64));
+        let y = y.map(|val| denormalize_unsigned_value_u16(val, self.config.height as f64));
 
         // Send events for x values
         if let Some(x) = x {
@@ -394,10 +394,4 @@ impl TargetOutputDevice for TouchpadDevice {
 
         Ok(vec![])
     }
-}
-
-/// De-normalizes the given value from 0.0 - 1.0 into a real value based on
-/// the maximum axis range.
-fn denormalize_unsigned_value(normal_value: f64, max: f64) -> u16 {
-    (normal_value * max).round() as u16
 }

--- a/src/input/target/touchscreen.rs
+++ b/src/input/target/touchscreen.rs
@@ -12,7 +12,7 @@ use crate::{
     input::{
         capability::{Capability, Touch},
         composite_device::client::CompositeDeviceClient,
-        event::{native::NativeEvent, value::InputValue},
+        event::{native::NativeEvent, value::denormalize_unsigned_value_u16, value::InputValue},
         output_event::OutputEvent,
     },
     udev::device::UdevDevice,
@@ -299,8 +299,8 @@ impl TouchscreenDevice {
         }
 
         // Denormalize the x, y values based on the screen size
-        let x = x.map(|val| denormalize_unsigned_value(val, width as f64));
-        let y = y.map(|val| denormalize_unsigned_value(val, height as f64));
+        let x = x.map(|val| denormalize_unsigned_value_u16(val, width as f64));
+        let y = y.map(|val| denormalize_unsigned_value_u16(val, height as f64));
 
         // Send events for x values
         if let Some(x) = x {
@@ -590,10 +590,4 @@ impl TargetOutputDevice for TouchscreenDevice {
 
         Ok(vec![])
     }
-}
-
-/// De-normalizes the given value from 0.0 - 1.0 into a real value based on
-/// the maximum axis range.
-fn denormalize_unsigned_value(normal_value: f64, max: f64) -> u16 {
-    (normal_value * max).round() as u16
 }


### PR DESCRIPTION
Fixes #465 

This refactor moves the repeated implementations of the [de]normalize_[un]signed_value functions into 'src/input/event/value.rs' so they can be reused by the source and target implementations.

No functional changes.