### PR TITLE
fix(Hardware Support): Update MSI Claw Driver Setup Rules Again

### DIFF
--- a/rootfs/usr/lib/udev/rules.d/99-inputplumber-device-setup.rules
+++ b/rootfs/usr/lib/udev/rules.d/99-inputplumber-device-setup.rules
@@ -27,8 +27,8 @@ ACTION=="add|change|bind", ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="61e[bcde]
 # MSI Claw Settings
 ACTION=="add|change|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="190[1-3]", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{button_m1}="KEY_RIGHTBRACE", ATTR{button_m2}="KEY_LEFTBRACE", GOTO="claw_desktop"
 LABEL="claw_desktop"
-ACTION=="add|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="1901", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{gamepad_mode}=="desktop", ATTR{gamepad_mode}="xinput", GOTO="end"
-ACTION=="add|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="1902", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{gamepad_mode}=="desktop", ATTR{gamepad_mode}="dinput", GOTO="end"
-ACTION=="add|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="1903", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{gamepad_mode}="xinput", GOTO="end"
+ACTION=="add|change|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="1901", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{gamepad_mode}=="desktop", ATTR{gamepad_mode}="xinput", GOTO="end"
+ACTION=="add|change|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="1902", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{gamepad_mode}=="desktop", ATTR{gamepad_mode}="dinput", GOTO="end"
+ACTION=="add|change|bind", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="1903", SUBSYSTEM=="hid", DRIVER=="hid-msi", ATTR{gamepad_mode}="xinput", GOTO="end"
 
 LABEL="end"


### PR DESCRIPTION
- Adds 'change' to the rules actions. Without this flag the rules only apply when you use 'udevadm trigger' and not during startup. Manually setting desktop is preserved through suspend and session switching but will properly set the gamepad mode upon startup.