### PR TITLE
feat(iio): add InvenSense ICM42xxx IMU support

### DIFF
--- a/src/input/source/iio.rs
+++ b/src/input/source/iio.rs
@@ -115,15 +115,15 @@ impl IioDevice {
         let device_name = device.name();
         let name = device_name.as_str();
         log::debug!("Finding driver for IIO interface: {name}");
-        // BMI_IMU
-        if glob_match("{i2c-10EC5280*,i2c-BOSC*,i2c-BMI*,bmi*-imu,bmi260}", name) {
-            log::info!("Detected BMI IMU");
+        // BMI_IMU (Bosch BMI160/260/323 and InvenSense ICM42xxx)
+        if glob_match("{i2c-10EC5280*,i2c-BOSC*,i2c-BMI*,bmi*-imu,bmi260,icm4*}", name) {
+            log::info!("Detected IMU: {name}");
             return DriverType::BmiImu;
         }
 
-        // AccelGryo3D
+        // AccelGryo3D (Windows-style HID sensor proxies)
         if glob_match("{gyro_3d,accel_3d}", name) {
-            log::info!("Detected Legion Go");
+            log::info!("Detected AccelGyro3D: {name}");
             return DriverType::AccelGryo3D;
         }
         log::debug!("No driver found for IIO Interface: {name}");


### PR DESCRIPTION
Add `icm4*` glob pattern to the IIO driver matching in get_driver_type() to support InvenSense ICM-42607P IMUs.

The ICM-42607P is found in the Anbernic RG DS (RK3568) handheld and uses the mainline `inv_icm42600` kernel driver, which creates IIO devices named `icm42607p-gyro` and `icm42607p-accel`. These names did not match any existing pattern, causing InputPlumber to log "No driver for iio interface found" and skip the IMU.

The ICM42607P exposes the same IIO channel structure as the BMI IMUs (in_anglvel_x/y/z for gyro, in_accel_x/y/z for accelerometer), so the existing BmiImu driver works without modification.

Kernel support for the ICM-42607P was added via Marco Morgan's LKML patch series "iio: add support for ICM-42607-P" which extends the inv_icm42600 driver with alternate register definitions for the ICM-42607 variant:
  https://lore.kernel.org/linux-iio/

Tested on: Anbernic RG DS (Rockchip RK3568, ICM-42607P on I2C bus 2 at 0x68) running ROCKNIX with Linux 7.0-rc4 and InputPlumber v0.75.2. The composite device config targets DualSense (ds5) to expose motion data via the SDL GameController sensor API for 3DS emulation (Azahar).