### PR TITLE
fix(iio): improve AccelGyro3d driver for HID Sensor Hub devices

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -392,6 +392,9 @@ pub struct IIO {
     pub id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
+    /// Desired sampling rate in Hz.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sample_rate: Option<f64>,
     #[deprecated(
         since = "0.43.0",
         note = "please use `<SourceDevice>.config.imu.mount_matrix` instead"

--- a/src/drivers/iio_imu/driver.rs
+++ b/src/drivers/iio_imu/driver.rs
@@ -91,11 +91,17 @@ impl Driver {
             }
         }
 
-        if !accel.is_empty() {
-            set_sample_rate(&device, &accel, ChannelType::Accel, sample_rate);
-        }
-        if !gyro.is_empty() {
-            set_sample_rate(&device, &gyro, ChannelType::AnglVel, sample_rate);
+        // Request a higher sampling rate
+        for (channels, ch_type) in [(&accel, ChannelType::Accel), (&gyro, ChannelType::AnglVel)] {
+            if channels.is_empty() {
+                continue;
+            }
+            if let Err(err) =
+                set_sample_rate_or_default(&device, channels, ch_type, sample_rate)
+            {
+                log::warn!("Failed to set sample rate: {err}, falling back to max available");
+                set_sample_rate_max(&device, channels, ch_type);
+            }
         }
 
         Ok(Self {
@@ -361,71 +367,106 @@ fn is_driver_loaded(driver_name: &str) -> io::Result<bool> {
     Ok(false)
 }
 
-fn set_sample_rate(
+/// Try to set a specific or default sampling rate. Returns Err if the
+/// requested rate is not in the hardware's available list.
+fn set_sample_rate_or_default(
     device: &Device,
     channels: &HashMap<String, Channel>,
     channel_type: ChannelType,
     target_rate: Option<f64>,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let rate = target_rate.unwrap_or(DEFAULT_SAMPLE_RATE);
+    let avail = read_sample_rates_available(device, channels, &channel_type);
+
+    if !avail.is_empty() && !avail.contains(&rate) {
+        return Err(format!(
+            "Requested {rate} Hz not in available rates: {avail:?}"
+        )
+        .into());
+    }
+
+    write_sample_rate(device, channels, channel_type, rate)
+}
+
+/// Set sampling rate to the maximum reported by the hardware.
+/// Falls back to DEFAULT_SAMPLE_RATE if no available rates are reported.
+fn set_sample_rate_max(
+    device: &Device,
+    channels: &HashMap<String, Channel>,
+    channel_type: ChannelType,
 ) {
-    let rate = if let Some(r) = target_rate {
-        log::debug!("Using configured sample rate: {r} Hz");
-        r
+    let avail = read_sample_rates_available(device, channels, &channel_type);
+    let rate = if avail.is_empty() {
+        log::warn!(
+            "No available sample rates reported, using default {DEFAULT_SAMPLE_RATE} Hz"
+        );
+        DEFAULT_SAMPLE_RATE
     } else {
-        let avail = read_sample_rates_available(device, channels, &channel_type);
-        if !avail.is_empty() {
-            let max = avail.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-            log::debug!("Using max available sample rate: {max} Hz");
-            max
-        } else {
-            log::debug!("No available rates found, using default: {DEFAULT_SAMPLE_RATE} Hz");
-            DEFAULT_SAMPLE_RATE
-        }
+        let max = avail.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        log::info!("Using max available sample rate: {max} Hz");
+        max
     };
 
-    // per-channel attribute
+    if let Err(err) = write_sample_rate(device, channels, channel_type, rate) {
+        log::warn!("Failed to set max sample rate: {err}");
+    }
+}
+
+/// Write a sampling rate to the device. Tries per-channel first (BMI-style),
+/// then falls back to device-level attribute (HID Sensor Hub).
+fn write_sample_rate(
+    device: &Device,
+    channels: &HashMap<String, Channel>,
+    channel_type: ChannelType,
+    rate: f64,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
     for (id, channel) in channels.iter() {
         match channel.attr_write_float("sampling_frequency", rate) {
             Ok(_) => {
-                let actual = channel
-                    .attr_read_float("sampling_frequency")
-                    .unwrap_or(rate);
-                log::debug!("Set sampling_frequency to {actual} Hz via channel {id}");
-                return;
+                match channel.attr_read_float("sampling_frequency") {
+                    Ok(actual) => {
+                        log::info!("Set sampling_frequency to {actual} Hz via channel {id}")
+                    }
+                    Err(err) => log::warn!(
+                        "Set sampling_frequency for {id} but read-back failed: {err}, assuming {rate} Hz"
+                    ),
+                }
+                return Ok(());
             }
-            Err(e) => {
-                log::debug!(
-                    "Per-channel sampling_frequency write failed for {id}: {e:?}, trying device-level"
+            Err(err) => {
+                log::warn!(
+                    "Per-channel sampling_frequency write failed for {id}: {err}"
                 );
             }
         }
     }
 
-    // device-level fallback
     let attr = match channel_type {
         ChannelType::Accel => "in_accel_sampling_frequency",
         ChannelType::AnglVel => "in_anglvel_sampling_frequency",
-        _ => return,
+        _ => return Err("Unknown channel type".into()),
     };
 
-    match device.attr_write_float(attr, rate) {
-        Ok(_) => {
-            let actual = device.attr_read_float(attr).unwrap_or(rate);
-            log::info!("Set device-level {attr} to {actual} Hz");
-        }
-        Err(e) => {
-            log::warn!("Failed to set {attr}: {e:?}");
-        }
+    device.attr_write_float(attr, rate)?;
+    match device.attr_read_float(attr) {
+        Ok(actual) => log::info!("Set device-level {attr} to {actual} Hz"),
+        Err(err) => log::warn!(
+            "Set {attr} but read-back failed: {err}, assuming {rate} Hz"
+        ),
     }
+    Ok(())
 }
 
+/// Read the list of supported sampling rates from the hardware.
+/// Tries per-channel attribute first, then device-level global attribute.
 fn read_sample_rates_available(
     device: &Device,
     channels: &HashMap<String, Channel>,
     channel_type: &ChannelType,
 ) -> Vec<f64> {
     for (_, channel) in channels.iter() {
-        if let Ok(v) = channel.attr_read_str("sampling_frequency_available") {
-            let rates: Vec<f64> = v
+        if let Ok(val) = channel.attr_read_str("sampling_frequency_available") {
+            let rates: Vec<f64> = val
                 .split_whitespace()
                 .filter_map(|s| s.parse().ok())
                 .collect();
@@ -441,8 +482,8 @@ fn read_sample_rates_available(
         _ => return vec![],
     };
 
-    if let Ok(v) = device.attr_read_str(attr) {
-        let rates: Vec<f64> = v
+    if let Ok(val) = device.attr_read_str(attr) {
+        let rates: Vec<f64> = val
             .split_whitespace()
             .filter_map(|s| s.parse().ok())
             .collect();

--- a/src/drivers/iio_imu/driver.rs
+++ b/src/drivers/iio_imu/driver.rs
@@ -113,14 +113,6 @@ impl Driver {
     //a standalone crate. When this driver is eventually separated, refactor the Event type to
     //follow the pattern DeviceEvent(Event, Value) and create a match table for
     //Capability->Event/Event->Capability in the SourceDriver implementation.
-    pub fn has_accel(&self) -> bool {
-        !self.accel.is_empty()
-    }
-
-    pub fn has_gyro(&self) -> bool {
-        !self.gyro.is_empty()
-    }
-
     pub fn update_filtered_events(&mut self, events: HashSet<Capability>) {
         self.filtered_events = events;
     }

--- a/src/drivers/iio_imu/driver.rs
+++ b/src/drivers/iio_imu/driver.rs
@@ -19,6 +19,7 @@ use super::{
 
 /// Driver for reading IIO IMU data
 pub struct Driver {
+    _device: Device, // must outlive Channel raw pointers
     mount_matrix: MountMatrix,
     accel: HashMap<String, Channel>,
     accel_info: HashMap<String, AxisInfo>,
@@ -87,9 +88,8 @@ impl Driver {
             }
         }
 
-        // Calculate the initial sample delay
-
         Ok(Self {
+            _device: device,
             mount_matrix,
             accel,
             accel_info,
@@ -103,6 +103,14 @@ impl Driver {
     //a standalone crate. When this driver is eventually separated, refactor the Event type to
     //follow the pattern DeviceEvent(Event, Value) and create a match table for
     //Capability->Event/Event->Capability in the SourceDriver implementation.
+    pub fn has_accel(&self) -> bool {
+        !self.accel.is_empty()
+    }
+
+    pub fn has_gyro(&self) -> bool {
+        !self.gyro.is_empty()
+    }
+
     pub fn update_filtered_events(&mut self, events: HashSet<Capability>) {
         self.filtered_events = events;
     }
@@ -158,6 +166,10 @@ impl Driver {
 
     /// Polls all the channels from the accelerometer
     fn poll_accel(&self) -> Result<Option<Event>, Box<dyn Error + Send + Sync>> {
+        if self.accel.is_empty() {
+            return Ok(None);
+        }
+
         // Read from each accel channel
         let mut accel_input = AxisData::default();
         for (id, channel) in self.accel.iter() {
@@ -186,7 +198,10 @@ impl Driver {
 
     /// Polls all the channels from the gyro
     fn poll_gyro(&self) -> Result<Option<Event>, Box<dyn Error + Send + Sync>> {
-        // Read from each accel channel
+        if self.gyro.is_empty() {
+            return Ok(None);
+        }
+
         let mut gyro_input = AxisData::default();
         for (id, channel) in self.gyro.iter() {
             // Get the info for the axis and read the data

--- a/src/drivers/iio_imu/driver.rs
+++ b/src/drivers/iio_imu/driver.rs
@@ -17,6 +17,8 @@ use super::{
     info::AxisInfo,
 };
 
+const DEFAULT_SAMPLE_RATE: f64 = 200.0;
+
 /// Driver for reading IIO IMU data
 pub struct Driver {
     _device: Device, // must outlive Channel raw pointers
@@ -34,6 +36,7 @@ impl Driver {
         id: String,
         name: String,
         matrix: Option<MountMatrix>,
+        sample_rate: Option<f64>,
     ) -> Result<Self, Box<dyn Error + Send + Sync>> {
         log::debug!("Creating IIO IMU driver instance for {name}");
 
@@ -86,6 +89,13 @@ impl Driver {
             for attr in channel.attrs() {
                 log::trace!("  Found attribute: {:?}", attr);
             }
+        }
+
+        if !accel.is_empty() {
+            set_sample_rate(&device, &accel, ChannelType::Accel, sample_rate);
+        }
+        if !gyro.is_empty() {
+            set_sample_rate(&device, &gyro, ChannelType::AnglVel, sample_rate);
         }
 
         Ok(Self {
@@ -357,4 +367,97 @@ fn is_driver_loaded(driver_name: &str) -> io::Result<bool> {
         }
     }
     Ok(false)
+}
+
+fn set_sample_rate(
+    device: &Device,
+    channels: &HashMap<String, Channel>,
+    channel_type: ChannelType,
+    target_rate: Option<f64>,
+) {
+    let rate = if let Some(r) = target_rate {
+        log::debug!("Using configured sample rate: {r} Hz");
+        r
+    } else {
+        let avail = read_sample_rates_available(device, channels, &channel_type);
+        if !avail.is_empty() {
+            let max = avail.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            log::debug!("Using max available sample rate: {max} Hz");
+            max
+        } else {
+            log::debug!("No available rates found, using default: {DEFAULT_SAMPLE_RATE} Hz");
+            DEFAULT_SAMPLE_RATE
+        }
+    };
+
+    // per-channel attribute
+    for (id, channel) in channels.iter() {
+        match channel.attr_write_float("sampling_frequency", rate) {
+            Ok(_) => {
+                let actual = channel
+                    .attr_read_float("sampling_frequency")
+                    .unwrap_or(rate);
+                log::debug!("Set sampling_frequency to {actual} Hz via channel {id}");
+                return;
+            }
+            Err(e) => {
+                log::debug!(
+                    "Per-channel sampling_frequency write failed for {id}: {e:?}, trying device-level"
+                );
+            }
+        }
+    }
+
+    // device-level fallback
+    let attr = match channel_type {
+        ChannelType::Accel => "in_accel_sampling_frequency",
+        ChannelType::AnglVel => "in_anglvel_sampling_frequency",
+        _ => return,
+    };
+
+    match device.attr_write_float(attr, rate) {
+        Ok(_) => {
+            let actual = device.attr_read_float(attr).unwrap_or(rate);
+            log::info!("Set device-level {attr} to {actual} Hz");
+        }
+        Err(e) => {
+            log::warn!("Failed to set {attr}: {e:?}");
+        }
+    }
+}
+
+fn read_sample_rates_available(
+    device: &Device,
+    channels: &HashMap<String, Channel>,
+    channel_type: &ChannelType,
+) -> Vec<f64> {
+    for (_, channel) in channels.iter() {
+        if let Ok(v) = channel.attr_read_str("sampling_frequency_available") {
+            let rates: Vec<f64> = v
+                .split_whitespace()
+                .filter_map(|s| s.parse().ok())
+                .collect();
+            if !rates.is_empty() {
+                return rates;
+            }
+        }
+    }
+
+    let attr = match channel_type {
+        ChannelType::Accel => "in_accel_sampling_frequency_available",
+        ChannelType::AnglVel => "in_anglvel_sampling_frequency_available",
+        _ => return vec![],
+    };
+
+    if let Ok(v) = device.attr_read_str(attr) {
+        let rates: Vec<f64> = v
+            .split_whitespace()
+            .filter_map(|s| s.parse().ok())
+            .collect();
+        if !rates.is_empty() {
+            return rates;
+        }
+    }
+
+    vec![]
 }

--- a/src/input/source/iio.rs
+++ b/src/input/source/iio.rs
@@ -121,9 +121,8 @@ impl IioDevice {
             return DriverType::BmiImu;
         }
 
-        // AccelGryo3D (Windows-style HID sensor proxies)
         if glob_match("{gyro_3d,accel_3d}", name) {
-            log::info!("Detected AccelGyro3D: {name}");
+            log::info!("Detected HID Sensor Hub IMU: {name}");
             return DriverType::AccelGryo3D;
         }
         log::debug!("No driver found for IIO Interface: {name}");

--- a/src/input/source/iio/accel_gyro_3d.rs
+++ b/src/input/source/iio/accel_gyro_3d.rs
@@ -111,25 +111,22 @@ fn translate_events(events: Vec<iio_imu::event::Event>) -> Vec<NativeEvent> {
 fn translate_event(event: iio_imu::event::Event) -> NativeEvent {
     match event {
         iio_imu::event::Event::Accelerometer(data) => {
+            let factor = 1.0 / 0.0006125; // m/s² → UHID LSB
             let cap = Capability::Accelerometer(Source::Center);
             let value = InputValue::Vector3 {
-                x: Some(data.roll * 10.0),
-                y: Some(data.pitch * 10.0),
-                z: Some(data.yaw * 10.0),
+                x: Some(data.roll * factor),
+                y: Some(data.pitch * factor),
+                z: Some(data.yaw * factor),
             };
             NativeEvent::new(cap, value)
         }
         iio_imu::event::Event::Gyro(data) => {
-            // Translate gyro values into the expected units of degrees per sec
-            // We apply a 500x scale so the motion feels like natural 1:1 motion.
-            // Adjusting the scale is not possible on the accel_gyro_3d IMU.
-            // From testing this is the highest scale we can apply before noise
-            // is amplified to the point the gyro cannot calibrate.
+            let factor = (180.0 / PI) / 0.0625; // rad/s → UHID LSB
             let cap = Capability::Gyroscope(Source::Center);
             let value = InputValue::Vector3 {
-                x: Some(data.roll * (180.0 / PI) * 1500.0),
-                y: Some(data.pitch * (180.0 / PI) * 1500.0),
-                z: Some(data.yaw * (180.0 / PI) * 1500.0),
+                x: Some(data.roll * factor),
+                y: Some(data.pitch * factor),
+                z: Some(data.yaw * factor),
             };
             NativeEvent::new(cap, value)
         }

--- a/src/input/source/iio/accel_gyro_3d.rs
+++ b/src/input/source/iio/accel_gyro_3d.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, error::Error, f64::consts::PI, fmt::Debug};
+use std::{collections::HashSet, error::Error, fmt::Debug};
 
 use crate::{
     config,
@@ -11,9 +11,15 @@ use crate::{
     udev::device::UdevDevice,
 };
 
+// Scale from IIO SI units to Steam Deck UHID raw LSB.
+// IIO channels report m/s² for accel and rad/s for gyro after applying scale:
+//   https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-bus-iio
+// UHID LSB constants from src/drivers/steam_deck/driver.rs.
+const ACCEL_SCALE_FACTOR: f64 = 1632.6530612244898; // 1 / 0.0006125 (m/s² → UHID LSB)
+const GYRO_SCALE_FACTOR: f64 = 916.7324722093172; // (180/π) / 0.0625 (rad/s → °/s → UHID LSB)
+
 pub struct AccelGyro3dImu {
     driver: Driver,
-    capabilities: Vec<Capability>,
 }
 
 impl AccelGyro3dImu {
@@ -46,20 +52,7 @@ impl AccelGyro3dImu {
         let name = device_info.name();
         let driver = Driver::new(id, name, mount_matrix, sample_rate)?;
 
-        // accel and gyro may be separate IIO devices on HID Sensor Hub
-        let mut capabilities = vec![];
-        if driver.has_accel() {
-            capabilities.push(Capability::Accelerometer(Source::Center));
-        }
-        if driver.has_gyro() {
-            capabilities.push(Capability::Gyroscope(Source::Center));
-        }
-        log::debug!("AccelGyro3dImu capabilities: {capabilities:?}");
-
-        Ok(Self {
-            driver,
-            capabilities,
-        })
+        Ok(Self { driver })
     }
 }
 
@@ -73,7 +66,7 @@ impl SourceInputDevice for AccelGyro3dImu {
 
     /// Returns the possible input events this device is capable of emitting
     fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
-        Ok(self.capabilities.clone())
+        Ok(CAPABILITIES.into())
     }
 
     fn update_event_filter(&mut self, events: HashSet<Capability>) -> Result<(), InputError> {
@@ -114,25 +107,28 @@ fn translate_events(events: Vec<iio_imu::event::Event>) -> Vec<NativeEvent> {
 fn translate_event(event: iio_imu::event::Event) -> NativeEvent {
     match event {
         iio_imu::event::Event::Accelerometer(data) => {
-            let factor = 1.0 / 0.0006125; // m/s² → UHID LSB
             let cap = Capability::Accelerometer(Source::Center);
             let value = InputValue::Vector3 {
-                x: Some(data.roll * factor),
-                y: Some(data.pitch * factor),
-                z: Some(data.yaw * factor),
+                x: Some(data.roll * ACCEL_SCALE_FACTOR),
+                y: Some(data.pitch * ACCEL_SCALE_FACTOR),
+                z: Some(data.yaw * ACCEL_SCALE_FACTOR),
             };
             NativeEvent::new(cap, value)
         }
         iio_imu::event::Event::Gyro(data) => {
-            let factor = (180.0 / PI) / 0.0625; // rad/s → UHID LSB
             let cap = Capability::Gyroscope(Source::Center);
             let value = InputValue::Vector3 {
-                x: Some(data.roll * factor),
-                y: Some(data.pitch * factor),
-                z: Some(data.yaw * factor),
+                x: Some(data.roll * GYRO_SCALE_FACTOR),
+                y: Some(data.pitch * GYRO_SCALE_FACTOR),
+                z: Some(data.yaw * GYRO_SCALE_FACTOR),
             };
             NativeEvent::new(cap, value)
         }
     }
 }
 
+/// List of all capabilities that the driver implements
+pub const CAPABILITIES: &[Capability] = &[
+    Capability::Accelerometer(Source::Center),
+    Capability::Gyroscope(Source::Center),
+];

--- a/src/input/source/iio/accel_gyro_3d.rs
+++ b/src/input/source/iio/accel_gyro_3d.rs
@@ -13,6 +13,7 @@ use crate::{
 
 pub struct AccelGyro3dImu {
     driver: Driver,
+    capabilities: Vec<Capability>,
 }
 
 impl AccelGyro3dImu {
@@ -43,7 +44,19 @@ impl AccelGyro3dImu {
         let name = device_info.name();
         let driver = Driver::new(id, name, mount_matrix)?;
 
-        Ok(Self { driver })
+        let mut capabilities = vec![];
+        if driver.has_accel() {
+            capabilities.push(Capability::Accelerometer(Source::Center));
+        }
+        if driver.has_gyro() {
+            capabilities.push(Capability::Gyroscope(Source::Center));
+        }
+        log::debug!("AccelGyro3dImu capabilities: {capabilities:?}");
+
+        Ok(Self {
+            driver,
+            capabilities,
+        })
     }
 }
 
@@ -57,7 +70,7 @@ impl SourceInputDevice for AccelGyro3dImu {
 
     /// Returns the possible input events this device is capable of emitting
     fn get_capabilities(&self) -> Result<Vec<Capability>, InputError> {
-        Ok(CAPABILITIES.into())
+        Ok(self.capabilities.clone())
     }
 
     fn update_event_filter(&mut self, events: HashSet<Capability>) -> Result<(), InputError> {
@@ -123,8 +136,3 @@ fn translate_event(event: iio_imu::event::Event) -> NativeEvent {
     }
 }
 
-/// List of all capabilities that the driver implements
-pub const CAPABILITIES: &[Capability] = &[
-    Capability::Accelerometer(Source::Center),
-    Capability::Gyroscope(Source::Center),
-];

--- a/src/input/source/iio/accel_gyro_3d.rs
+++ b/src/input/source/iio/accel_gyro_3d.rs
@@ -40,10 +40,13 @@ impl AccelGyro3dImu {
             None
         };
 
+        let sample_rate = config.as_ref().and_then(|c| c.sample_rate);
+
         let id = device_info.sysname();
         let name = device_info.name();
-        let driver = Driver::new(id, name, mount_matrix)?;
+        let driver = Driver::new(id, name, mount_matrix, sample_rate)?;
 
+        // accel and gyro may be separate IIO devices on HID Sensor Hub
         let mut capabilities = vec![];
         if driver.has_accel() {
             capabilities.push(Capability::Accelerometer(Source::Center));

--- a/src/input/source/iio/bmi_imu.rs
+++ b/src/input/source/iio/bmi_imu.rs
@@ -39,9 +39,11 @@ impl BmiImu {
             None
         };
 
+        let sample_rate = config.as_ref().and_then(|c| c.sample_rate);
+
         let id = device_info.sysname();
         let name = device_info.name();
-        let driver = Driver::new(id, name, mount_matrix)?;
+        let driver = Driver::new(id, name, mount_matrix, sample_rate)?;
 
         Ok(Self { driver })
     }


### PR DESCRIPTION
## Summary

Fix the `AccelGyro3d` IIO driver for HID Sensor Hub devices (Intel ISH, AMD SFH) where accelerometer and gyroscope are exposed as separate IIO devices (`accel_3d`, `gyro_3d`).

## Changes

### Handle separate accel/gyro IIO devices

The previous code assumed both accel and gyro channels were always present in one device, emitting zero-valued events for the missing sensor. This caused alternating valid/zero data on HID Sensor Hub hardware (e.g. MSI Claw).

- Detect capabilities dynamically via `has_accel()` / `has_gyro()`
- Return `None` from poll when no channels are found
- Keep the IIO `Device` alive in `Driver` to prevent `Channel` pointer invalidation

### Correct scaling factors

The previous scaling factors (`* 10.0` for accel, `* (180/π) * 1500.0` for gyro) were empirically tuned on the Legion Go — the original commit explicitly states they were derived "from testing" to make motion "feel like natural 1:1". These values were likely calibrated against the `amd_sfh` kernel driver's imprecise output (the driver has known integer division errors that reduce accel values by 10× and gyro by 100×), rather than against correct SI-unit data.

This PR replaces them with physically derived values based on the Steam Deck UHID protocol constants:

- Accel: `1 / 0.0006125` (m/s² → UHID LSB)
- Gyro: `(180/π) / 0.0625` (rad/s → °/s → UHID LSB)

These factors assume the IIO subsystem reports correct SI-unit values. Hardware-specific sensitivity is handled by the per-device `scale` sysfs attribute. Verified on MSI Claw A1M (Intel ISH) and MSI Claw A8 BZ2EM (AMD SFH with kernel precision patch) — both produce correct and consistent output.

**Impact on Legion Go:** When the `hid-lenovo-go` kernel driver is loaded, InputPlumber already disables the internal IMU and uses the controller's built-in gyroscope instead (`get_default_event_filter`), so this change has no effect. On kernels without `hid-lenovo-go` where the internal IMU is active, the new factors may produce different output if the `amd_sfh` precision bug is present — but the old values were not physically correct either.

### Initialize sampling rate on startup

Some HID Sensor Hub devices default to very low rates (e.g. 10 Hz on MSI Claw), which is insufficient for gaming input. The driver now initializes the rate with priority: YAML config > hardware max available > 200 Hz default. Supports both per-channel and device-level attributes with fallback.

## Test plan

- [x] MSI Claw A1M (Intel ISH, separate `accel_3d` + `gyro_3d`)
- [x] MSI Claw A8 BZ2EM (AMD SFH). Note: stock `amd_sfh` kernel driver has precision issues requiring a kernel patch, independent of InputPlumber.
- [x] BMI260 device — no regression in shared Driver code
- [ ] Verify no regression on Legion Go / ROG Ally