### PR TITLE
chore(Makefile): Don't call build in install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 .PHONY: install
-install: build ## Install inputplumber to the given prefix (default: PREFIX=/usr)
+install: ## Install inputplumber to the given prefix (default: PREFIX=/usr)
 	install -D -m 755 target/$(TARGET_ARCH)/$(BUILD_TYPE)/$(NAME) \
 		$(PREFIX)/bin/$(NAME)
 	install -D -m 644 rootfs/usr/share/dbus-1/system.d/$(DBUS_NAME).conf \


### PR DESCRIPTION
Removes build from install target to reduce build times in CI. PKGBUILD already calls build prior to install, install.md already tells the user to run make build before sudo make install.