### PR TITLE
fix(Hardware Support): Fix MSI Claw Button Regression

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw7_a2vm.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw7_a2vm.yaml
@@ -36,8 +36,11 @@ source_devices:
       include:
         - Keyboard:KeyF15
         - Keyboard:KeyF16
-        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyG
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyTab
         - Keyboard:KeyVolumeDown
+        - Keyboard:KeyVolumeUp
 
   # Conflicts, block
   - group: keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw8_a2vm.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw8_a2vm.yaml
@@ -36,8 +36,11 @@ source_devices:
       include:
         - Keyboard:KeyF15
         - Keyboard:KeyF16
-        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyG
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyTab
         - Keyboard:KeyVolumeDown
+        - Keyboard:KeyVolumeUp
 
   # Conflicts, block
   - group: keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw_a1m.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw_a1m.yaml
@@ -36,8 +36,11 @@ source_devices:
       include:
         - Keyboard:KeyF15
         - Keyboard:KeyF16
-        - Keyboard:KeyVolumeUp
+        - Keyboard:KeyG
+        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyTab
         - Keyboard:KeyVolumeDown
+        - Keyboard:KeyVolumeUp
 
   # Conflicts, block
   - group: keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw_a8_bz2e.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw_a8_bz2e.yaml
@@ -34,11 +34,13 @@ source_devices:
       exclude:
         - "*"
       include:
-        - Keyboard:KeyLeftMeta
+        - Keyboard:KeyF15
+        - Keyboard:KeyF16
         - Keyboard:KeyG
+        - Keyboard:KeyLeftMeta
         - Keyboard:KeyTab
-        - Keyboard:KeyVolumeUp
         - Keyboard:KeyVolumeDown
+        - Keyboard:KeyVolumeUp
 
   # Face Guide
   - group: keyboard


### PR DESCRIPTION
- MSI Claw devices might have the newer firmware on multiple devices that use the new keycodes. Enable all keycodes for all models to ensure nothing gets lost.