### PR TITLE
fix(Hardware Support): Update MSI Claw Driver Name

### DIFF
--- a/rootfs/usr/lib/udev/rules.d/99-inputplumber-device-setup.rules
+++ b/rootfs/usr/lib/udev/rules.d/99-inputplumber-device-setup.rules
@@ -25,8 +25,6 @@ ACTION=="add|change|bind", ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="61e[bcde]
 #ACTION=="add|change", KERNEL=="0003:0B05:1B4C*", SUBSYSTEM=="hid", DRIVER=="asus_rog_ally", ATTRS{bInterfaceNumber}=="05", ATTR{qam_mode}="0", GOTO="end"
 
 # MSI Claw Settings
-ACTION=="add|change|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="190[1-3]", SUBSYSTEM=="hid", DRIVER=="hid-msi-claw", ATTR{button_m1}="KEY_RIGHTBRACE", ATTR{button_m2}="KEY_LEFTBRACE", ATTR{mkeys_function}="macro" GOTO="end"
+ACTION=="add|change|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="190[1-3]", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{button_m1}="KEY_RIGHTBRACE", ATTR{button_m2}="KEY_LEFTBRACE", GOTO="end"
 
 LABEL="end"
-
-


### PR DESCRIPTION
- Upstream requested a driver name change from hid-msi-claw to hid-msi. Update the udev rules to reflect the new name.