### PR TITLE
fix(zotac-zone): add IMU mount matrix

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-zotac-zone.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-zotac-zone.yaml
@@ -58,6 +58,10 @@ source_devices:
   - group: imu
     iio:
       name: "{i2c-BMI0160:00,bmi260}"
+      mount_matrix:
+        x: [0, -1, 0]
+        y: [-1, 0, 0]
+        z: [0, 0, -1]
 
   #RGB
   - group: led


### PR DESCRIPTION
## Summary

Add the IMU mount matrix for Zotac Zone to fix IMU orientation

## Test plan

- [x] Tested manually on Zotac Zone
- [x] Compared behavior against Steam Deck