### PR TITLE
Add support for GPD Win Mini 2024 (8840U / G1617-01)

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
@@ -25,7 +25,7 @@ source_devices:
   - group: gamepad
     evdev:
       name: "Microsoft X-Box 360 pad"
-      phys_path: usb-0000:63:00.3-5/input0
+      phys_path: "{usb-0000:63:00.3-5/input0,usb-0000:c3:00.3-5/input0}"
       handler: event*
   - group: keyboard
     hidraw:

--- a/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
@@ -11,49 +11,44 @@ name: GPD WinMini
 # Only allow a single source device per composite device of this type.
 single_source: false
 
-# Matches: We explicitly define both the 2023 (7840U) and 2024 (8840U) 
-# DMI product names so this profile universally applies to both generations.
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
 matches:
   - dmi_data:
       product_name: G1617-01
       sys_vendor: GPD
-  - dmi_data:
-      product_name: G1617-02
-      sys_vendor: GPD
 
-# Source Devices: The raw hardware inputs InputPlumber will grab and manage.
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
 source_devices:
   - group: gamepad
     evdev:
       name: "Microsoft X-Box 360 pad"
-      # We use an array {63,c3} to support the different internal USB PCI bus 
-      # routing used by the 2023 and 2024 AMD motherboards respectively.
-      phys_path: "{usb-0000:63:00.3-5/input0,usb-0000:c3:00.3-5/input0}"
+      phys_path: usb-0000:63:00.3-5/input0
       handler: event*
-      
-  # This hidraw node handles the physical L4 and R4 macro back-buttons. 
-  # (Requires Rust driver debounce logic for the 2024 0x6f/0x70 hex codes).
   - group: keyboard
     hidraw:
       vendor_id: 0x2f24
       product_id: 0x0135
       interface_num: 1
-      
-  # The macro keyboard generates phantom Windows mouse events. 
-  # We block them here so they don't interfere with the real mouse.
   - group: keyboard
     blocked: true
     evdev:
       name: "  Mouse for Windows"
-      phys_path: "{usb-0000:63:00.3-3/input1,usb-0000:c3:00.3-3/input1}"
+      phys_path: usb-0000:63:00.3-3/input1
       handler: event*
-      
-  # NOTE: The physical Touchpad (group: mouse) has been intentionally omitted!
-  # By hiding the touchpad from InputPlumber, Linux handles it natively. 
-  # This preserves multi-touch gestures and prevents Steam from hijacking 
-  # the touchpad and turning it into a joystick.
-      
-  # The internal Gyroscope for motion controls.
+  - group: mouse
+    hidraw:
+      vendor_id: 0x093A
+      product_id: 0x0255
+      interface_num: 0
+  - group: mouse
+    unique: false
+    blocked: true
+    evdev:
+      name: "{HTIX5288:00 093A:0255 Mouse,HTIX5288:00 093A:0255 Touchpad}"
+      handler: event*
   - group: imu
     iio:
       name: "{i2c-BMI0160:00,bmi260}"
@@ -64,19 +59,17 @@ source_devices:
 
 # Optional configuration for the composite device
 options:
-  # If true, InputPlumber will automatically try to manage the input device. 
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
   auto_manage: true
 
-# The fallback target device to emulate. 
-# NOTE: If steamos-manager is running, it will dynamically override this 
-# to 'ds5-edge' (DualSense Edge) via ~/.config/steamos-manager/config.toml
+# The target input device(s) to emulate by default
 target_devices:
   - xbox-elite
   - mouse
   - keyboard
   - touchpad
 
-# The capability map that dictates how buttons are translated.
-# We edited this map locally to free R4 from 'QuickAccess' so it acts 
-# as a standard RightPaddle1 in Steam.
+# The ID of a device event mapping in the 'event_maps' folder
 capability_map_id: gpd3

--- a/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml
@@ -11,44 +11,49 @@ name: GPD WinMini
 # Only allow a single source device per composite device of this type.
 single_source: false
 
-# Only use this profile if *any* of the given matches matches. If this list is
-# empty, then the source devices will *always* be checked.
-# /sys/class/dmi/id/product_name
+# Matches: We explicitly define both the 2023 (7840U) and 2024 (8840U) 
+# DMI product names so this profile universally applies to both generations.
 matches:
   - dmi_data:
       product_name: G1617-01
       sys_vendor: GPD
+  - dmi_data:
+      product_name: G1617-02
+      sys_vendor: GPD
 
-# One or more source devices to combine into a single virtual device. The events
-# from these devices will be watched and translated according to the key map.
+# Source Devices: The raw hardware inputs InputPlumber will grab and manage.
 source_devices:
   - group: gamepad
     evdev:
       name: "Microsoft X-Box 360 pad"
-      phys_path: usb-0000:63:00.3-5/input0
+      # We use an array {63,c3} to support the different internal USB PCI bus 
+      # routing used by the 2023 and 2024 AMD motherboards respectively.
+      phys_path: "{usb-0000:63:00.3-5/input0,usb-0000:c3:00.3-5/input0}"
       handler: event*
+      
+  # This hidraw node handles the physical L4 and R4 macro back-buttons. 
+  # (Requires Rust driver debounce logic for the 2024 0x6f/0x70 hex codes).
   - group: keyboard
     hidraw:
       vendor_id: 0x2f24
       product_id: 0x0135
       interface_num: 1
+      
+  # The macro keyboard generates phantom Windows mouse events. 
+  # We block them here so they don't interfere with the real mouse.
   - group: keyboard
     blocked: true
     evdev:
       name: "  Mouse for Windows"
-      phys_path: usb-0000:63:00.3-3/input1
+      phys_path: "{usb-0000:63:00.3-3/input1,usb-0000:c3:00.3-3/input1}"
       handler: event*
-  - group: mouse
-    hidraw:
-      vendor_id: 0x093A
-      product_id: 0x0255
-      interface_num: 0
-  - group: mouse
-    unique: false
-    blocked: true
-    evdev:
-      name: "{HTIX5288:00 093A:0255 Mouse,HTIX5288:00 093A:0255 Touchpad}"
-      handler: event*
+      
+  # NOTE: The physical Touchpad (group: mouse) has been intentionally omitted!
+  # By hiding the touchpad from InputPlumber, Linux handles it natively. 
+  # This preserves multi-touch gestures and prevents Steam from hijacking 
+  # the touchpad and turning it into a joystick.
+      
+  # The internal Gyroscope for motion controls.
   - group: imu
     iio:
       name: "{i2c-BMI0160:00,bmi260}"
@@ -59,17 +64,19 @@ source_devices:
 
 # Optional configuration for the composite device
 options:
-  # If true, InputPlumber will automatically try to manage the input device. If
-  # this is false, InputPlumber will not try to manage the device unless an
-  # external service enables management of the device. Defaults to 'false'
+  # If true, InputPlumber will automatically try to manage the input device. 
   auto_manage: true
 
-# The target input device(s) to emulate by default
+# The fallback target device to emulate. 
+# NOTE: If steamos-manager is running, it will dynamically override this 
+# to 'ds5-edge' (DualSense Edge) via ~/.config/steamos-manager/config.toml
 target_devices:
   - xbox-elite
   - mouse
   - keyboard
   - touchpad
 
-# The ID of a device event mapping in the 'event_maps' folder
+# The capability map that dictates how buttons are translated.
+# We edited this map locally to free R4 from 'QuickAccess' so it acts 
+# as a standard RightPaddle1 in Steam.
 capability_map_id: gpd3

--- a/src/drivers/gpd_win_mini/macro_keyboard_driver.rs
+++ b/src/drivers/gpd_win_mini/macro_keyboard_driver.rs
@@ -16,12 +16,8 @@ pub const IID: i32 = 0x01;
 
 const RELEASE_DELAY: Duration = Duration::from_millis(40);
 
-const L4_CODES: &[u8] = &[0x46, 0x6f];
-const R4_CODES: &[u8] = &[0x48, 0x70];
-
-fn report_has_any_key(report: &MacroKeyboardDataReport, codes: &[u8]) -> bool {
-    codes.iter().any(|code| report.has_key(*code))
-}
+pub const L4_CODE: u8 = 0x46;
+pub const R4_CODE: u8 = 0x48;
 
 // Input report size
 const KEYBOARD_PACKET_SIZE: usize = 8;
@@ -147,7 +143,7 @@ impl MacroKeyboardDriver {
             return events;
         };
 
-        if report_has_any_key(&state, L4_CODES) {
+        if state.has_key(L4_CODE) {
             self.l4_last_pressed = Instant::now();
             if !self.l4_pressed {
                 log::trace!("Started L4 event");
@@ -158,7 +154,7 @@ impl MacroKeyboardDriver {
             }
         }
 
-        if report_has_any_key(&state, R4_CODES) {
+        if state.has_key(R4_CODE) {
             self.r4_last_pressed = Instant::now();
             if !self.r4_pressed {
                 log::trace!("Started R4 event");

--- a/src/drivers/gpd_win_mini/macro_keyboard_driver.rs
+++ b/src/drivers/gpd_win_mini/macro_keyboard_driver.rs
@@ -16,8 +16,12 @@ pub const IID: i32 = 0x01;
 
 const RELEASE_DELAY: Duration = Duration::from_millis(40);
 
-pub const L4_CODE: u8 = 0x46;
-pub const R4_CODE: u8 = 0x48;
+const L4_CODES: &[u8] = &[0x46, 0x6f];
+const R4_CODES: &[u8] = &[0x48, 0x70];
+
+fn report_has_any_key(report: &MacroKeyboardDataReport, codes: &[u8]) -> bool {
+    codes.iter().any(|code| report.has_key(*code))
+}
 
 // Input report size
 const KEYBOARD_PACKET_SIZE: usize = 8;
@@ -143,7 +147,7 @@ impl MacroKeyboardDriver {
             return events;
         };
 
-        if state.has_key(L4_CODE) {
+        if report_has_any_key(&state, L4_CODES) {
             self.l4_last_pressed = Instant::now();
             if !self.l4_pressed {
                 log::trace!("Started L4 event");
@@ -154,7 +158,7 @@ impl MacroKeyboardDriver {
             }
         }
 
-        if state.has_key(R4_CODE) {
+        if report_has_any_key(&state, R4_CODES) {
             self.r4_last_pressed = Instant::now();
             if !self.r4_pressed {
                 log::trace!("Started R4 event");


### PR DESCRIPTION
NOTE: This PR add additional support for 2024 model while keep the same compability with older model which Inputplumber already supported. Some GPD Win Mini 2024 can also name G1617-01 duplicated with 2023/2022 version

Description of Changes:
This PR introduces full hardware support for the 2024 iteration of the GPD Win Mini (8840U), fixing issues where the controller was not properly grabbed and the L4/R4 back buttons were entirely unresponsive due to changed hardware hex codes.

1. Rust Driver Updates (src/drivers/gpd_win_mini/macro_keyboard_driver.rs)

The Bug: The 2024 model (G1617-02) uses completely different hex codes for the L4 and R4 macro keys than the 2023 model.

The Fix: * Refactored the single L4_CODE (0x46) and R4_CODE (0x48) constants into arrays to support both generations.

Added the discovered 2024 hardware codes: L4 = 0x6f, R4 = 0x70.

Created a report_has_any_key helper function to check the report against the new code arrays.

Updated the press state checks so the software debounce logic now successfully catches and holds the macro pulses for both the 2023 and 2024 models.

2. YAML Profile Updates (rootfs/usr/share/inputplumber/devices/50-gpd_winmini.yaml)

DMI Matching: Added G1617-02 (the 2024 model) to the product_name match list.

PCI Routing: Updated the phys_path definitions for the Xbox pad and Windows Mouse to use an array {usb-0000:63...,usb-0000:c3...}. The 2024 AMD motherboard routes through c3 instead of the 2023's 63, which previously caused InputPlumber to drop the physical controller and crash when steamos-manager requested the ds5-edge profile.

3. Notes for the Maintainers (Optional / Discussion):

Touchpad Handling: We found that completely omitting the group: mouse blocks from the YAML allows Linux to handle the touchpad natively. When InputPlumber grabs it and virtualizes it into the ds5-edge profile, Steam's default behavior hijacks the PS5 touchpad and turns it into a Right Joystick, breaking native desktop navigation.

R4 Capability Map: We locally overrode gpd_type3.yaml to change R4 from QuickAccess to RightPaddle1. The default QuickAccess mapping prevents users from mapping R4 as a standard gameplay paddle in Steam's Controller Settings.