### PR TITLE
fix(Hardware Support): Fix rare double input bug on Legion devices

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
@@ -75,6 +75,7 @@ source_devices:
   ## XInput - Connected 0x6182 (Go PID)
   # Gamepad
   - group: gamepad
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x6182
@@ -83,6 +84,7 @@ source_devices:
   ## XInput - Connected 0x61eb (Go 2 PID)
   # Gamepad
   - group: gamepad
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x61eb
@@ -91,11 +93,13 @@ source_devices:
   ## DInput - Attached 0x6183 (Go PID)
   # Gamepad
   - group: gamepad # Dinput report
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x6183
       interface_num: 0
   - group: gamepad # XInput report 40Hz
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x6183
@@ -104,11 +108,13 @@ source_devices:
   ## DInput - Attached 0x61ec (Go 2 PID)
   # Gamepad
   - group: gamepad # Dinput report
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x61ec
       interface_num: 0
   - group: gamepad # XInput report 40Hz
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x61ec
@@ -117,6 +123,7 @@ source_devices:
   ## DInput - Detached 0x6184 (Go PID)
   # Gamepad
   - group: gamepad
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x6184
@@ -125,6 +132,7 @@ source_devices:
   ## DInput - Detached 0x61ed (Go 2 PID)
   # Gamepad
   - group: gamepad
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x61ed
@@ -133,6 +141,7 @@ source_devices:
   ## FPS Mode - 0x6185 (Go PID)
   # Gamepad
   - group: gamepad
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x6185
@@ -141,6 +150,7 @@ source_devices:
   ## FPS Mode - 0x61ee (Go 2 PID)
   # Gamepad
   - group: gamepad
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x61ee

--- a/rootfs/usr/share/inputplumber/devices/50-legion_go_2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go_2.yaml
@@ -75,6 +75,7 @@ source_devices:
   ## XInput - Connected 0x61eb (Go 2 PID)
   # Gamepad
   - group: gamepad
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x61eb
@@ -83,11 +84,13 @@ source_devices:
   ## DInput - Attached 0x61ec (Go 2 PID)
   # Gamepad
   - group: gamepad # Dinput report
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x61ec
       interface_num: 0
   - group: gamepad # XInput report 40Hz
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x61ec
@@ -96,6 +99,7 @@ source_devices:
   ## DInput - Detached 0x61ed (Go 2 PID)
   # Gamepad
   - group: gamepad
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x61ed
@@ -104,6 +108,7 @@ source_devices:
   ## FPS Mode - 0x61ee (Go 2 PID)
   # Gamepad
   - group: gamepad
+    unique: false
     hidraw:
       vendor_id: 0x17ef
       product_id: 0x61ee


### PR DESCRIPTION
A somewhat rare event is described in #562 where the entire /dev directory seems to reset during startup after InputPlumber has already started gathering devices. During this event it is possible for the 'new' hidraw file descriptor for an already grabbed hidraw device to be detected before the cleanup has finished for that device. When this happens all of the evdev and iio devices end up on the original CompositeDevice and the hidraw all end up on a new composite device. This leads to duplicate device entries and input events.

To resolve this until a better long-term solution is found, treat the hidraw devices as non-unique for now.