### PR TITLE
fix(NixOS): check nix paths for binaries in udev hiding rules

### DIFF
--- a/src/udev/mod.rs
+++ b/src/udev/mod.rs
@@ -50,8 +50,14 @@ pub async fn hide_device(path: &str, flags: &[HideFlag]) -> Result<(), Box<dyn E
             "/bin/chmod".to_string()
         } else if Path::new("/usr/bin/chmod").exists() {
             "/usr/bin/chmod".to_string()
+        } else if Path::new("/run/current-system/sw/bin/chmod").exists() {
+            "/run/current-system/sw/bin/chmod".to_string()
         } else {
-            let output = Command::new("which").arg("chmod").output().await?;
+            let output = Command::new("sh")
+                .arg("-c")
+                .arg("which chmod")
+                .output()
+                .await?;
             if !output.status.success() {
                 return Err("Unable to determine chmod command location".into());
             }
@@ -83,8 +89,14 @@ KERNEL=="hidraw[0-9]*", SUBSYSTEM=="{subsystem}", MODE="000", GROUP="root", TAG-
             "/bin/mv".to_string()
         } else if Path::new("/usr/bin/mv").exists() {
             "/usr/bin/mv".to_string()
+        } else if Path::new("/run/current-system/sw/bin/mv").exists() {
+            "/run/current-system/sw/bin/mv".to_string()
         } else {
-            let output = Command::new("which").arg("mv").output().await?;
+            let output = Command::new("sh")
+                .arg("-c")
+                .arg("which mv")
+                .output()
+                .await?;
             if !output.status.success() {
                 return Err("Unable to determine mv command location".into());
             }


### PR DESCRIPTION
Since adding the devnode moving logic, inputplumber would fail in finding the correct binary paths for `chmod` and `mv`. This change fixes that by checking for the binaries in NixOS paths. Otherwise it will try to use the `which` built-in shell command to discover the path.

``` 
WARN  inputplumber::input::composite_device] Failed to hide device '/dev/input/event4': Os { code: 2, kind: NotFound }
```