### PR TITLE
Feat: Support QA button for switch pro controller and pass through LT/RT correctly

### DIFF
--- a/src/input/event/evdev.rs
+++ b/src/input/event/evdev.rs
@@ -159,6 +159,12 @@ impl EvdevEvent {
                 KeyCode::BTN_EAST => Capability::Gamepad(Gamepad::Button(GamepadButton::East)),
                 KeyCode::BTN_TL => Capability::Gamepad(Gamepad::Button(GamepadButton::LeftBumper)),
                 KeyCode::BTN_TR => Capability::Gamepad(Gamepad::Button(GamepadButton::RightBumper)),
+                KeyCode::BTN_TL2 => {
+                    Capability::Gamepad(Gamepad::Button(GamepadButton::LeftTrigger))
+                }
+                KeyCode::BTN_TR2 => {
+                    Capability::Gamepad(Gamepad::Button(GamepadButton::RightTrigger))
+                }
                 KeyCode::BTN_START => Capability::Gamepad(Gamepad::Button(GamepadButton::Start)),
                 KeyCode::BTN_SELECT => Capability::Gamepad(Gamepad::Button(GamepadButton::Select)),
                 KeyCode::BTN_MODE => Capability::Gamepad(Gamepad::Button(GamepadButton::Guide)),
@@ -186,6 +192,7 @@ impl EvdevEvent {
                 KeyCode::BTN_THUMBR => {
                     Capability::Gamepad(Gamepad::Button(GamepadButton::RightStick))
                 }
+                KeyCode::BTN_Z => Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)),
                 // Keyboard Buttons
                 KeyCode::KEY_0 => Capability::Keyboard(Keyboard::Key0),
                 KeyCode::KEY_1 => Capability::Keyboard(Keyboard::Key1),

--- a/src/input/source/led.rs
+++ b/src/input/source/led.rs
@@ -99,6 +99,6 @@ impl LedDevice {
 }
 /// Returns the DBus path for an [LedDevice] from a device id (E.g. leds://input7__numlock)
 pub fn get_dbus_path(id: String) -> String {
-    let name = id.replace(':', "_").replace("-", "_");
+    let name = id.replace([':', '-', '.'], "_");
     format!("{}/{}", BUS_SOURCES_PREFIX, name)
 }


### PR DESCRIPTION
The switch pro controller LT/RT weren't working in Pass intercept mode due to a missing mapping, and QA button as well needed to be mapped

There is also a minor fix regarding an error loading the controller's LEDs which contain invalid characters that can't be used in dbus path