### PR TITLE
feat(Config): add udev matching for composite device configs

### DIFF
--- a/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+++ b/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
@@ -106,6 +106,9 @@
       "properties": {
         "dmi_data": {
           "$ref": "#/definitions/DMIMatch"
+        },
+        "udev": {
+          "$ref": "#/definitions/Udev"
         }
       },
       "title": "Match"

--- a/src/udev/device.rs
+++ b/src/udev/device.rs
@@ -427,6 +427,34 @@ impl UdevDevice {
         UdevDevice::from_devnode(base_path, name)
     }
 
+    /// Returns a UdevDevice object from the given syspath.
+    /// e.g. UdevDevice::from_syspath("/sys/firmware/devicetree/base");
+    pub fn from_syspath(path: &str) -> Self {
+        let path = PathBuf::from(path);
+        let device = match ::udev::Device::from_syspath(path.as_path()) {
+            Ok(dev) => dev,
+            Err(_) => return Default::default(),
+        };
+
+        Self {
+            devnode: device
+                .devnode()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_default(),
+            subsystem: device
+                .subsystem()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_default(),
+            syspath: device.syspath().to_string_lossy().to_string(),
+            sysname: device.sysname().to_string_lossy().to_string(),
+            name: Some(device.name().to_string()),
+            vendor_id: None,
+            product_id: None,
+            bus_type: None,
+            properties: Default::default(),
+        }
+    }
+
     /// Returns a udev::Device from the stored syspath.
     pub fn get_device(&self) -> Result<::udev::Device, Box<dyn Error + Send + Sync>> {
         match ::udev::Device::from_syspath(Path::new(self.syspath.as_str())) {


### PR DESCRIPTION
This change adds a new 'udev' property to the 'matches' section of the composite device config, allowing you to match composite devices based on a pre-defined syspath.

You can now use syspath udev properties for the 'matches' section like this:

```yaml
matches:
  - udev:
      sys_path: /sys/firmware/devicetree/base
      attributes:
        - name: model
          value: Lenovo ThinkPad X13s
  - udev:
      sys_path: /sys/devices/virtual/dmi/id
      attributes:
        - name: product_name
          value: Lenovo Think*
        - name: board_name
          value: ABC*123
```

It can also replace how we're currently using dmi data. E.g.

**Old**

```yaml
  - dmi_data:
      board_name: RC71L
      sys_vendor: ASUSTeK COMPUTER INC.
  - dmi_data:
      board_name: RC73YA
      sys_vendor: ASUSTeK COMPUTER INC.
```

**New**
```yaml
  - udev:
      sys_path: /sys/devices/virtual/dmi/id
      attributes:
        - name: board_name
          value: "{RC71L,RC73YA}"
        - name: sys_vendor
          value: ASUSTeK COMPUTER INC.
```

Fixes #503 