### PR TITLE
fix(Hardware Support): Update MSI Claw Driver Setup Rules

### DIFF
--- a/rootfs/usr/lib/udev/rules.d/99-inputplumber-device-setup.rules
+++ b/rootfs/usr/lib/udev/rules.d/99-inputplumber-device-setup.rules
@@ -25,6 +25,10 @@ ACTION=="add|change|bind", ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="61e[bcde]
 #ACTION=="add|change", KERNEL=="0003:0B05:1B4C*", SUBSYSTEM=="hid", DRIVER=="asus_rog_ally", ATTRS{bInterfaceNumber}=="05", ATTR{qam_mode}="0", GOTO="end"
 
 # MSI Claw Settings
-ACTION=="add|change|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="190[1-3]", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{button_m1}="KEY_RIGHTBRACE", ATTR{button_m2}="KEY_LEFTBRACE", GOTO="end"
+ACTION=="add|change|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="190[1-3]", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{button_m1}="KEY_RIGHTBRACE", ATTR{button_m2}="KEY_LEFTBRACE", GOTO="claw_desktop"
+LABEL="claw_desktop"
+ACTION=="add|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="1901", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{gamepad_mode}=="desktop", ATTR{gamepad_mode}="xinput", GOTO="end"
+ACTION=="add|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="1902", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{gamepad_mode}=="desktop", ATTR{gamepad_mode}="dinput", GOTO="end"
+ACTION=="add|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="1903", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{gamepad_mode}="xinput", GOTO="end"
 
 LABEL="end"


### PR DESCRIPTION
- Devices that boot up in desktop mode are unable to present events that function as gamepad, and there is no way for a user to switch the mode without writing to the CLI path at /sys/class/hidraw/hidraw0/device/gamepad_mode. Xinput mode and Dinput mode express themselves with unique PIDs (1901/1902 respectively), and trigger a device disconnect/reconnect. Desktop mode, by contrast, adopts the PID of the input mode that was last set and does not trigger a reset. This provides the opportunity to ensure the device is in a gamepad mode at startup without hard forcing a retrigger loop, as setting xinput/dinput explicitly would. The rules only trigger on "add|bind"" to prevent loops on "change", permitting a user to select desktop mode later.
- While at it, prevent the device from ever showing as PID 1903, which is a bugged BIOS mode.

Fixes #494 