### PR TITLE
fix(Hardware Support): Add guide button support for MSI Claw A8

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw7_a2vm.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw7_a2vm.yaml
@@ -30,6 +30,27 @@ source_devices:
           value: "AT Translated Set 2 keyboard"
         - name: phys
           value: "isa0060/serio0/input0"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyF15
+        - Keyboard:KeyF16
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+
+  # Conflicts, block
+  - group: keyboard
+    blocked: true
+    udev:
+      attributes:
+        - name: name
+          value: "MSI WMI hotkeys"
+        - name: phys
+          value: "wmi/input0"
+    events:
+      exclude:
+        - "*"
 
   # Xinput Gamepad
   - group: gamepad
@@ -58,6 +79,12 @@ source_devices:
           value: "1901"
         - name: phys
           value: "usb-0000:00:14.0-2/input2"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftBrace
+        - Keyboard:KeyRightBrace
 
   # Dinput Gamepad
   - group: gamepad
@@ -87,6 +114,12 @@ source_devices:
           value: "1902"
         - name: phys
           value: "usb-0000:00:14.0-2/input1"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftBrace
+        - Keyboard:KeyRightBrace
 
 # Optional configuration for the composite device
 options:

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw8_a2vm.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw8_a2vm.yaml
@@ -30,6 +30,27 @@ source_devices:
           value: "AT Translated Set 2 keyboard"
         - name: phys
           value: "isa0060/serio0/input0"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyF15
+        - Keyboard:KeyF16
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+
+  # Conflicts, block
+  - group: keyboard
+    blocked: true
+    udev:
+      attributes:
+        - name: name
+          value: "MSI WMI hotkeys"
+        - name: phys
+          value: "wmi/input0"
+    events:
+      exclude:
+        - "*"
 
   # Xinput Gamepad
   - group: gamepad
@@ -58,6 +79,12 @@ source_devices:
           value: "1901"
         - name: phys
           value: "usb-0000:00:14.0-2/input2"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftBrace
+        - Keyboard:KeyRightBrace
 
   # Dinput Gamepad
   - group: gamepad
@@ -87,6 +114,12 @@ source_devices:
           value: "1902"
         - name: phys
           value: "usb-0000:00:14.0-2/input1"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftBrace
+        - Keyboard:KeyRightBrace
 
   # IMU
 

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw_a1m.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw_a1m.yaml
@@ -30,6 +30,27 @@ source_devices:
           value: "AT Translated Set 2 keyboard"
         - name: phys
           value: "isa0060/serio0/input0"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyF15
+        - Keyboard:KeyF16
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+
+  # Conflicts, block
+  - group: keyboard
+    blocked: true
+    udev:
+      attributes:
+        - name: name
+          value: "MSI WMI hotkeys"
+        - name: phys
+          value: "wmi/input0"
+    events:
+      exclude:
+        - "*"
 
   # Xinput Gamepad
   - group: gamepad
@@ -58,6 +79,12 @@ source_devices:
           value: "1901"
         - name: phys
           value: "usb-0000:00:14.0-9/input2"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftBrace
+        - Keyboard:KeyRightBrace
 
   # Dinput Gamepad
   - group: gamepad
@@ -87,6 +114,12 @@ source_devices:
           value: "1902"
         - name: phys
           value: "usb-0000:00:14.0-9/input1"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftBrace
+        - Keyboard:KeyRightBrace
 
   # IMU
   - group: imu

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw_a8_bz2e.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw_a8_bz2e.yaml
@@ -22,7 +22,7 @@ matches:
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.
 source_devices:
-  # Face Extra Buttons
+  # Face Quick Access
   - group: keyboard
     udev:
       attributes:
@@ -30,6 +30,29 @@ source_devices:
           value: "AT Translated Set 2 keyboard"
         - name: phys
           value: "isa0060/serio0/input0"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyG
+        - Keyboard:KeyTab
+        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyVolumeDown
+
+  # Face Guide
+  - group: keyboard
+    udev:
+      attributes:
+        - name: name
+          value: "MSI WMI hotkeys"
+        - name: phys
+          value: "wmi/input0"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyF15
 
   # Xinput Gamepad
   - group: gamepad
@@ -58,6 +81,12 @@ source_devices:
           value: "1901"
         - name: phys
           value: "usb-0000:c6:00.0-3/input2"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftBrace
+        - Keyboard:KeyRightBrace
 
   # Dinput Gamepad
   - group: gamepad
@@ -87,8 +116,22 @@ source_devices:
           value: "1902"
         - name: phys
           value: "usb-0000:c6:00.0-3/input1"
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyLeftBrace
+        - Keyboard:KeyRightBrace
 
   # IMU
+  - group: imu
+    iio:
+      name: gyro_3d
+      mount_matrix:
+        # TODO: Verify
+        x: [0, 1, 0]
+        y: [-1, 0, 0]
+        z: [0, 0, -1]
 
 # Optional configuration for the composite device
 options:

--- a/src/input/manager.rs
+++ b/src/input/manager.rs
@@ -64,6 +64,7 @@ const VIRT_DEVICE_WHITELIST: &[&str] = &[
     "Sunshine X-Box One (virtual) pad",
     "Sunshine gamepad (virtual) motion sensors",
     "Sunshine Nintendo (virtual) pad",
+    "MSI WMI hotkeys",
 ];
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
Adds support for the MSI Claw A8 Guide button. Event from 'MSI WMI hotkeys' requires a kernel patch to function. 
While at it, add event filtering for all MSI Claw devices so only the real capabilities are exposed.

Closes #599 when paired with this kernel patch: https://lore.kernel.org/platform-driver-x86/20260611223920.1679438-1-derekjohn.clark@gmail.com/