### PR TITLE
WIP add Steam Deck touchpad functionality and enable the device profile

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-steam_deck.yaml
@@ -61,7 +61,7 @@ options:
 
 # The target input device(s) to emulate by default
 target_devices:
-  - xbox-elite
+  - deck
   - mouse
   - keyboard
   #- touchscreen


### PR DESCRIPTION

this makes it so left and right touchpad mimic SteamOS functionality, with one minor improvement.

SteamOS behavior:
left pad = dpad, tactile bump when navigating menus. right pad = nothing

Enhanced behavior provided:
left pad = dpad, tactile bump when navigating menus. right pad = standard touchpad with cursor movement, left click select with tactile bump

Note: all controls are fully re-mappable per-game within steam, this just provides functionality to match steamos when in a steamos session instead of doing nothing like they currently do.

this also enables the device profile and changes its target to deck so that the driver is used.

requires https://github.com/ShadowBlip/OpenGamepadUI/pull/500 for OGUI to be able to apply profiles with leftpad/rightpad support