### PR TITLE
fix: add environment variable to disable polkit auth

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -269,6 +269,7 @@ is the current list of environment variables that are used:
 | `LOG_LEVEL` | info | Log level to use. Can be one of: 'error', 'warn', 'info', 'debug', 'trace' |
 | `HIDE_DEVICES_FROM_ROOT` | 0 | Try to hide the device from elevated processes by moving the device node to `/dev/inputplumber/sources`. |
 | `ENABLE_METRICS` | 0 | Enable input latency monitoring (debug builds only). Metrics can be viewed with `inputplumber device <id> target monitor <target>`. |
+| `INSECURE_DISABLE_POLKIT` | 0 | Disable polkit authorization (NOT RECOMMENDED) |
 
 
 ### Troubleshooting

--- a/src/dbus/polkit.rs
+++ b/src/dbus/polkit.rs
@@ -1,12 +1,28 @@
 use std::collections::HashMap;
+use std::env;
+use std::sync::LazyLock;
 use zbus::zvariant::{OwnedValue, Value};
 use zbus::{fdo, message::Header, Connection, Proxy};
+
+/// Whether or not polkit should be used for action authorization.
+static POLKIT_DISABLED: LazyLock<bool> = LazyLock::new(|| {
+    let is_disabled = env::var("INSECURE_DISABLE_POLKIT")
+        .map(|v| v.as_str() == "1" || v.as_str().to_lowercase() == "true")
+        .unwrap_or(false);
+    if is_disabled {
+        log::warn!("Running without polkit authorization");
+    }
+    is_disabled
+});
 
 pub async fn check_polkit(
     connection: &Connection,
     hdr: Option<Header<'_>>,
     action_id: &str,
 ) -> fdo::Result<()> {
+    if *POLKIT_DISABLED {
+        return Ok(());
+    }
     let Some(hdr) = hdr else {
         return Ok(());
     };


### PR DESCRIPTION
Adds the `INSECURE_DISABLE_POLKIT` environment variable that can allow users who are ok with the security implications to disable polkit authorization (not typically recommended)