### PR TITLE
fix(Legion Go 2): Fix device names for Legion Go 2 controllers

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-legion_go_2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go_2.yaml
@@ -28,7 +28,7 @@ source_devices:
     blocked: true
     unique: false
     evdev:
-      name: "{  Legion Controller for Windows  Mouse,Legion-Controller [0-Z]-[0-Z][0-Z] Mouse}"
+      name: "{  Legion Controller  Mouse,  Legion Controller for Windows  Mouse,Legion-Controller [0-Z]-[0-Z][0-Z] Mouse}"
       vendor_id: "17ef"
       product_id: "{61e[b-d]}" # Don't grab 5/e, thats FPS mode Keyboard events
       handler: event*
@@ -38,7 +38,7 @@ source_devices:
     blocked: true
     unique: false
     evdev:
-      name: "{  Legion Controller for Windows  Touchpad,Legion-Controller [0-Z]-[0-Z][0-Z] Touchpad}"
+      name: "{  Legion Controller  Touchpad,  Legion Controller for Windows  Touchpad,Legion-Controller [0-Z]-[0-Z][0-Z] Touchpad}"
       vendor_id: "17ef"
       product_id: "{61e[b-d]}" # 5/e don't exist
       handler: event*
@@ -46,7 +46,7 @@ source_devices:
     blocked: true
     unique: false
     evdev:
-      name: "{  Legion Controller for Windows  Keyboard,Legion-Controller [0-Z]-[0-Z][0-Z] Keyboard}"
+      name: "{  Legion Controller  Keyboard,  Legion Controller for Windows  Keyboard,Legion-Controller [0-Z]-[0-Z][0-Z] Keyboard}"
       vendor_id: "17ef"
       product_id: "{61e[b-d]}" # Don't grab 5/e, thats FPS mode Keyboard events
       handler: event*


### PR DESCRIPTION
I: Bus=0003 Vendor=17ef Product=61eb Version=0110
N: Name="  Legion Controller  Keyboard"

I: Bus=0003 Vendor=17ef Product=61eb Version=0110
N: Name="  Legion Controller  Mouse"

I: Bus=0003 Vendor=17ef Product=61eb Version=0110
N: Name="  Legion Controller  Touchpad"