### PR TITLE
fix(Hardware Support): Fix Legion Go 2 mouse wheel #584

### DIFF
--- a/src/drivers/lego/driver.rs
+++ b/src/drivers/lego/driver.rs
@@ -407,15 +407,17 @@ impl Driver {
                     value: state.a_trigger_r,
                 })));
             }
-            if state.mouse_z != old_state.mouse_z {
-                log::debug!("Raw mouse value: {:b}, {}", state.mouse_z, !state.mouse_z);
-                let value = state.mouse_z.wrapping_sub(128) as i8;
-                let value = match value {
-                    64..=127 => value - 127 - 1,
-                    v => v,
+            // mouse_z is a 7-bit signed delta (bit 6 = sign bit) pulsed from 0:
+            //   scroll up   = 0x01 (+1 in 7-bit)
+            //   scroll down = 0x7f (-1 in 7-bit)
+            // Positive value → REL_WHEEL positive → traditional scroll up.
+            if state.mouse_z != old_state.mouse_z && state.mouse_z != 0 {
+                let value = if state.mouse_z & 0x40 != 0 {
+                    (state.mouse_z | 0x80) as i8 // sign-extend bit 6 → bit 7
+                } else {
+                    state.mouse_z as i8
                 };
-
-                log::debug!("Normalized mouse value: {value}");
+                log::debug!("Mouse wheel value: {value}");
                 events.push(Event::Trigger(TriggerEvent::MouseWheel(MouseWheelInput {
                     value,
                 })));


### PR DESCRIPTION
Fix issue #584 
Co-developed-by: Claude Sonnet 4.6

The following part is AI-generated, the Claude Code explanation:

> The Legion Go 2 uses a different encoding for the scroll wheel (mouse_z) compared to the original Legion Go 1:
> 
> - Legion Go 1: mouse_z centered at 128 (neutral=128, deltas around it)
> - Legion Go 2: mouse_z is a 7-bit signed value pulsed from 0
>     scroll up   = 0x01 (+1 in 7-bit two's complement)
>     scroll down = 0x7f (-1 in 7-bit two's complement, bit 6 = sign bit)
>   The device resets mouse_z back to 0x00 after each pulse.
> 
> The old code used wrapping_sub(128) which was correct for Gen 1 but produced wrong sign and wrong magnitude for Gen 2:
> - Scroll up   (0x01) → wrapping_sub → -127 → kernel REL_WHEEL -127
> - Scroll down (0x7f) → wrapping_sub → match arm → -1  → kernel REL_WHEEL -1
> - Reset to 0         → wrapping_sub → -128 → spurious extra scroll event
> 
> All kernel values were negative, so content always scrolled one direction. The reset event also doubled every scroll event in libinput.
> 
> Fix: interpret mouse_z as a 7-bit signed integer by sign-extending bit 6 to bit 7, skip the 0x00 reset pulse, and use the value directly:
> - 0x01 → +1 → REL_WHEEL +1 → traditional scroll up   ✓
> - 0x7f → -1 → REL_WHEEL -1 → traditional scroll down ✓
> 
> Tested on Legion Go 2 (product 83N0/83N1) in CachyOS desktop mode and in gaming mode with The Planet Crafter and The Elder Scrolls IV: Oblivion Remastered.

There is additional data that Claude Code made on the PR to the main repository (which I denied) which expands on the explanation and test cases:

> 
> 
> ## Test plan
> 
> - [x] Scroll up moves content up, scroll down moves content down
> - [x] Each physical click produces exactly one libinput scroll event (no spurious duplicate)
> - [x] Tested on Legion Go 2 (DMI product `83N0`) running CachyOS
> - [x] Verified in desktop mode and in gaming mode with The Planet Crafter and The Elder Scrolls IV: Oblivion Remastered (mouse/keyboard emulation profile)
> - [ ] Regression test on original Legion Go 1 (Gen 1 uses 0x80 neutral — the new code path only activates for non-zero mouse_z, so Gen 1 values near 0x80 like 0x7f/0x81 will now be sign-extended differently; Gen 1 owners should verify)
> 
> ## Reviewer notes
> 
> The Gen 1 and Gen 2 share the same `lego` driver. The Gen 1 encoding (centered at 128) would now be interpreted differently by this code — a Gen 1 scroll-down of 0x7f (127, = -1 after wrapping_sub) would now sign-extend to -1, which happens to be the same result, so typical ±1 click values are unaffected. Larger multi-click deltas may differ. If a Gen 1 owner can test, that would be ideal.

So that summarizes well with what we went through. Initially for this troubleshooting I have used the same command that I have used in my bug report, which is `sudo libinput debug-events` which is quite verbose. Please let me know whether you want the complete history of the troubleshooting and fix session, I am not pasting it here because it seems excessive and not particularly informative.