### PR TITLE
fix(Target): re-add starting deck device after receiving config

### DIFF
--- a/src/input/target/steam_deck.rs
+++ b/src/input/target/steam_deck.rs
@@ -1062,7 +1062,8 @@ impl TargetOutputDevice for SteamDeckDevice {
                     TryRecvError::Disconnected => self.config.clone(),
                 },
             };
-            let device = SteamDeckDevice::create_virtual_device(&config)?;
+            let mut device = SteamDeckDevice::create_virtual_device(&config)?;
+            device.start()?;
             self.device = Some(device);
             self.config = config;
             self.config_rx = None;


### PR DESCRIPTION
This change fixes a regression introduced in v0.74.0 where `device.start()` was not added after initialization was refactored.

Fixes #531