### PR TITLE
fix(devices/onexplayer_apex): target xbox-elite to surface oxp8 paddles

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-onexplayer_apex.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-onexplayer_apex.yaml
@@ -57,9 +57,12 @@ options:
   # external service enables management of the device. Defaults to 'false'
   auto_manage: true
 
-# The target input device(s) to emulate by default
+# The target input device(s) to emulate by default. xbox-elite (matching
+# 50-onexplayer_x1.yaml) so the oxp8 capability map's LeftPaddle1 /
+# RightPaddle1 outputs surface — those button codes only exist on
+# Xbox Elite, not Xbox Series.
 target_devices:
-  - xbox-series
+  - xbox-elite
   - mouse
   - keyboard
 

--- a/rootfs/usr/share/inputplumber/devices/50-onexplayer_apex.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-onexplayer_apex.yaml
@@ -57,10 +57,7 @@ options:
   # external service enables management of the device. Defaults to 'false'
   auto_manage: true
 
-# The target input device(s) to emulate by default. xbox-elite (matching
-# 50-onexplayer_x1.yaml) so the oxp8 capability map's LeftPaddle1 /
-# RightPaddle1 outputs surface — those button codes only exist on
-# Xbox Elite, not Xbox Series.
+# The target input device(s) to emulate by default
 target_devices:
   - xbox-elite
   - mouse


### PR DESCRIPTION
The OneXPlayer Apex profile targets `xbox-series`, but its `oxp8` capability map emits `LeftPaddle1` / `RightPaddle1` — codes that only exist on `xbox-elite`. So under `xbox-series` they silently drop and the back paddles do nothing.

Switching the target to `xbox-elite` (which `50-onexplayer_x1.yaml` already does for the same reason, since its `oxp5` map also emits paddle codes) makes them surface as `BTN_TRIGGER_HAPPY5` / `BTN_TRIGGER_HAPPY6`.

Tested on a OneXPlayer Apex (Bazzite, hidraw `1a86:fe00`). Before: paddles produce nothing on the emulated `/dev/input/eventN`. After: they fire as expected. No regression on the rest (sticks, face buttons, triggers, bumpers, dpad).

## AI disclosure

Per CONTRIBUTING.md: the original PR description and an explanatory YAML comment in the first commit were drafted with Claude. The fix itself, the on-hardware testing, and the reasoning are my own. The follow-up commit `7ed00b7` removes the LLM-drafted YAML comment so the diff is exactly the target value change, with `Co-developed-by: Claude Opus 4.7` in that commit's message.
