### PR TITLE
fix(CapabilityMap): use signed normalization for buttons on bipolar axes

### DIFF
--- a/src/input/event/evdev/translator.rs
+++ b/src/input/event/evdev/translator.rs
@@ -504,7 +504,13 @@ impl EventTranslator {
         const IMU_SCALE: f64 = 0.01;
 
         match value_type {
-            ValueType::Button => normalize_unsigned_value(raw_value, info.minimum(), info.maximum()),
+            ValueType::Button => {
+                if info.minimum() < 0 {
+                    normalize_signed_value(raw_value, info.minimum(), info.maximum())
+                } else {
+                    normalize_unsigned_value(raw_value, info.minimum(), info.maximum())
+                }
+            }
             ValueType::Trigger => normalize_unsigned_value(raw_value, info.minimum(), info.maximum()),
             ValueType::JoystickX | ValueType::JoystickY => {
                 normalize_signed_value(raw_value, info.minimum(), info.maximum())


### PR DESCRIPTION
Fixes regression introduced https://github.com/ShadowBlip/InputPlumber/pull/569 for devices that have negative axis values. 