### PR TITLE
feat(CapabilityMap): add config for inverting axis values

### DIFF
--- a/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+++ b/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
@@ -67,6 +67,7 @@
       "type": "object",
       "properties": {
         "deadzone": {
+          "description": "A value from 0.0-1.0 of how far an axis should be pressed in a particular direction\nin order for it to be considered \"pressed\"",
           "type": [
             "number",
             "null"
@@ -74,13 +75,28 @@
           "format": "double"
         },
         "direction": {
+          "description": "Direction of the axis to translate. Can be one of [\"vertical\", \"horizontal\", \"left\",\n\"right\", \"up\", \"down\"].",
           "type": [
             "string",
             "null"
           ]
         },
+        "invert": {
+          "description": "Invert all values of this axis with the matching direction",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "name": {
           "type": "string"
+        },
+        "quadratic_scaling": {
+          "description": "Use quadratic scaling for more precise control with small stick movements",
+          "type": [
+            "boolean",
+            "null"
+          ]
         }
       },
       "required": [

--- a/src/config/capability_map.rs
+++ b/src/config/capability_map.rs
@@ -222,12 +222,20 @@ pub struct GamepadCapability {
 #[serde(rename_all = "snake_case")]
 pub struct AxisCapability {
     pub name: String,
+    /// Direction of the axis to translate. Can be one of ["vertical", "horizontal", "left",
+    /// "right", "up", "down"].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub direction: Option<String>,
+    /// A value from 0.0-1.0 of how far an axis should be pressed in a particular direction
+    /// in order for it to be considered "pressed"
     #[serde(skip_serializing_if = "Option::is_none")]
     pub deadzone: Option<f64>,
+    /// Use quadratic scaling for more precise control with small stick movements
     #[serde(skip_serializing_if = "Option::is_none")]
     pub quadratic_scaling: Option<bool>,
+    /// Invert all values of this axis with the matching direction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invert: Option<bool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]


### PR DESCRIPTION
This change adds a new `inverse` option for axes, which can allow a user to invert the axis value of a matching direction.

E.g.

```yaml
mapping:
  - name: Invert left stick vertical
    source_events:
      - gamepad:
          axis:
            name: LeftStick
    target_event:
      gamepad:
        axis:
          name: LeftStick
          direction: vertical
          invert: true
```

Fixes #532