### PR TITLE
fix(Hardware Support): Add new PID's for Steam Deck target

### DIFF
--- a/src/drivers/steam_deck/driver.rs
+++ b/src/drivers/steam_deck/driver.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, ffi::CString};
 
-use crate::drivers::steam_deck::hid_report::PackedInputDataReport;
+use crate::drivers::steam_deck::{hid_report::PackedInputDataReport, ProductId, VID};
 use hidapi::HidDevice;
 use packed_struct::{
     types::{Integer, SizedInteger},
@@ -15,10 +15,6 @@ use super::{
     hid_report::{PackedMappingsReport, PackedRumbleReport, Register, ReportType, TrackpadMode},
 };
 
-/// Vendor ID
-pub const VID: u16 = 0x28de;
-/// Product ID
-pub const PID: u16 = 0x1205;
 /// Scale to multiply accelerometer values to get in units of meters per second
 pub const ACCEL_SCALE: f64 = 0.0006125;
 /// Scale to multiply gyro values to get in units of degrees per second
@@ -39,7 +35,7 @@ impl Driver {
         let api = hidapi::HidApi::new()?;
         let device = api.open_path(&path)?;
         let info = device.get_device_info()?;
-        if info.vendor_id() != VID || info.product_id() != PID {
+        if info.vendor_id() != VID || info.product_id() != ProductId::SteamDeck.to_u16() {
             return Err("Device '{path}' is not a Steam Deck Controller".into());
         }
 

--- a/src/drivers/steam_deck/mod.rs
+++ b/src/drivers/steam_deck/mod.rs
@@ -2,3 +2,47 @@ pub mod driver;
 pub mod event;
 pub mod hid_report;
 pub mod report_descriptor;
+
+/// Target Device ProductIds, used to ID specific devices in SDL.
+#[derive(Debug, Clone)]
+pub enum ProductId {
+    SteamDeck = 0x1205,
+    Generic = 0x12f0,
+    MsiClaw = 0x12fa,
+    LenovoLegionGo2 = 0x12fb,
+    ZotacZone = 0x12fc,
+    AsusRogAlly = 0x12fd,
+    LenovoLegionGo = 0x12fe,
+    LenovoLegionGoS = 0x12ff,
+}
+
+/// Vendor ID
+pub const VID: u16 = 0x28de;
+
+impl ProductId {
+    pub fn to_u16(&self) -> u16 {
+        match self {
+            ProductId::SteamDeck => ProductId::SteamDeck as u16,
+            ProductId::Generic => ProductId::Generic as u16,
+            ProductId::MsiClaw => ProductId::MsiClaw as u16,
+            ProductId::LenovoLegionGo2 => ProductId::LenovoLegionGo2 as u16,
+            ProductId::ZotacZone => ProductId::ZotacZone as u16,
+            ProductId::AsusRogAlly => ProductId::AsusRogAlly as u16,
+            ProductId::LenovoLegionGo => ProductId::LenovoLegionGo as u16,
+            ProductId::LenovoLegionGoS => ProductId::LenovoLegionGoS as u16,
+        }
+    }
+
+    pub fn to_u32(&self) -> u32 {
+        match self {
+            ProductId::SteamDeck => ProductId::SteamDeck as u32,
+            ProductId::Generic => ProductId::Generic as u32,
+            ProductId::MsiClaw => ProductId::MsiClaw as u32,
+            ProductId::LenovoLegionGo2 => ProductId::LenovoLegionGo2 as u32,
+            ProductId::ZotacZone => ProductId::ZotacZone as u32,
+            ProductId::AsusRogAlly => ProductId::AsusRogAlly as u32,
+            ProductId::LenovoLegionGo => ProductId::LenovoLegionGo as u32,
+            ProductId::LenovoLegionGoS => ProductId::LenovoLegionGoS as u32,
+        }
+    }
+}

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -435,7 +435,9 @@ impl HidRawDevice {
         }
 
         // Steam Deck
-        if vid == steam_deck::VID && pid == steam_deck::PID {
+        if vid == drivers::steam_deck::VID
+            && pid == drivers::steam_deck::ProductId::SteamDeck.to_u16()
+        {
             log::info!("Detected Steam Deck");
             return DriverType::SteamDeck;
         }

--- a/src/input/source/hidraw/steam_deck.rs
+++ b/src/input/source/hidraw/steam_deck.rs
@@ -36,11 +36,6 @@ use crate::{
     udev::device::UdevDevice,
 };
 
-/// Vendor ID
-pub const VID: u16 = 0x28de;
-/// Product ID
-pub const PID: u16 = 0x1205;
-
 pub struct DeckController {
     driver: Driver,
     device_info: UdevDevice,

--- a/src/input/target/steam_deck.rs
+++ b/src/input/target/steam_deck.rs
@@ -24,13 +24,13 @@ use virtual_usb::{
 use crate::{
     config::CompositeDeviceConfig,
     drivers::steam_deck::{
-        driver::VID,
         hid_report::{
             PackedHapticReport, PackedInputDataReport, PackedRumbleReport, ReportType,
             PAD_FORCE_MAX, PAD_X_MAX, PAD_X_MIN, PAD_Y_MAX, PAD_Y_MIN, STICK_FORCE_MAX,
             STICK_X_MAX, STICK_X_MIN, STICK_Y_MAX, STICK_Y_MIN, TRIGG_MAX,
         },
         report_descriptor::{CONTROLLER_DESCRIPTOR, KEYBOARD_DESCRIPTOR, MOUSE_DESCRIPTOR},
+        ProductId, VID,
     },
     input::{
         capability::{
@@ -40,8 +40,7 @@ use crate::{
         composite_device::client::CompositeDeviceClient,
         event::{
             native::{NativeEvent, ScheduledNativeEvent},
-            value::InputValue,
-            value::{denormalize_signed_value_i16, denormalize_unsigned_value_u16},
+            value::{denormalize_signed_value_i16, denormalize_unsigned_value_u16, InputValue},
         },
         output_capability::{Haptic, OutputCapability},
         output_event::OutputEvent,
@@ -49,42 +48,6 @@ use crate::{
 };
 
 use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
-
-/// Target Device ProductIds, used to ID specific devices in SDL.
-#[derive(Debug, Clone)]
-pub enum ProductId {
-    SteamDeck = 0x1205,
-    Generic = 0x12f0,
-    ZotacZone = 0x12fc,
-    AsusRogAlly = 0x12fd,
-    LenovoLegionGo = 0x12fe,
-    LenovoLegionGoS = 0x12ff,
-    //LenovoLegionGo2 = 0x13__,
-}
-
-impl ProductId {
-    pub fn to_u16(&self) -> u16 {
-        match self {
-            ProductId::SteamDeck => ProductId::SteamDeck as u16,
-            ProductId::Generic => ProductId::Generic as u16,
-            ProductId::ZotacZone => ProductId::ZotacZone as u16,
-            ProductId::AsusRogAlly => ProductId::AsusRogAlly as u16,
-            ProductId::LenovoLegionGo => ProductId::LenovoLegionGo as u16,
-            ProductId::LenovoLegionGoS => ProductId::LenovoLegionGoS as u16,
-        }
-    }
-
-    pub fn to_u32(&self) -> u32 {
-        match self {
-            ProductId::SteamDeck => ProductId::SteamDeck as u32,
-            ProductId::Generic => ProductId::Generic as u32,
-            ProductId::ZotacZone => ProductId::ZotacZone as u32,
-            ProductId::AsusRogAlly => ProductId::AsusRogAlly as u32,
-            ProductId::LenovoLegionGo => ProductId::LenovoLegionGo as u32,
-            ProductId::LenovoLegionGoS => ProductId::LenovoLegionGoS as u32,
-        }
-    }
-}
 
 /// Configuration of the target SteamDeck device.
 #[derive(Debug, Clone)]
@@ -873,8 +836,8 @@ impl TargetInputDevice for SteamDeckDevice {
                 }
                 "Lenovo Legion Go 2" => {
                     device_config.vendor = "Lenovo".to_string();
-                    device_config.name = "Legion Go Controller".to_string();
-                    device_config.product_id = ProductId::LenovoLegionGo;
+                    device_config.name = "Legion Go 2 Controller".to_string();
+                    device_config.product_id = ProductId::LenovoLegionGo2;
                 }
                 "Lenovo Legion Go S" => {
                     device_config.vendor = "Lenovo".to_string();
@@ -910,6 +873,26 @@ impl TargetInputDevice for SteamDeckDevice {
                     device_config.vendor = "Valve Corporation".to_string();
                     device_config.name = "Steam Controller".to_string();
                     device_config.product_id = ProductId::SteamDeck;
+                }
+                "MSI Claw" => {
+                    device_config.vendor = "MSI".to_string();
+                    device_config.name = "Claw Controller".to_string();
+                    device_config.product_id = ProductId::MsiClaw;
+                }
+                "MSI Claw 7 AI+ A2VM" => {
+                    device_config.vendor = "MSI".to_string();
+                    device_config.name = "Claw Controller".to_string();
+                    device_config.product_id = ProductId::MsiClaw;
+                }
+                "MSI Claw 8 AI+ A2VM" => {
+                    device_config.vendor = "MSI".to_string();
+                    device_config.name = "Claw Controller".to_string();
+                    device_config.product_id = ProductId::MsiClaw;
+                }
+                "MSI Claw A8 BZ2EM" => {
+                    device_config.vendor = "MSI".to_string();
+                    device_config.name = "Claw Controller".to_string();
+                    device_config.product_id = ProductId::MsiClaw;
                 }
                 _ => {}
             };

--- a/src/input/target/steam_deck_uhid.rs
+++ b/src/input/target/steam_deck_uhid.rs
@@ -17,13 +17,13 @@ use uhid_virt::{Bus, CreateParams, StreamError, UHIDDevice};
 use crate::{
     config::CompositeDeviceConfig,
     drivers::steam_deck::{
-        driver::VID,
         hid_report::{
             PackedHapticReport, PackedInputDataReport, PackedRumbleReport, ReportType,
             PAD_FORCE_MAX, PAD_X_MAX, PAD_X_MIN, PAD_Y_MAX, PAD_Y_MIN, STICK_FORCE_MAX,
             STICK_X_MAX, STICK_X_MIN, STICK_Y_MAX, STICK_Y_MIN, TRIGG_MAX,
         },
         report_descriptor::CONTROLLER_DESCRIPTOR,
+        ProductId, VID,
     },
     input::{
         capability::{
@@ -33,12 +33,10 @@ use crate::{
         composite_device::client::CompositeDeviceClient,
         event::{
             native::{NativeEvent, ScheduledNativeEvent},
-            value::InputValue,
-            value::{denormalize_signed_value_i16, denormalize_unsigned_value_u16},
+            value::{denormalize_signed_value_i16, denormalize_unsigned_value_u16, InputValue},
         },
         output_capability::{Haptic, OutputCapability},
         output_event::OutputEvent,
-        target::steam_deck::ProductId,
     },
 };
 
@@ -645,8 +643,8 @@ impl TargetInputDevice for SteamDeckUhidDevice {
                 }
                 "Lenovo Legion Go 2" => {
                     device_config.vendor = "Lenovo".to_string();
-                    device_config.name = "Legion Go Controller".to_string();
-                    device_config.product_id = ProductId::LenovoLegionGo;
+                    device_config.name = "Legion Go 2 Controller".to_string();
+                    device_config.product_id = ProductId::LenovoLegionGo2;
                 }
                 "Lenovo Legion Go S" => {
                     device_config.vendor = "Lenovo".to_string();
@@ -684,6 +682,26 @@ impl TargetInputDevice for SteamDeckUhidDevice {
                     // True PID will only work with the VCHI target as Steam looks for a
                     // specific bInterfaceNumber when that PID is detected.
                     device_config.product_id = ProductId::Generic;
+                }
+                "MSI Claw" => {
+                    device_config.vendor = "MSI".to_string();
+                    device_config.name = "Claw Controller".to_string();
+                    device_config.product_id = ProductId::MsiClaw;
+                }
+                "MSI Claw 7 AI+ A2VM" => {
+                    device_config.vendor = "MSI".to_string();
+                    device_config.name = "Claw Controller".to_string();
+                    device_config.product_id = ProductId::MsiClaw;
+                }
+                "MSI Claw 8 AI+ A2VM" => {
+                    device_config.vendor = "MSI".to_string();
+                    device_config.name = "Claw Controller".to_string();
+                    device_config.product_id = ProductId::MsiClaw;
+                }
+                "MSI Claw A8 BZ2EM" => {
+                    device_config.vendor = "MSI".to_string();
+                    device_config.name = "Claw Controller".to_string();
+                    device_config.product_id = ProductId::MsiClaw;
                 }
                 _ => {}
             };


### PR DESCRIPTION
- Add PID for Legion Go 2
- Move PID list from target to driver mod. That seems like a more appropriate location as it is shared among multiple target devices.
- Move VID to mod as well.
- De-duplicate VID and PID references.