### PR TITLE
feat: use vendor_id and product_id to match switch pro controllers via bluetooth as well

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/60-switch_pro.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-switch_pro.yaml
@@ -21,7 +21,9 @@ matches: []
 source_devices:
   - group: gamepad
     evdev:
-      name: Nintendo Co., Ltd. Pro Controller
+      vendor_id: "057e"
+      product_id: "2009"
+      name: "*Pro Controller"
       handler: event*
   #- group: imu
   #  evdev:


### PR DESCRIPTION
I found that when connected via bluetooth, my switch pro controller is listed as "Pro Controller" instead of the full name, thus matching a generic device profile instead of the specific one.

This change works, but I would like to have feedback if this is the best way to go about it.. we could also match on name "*Pro Controller", but I don't know if there are other controllers which would conflict in terms of naming