### PR TITLE
fix(Hardware Support): Fix Legion Go Regressions

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-legion_go_2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go_2.yaml
@@ -114,15 +114,6 @@ source_devices:
       product_id: 0x61ee
       interface_num: 2
 
-  # IMU
-  - group: imu
-    iio:
-      name: gyro_3d
-      mount_matrix:
-        x: [1, 0, 0]
-        y: [0, -1, 0]
-        z: [0, 0, 1]
-
 # Optional configuration for the composite device
 options:
   # If true, InputPlumber will automatically try to manage the input device. If

--- a/src/drivers/lego/go1_driver.rs
+++ b/src/drivers/lego/go1_driver.rs
@@ -5,32 +5,22 @@ use hidapi::HidDevice;
 use packed_struct::PackedStruct;
 use tokio::time::Instant;
 
-use crate::drivers::lego::DEFAULT_EVENT_FILTER;
-use crate::input::capability::Source;
+use crate::input::capability::Capability;
 use crate::udev::device::UdevDevice;
-use crate::{
-    drivers::lego::{
-        event::{ImuAxisInput, TouchAxisInput, TouchButtonEvent},
-        hid_report::GamepadMode,
-        CLICK_DELAY, PAD_FORCE_NORMAL, RELEASE_DELAY, XINPUT_COMMAND_ID,
-    },
-    input::capability::Capability,
-};
 
 use super::{
     event::{
         AxisEvent, BinaryInput, Event, GamepadButtonEvent, JoyAxisInput, MouseWheelInput,
-        TriggerEvent, TriggerInput,
+        TouchAxisInput, TouchButtonEvent, TriggerEvent, TriggerInput,
     },
-    hid_report::XInputDataReport,
-    GP_IID, HID_TIMEOUT, PIDS, VID, XINPUT_DATA, XINPUT_PACKET_SIZE,
+    hid_report::{GamepadMode, XInputDataReport},
+    CLICK_DELAY, GO1_PIDS, GP_IID, HID_TIMEOUT, PAD_FORCE_NORMAL, RELEASE_DELAY, VID,
+    XINPUT_COMMAND_ID, XINPUT_DATA, XINPUT_PACKET_SIZE,
 };
 
 pub struct Driver {
     /// HIDRAW device instance
     hid_device: HidDevice,
-    /// Udev device instance
-    udev_device: UdevDevice,
     /// List of events that should not be generated
     filtered_events: HashSet<Capability>,
     /// Timestamp of the first touch event.
@@ -44,7 +34,7 @@ pub struct Driver {
     /// Whether or not a touch event was started that hasn't been cleared.
     touch_started: bool,
     /// State for the internal gamepad controller
-    xinput_state: Option<XInputDataReport>,
+    state: Option<XInputDataReport>,
 }
 
 impl Driver {
@@ -56,14 +46,13 @@ impl Driver {
         let info = hid_device.get_device_info()?;
 
         if info.vendor_id() != VID
-            || !PIDS.contains(&info.product_id())
+            || !GO1_PIDS.contains(&info.product_id())
             || info.interface_number() != GP_IID
         {
             return Err(format!("Device '{fmtpath}' is not a Legion Go S Controller").into());
         }
 
         Ok(Self {
-            udev_device,
             hid_device,
             filtered_events: Default::default(),
             first_touch: Instant::now(),
@@ -71,7 +60,7 @@ impl Driver {
             is_touching: false,
             last_touch: Instant::now(),
             touch_started: false,
-            xinput_state: None,
+            state: None,
         })
     }
 
@@ -83,41 +72,15 @@ impl Driver {
         self.filtered_events = events;
     }
 
-    pub fn get_default_event_filter(
-        &self,
-    ) -> Result<HashSet<Capability>, Box<dyn Error + Send + Sync>> {
-        let device = self.udev_device.get_device()?;
-        let Some(parent) = device.parent() else {
-            return Ok(HashSet::from(DEFAULT_EVENT_FILTER));
-        };
-
-        let Some(driver) = parent.driver() else {
-            return Ok(HashSet::from(DEFAULT_EVENT_FILTER));
-        };
-
-        let Some(driver) = driver.to_str() else {
-            return Ok(HashSet::from(DEFAULT_EVENT_FILTER));
-        };
-
-        let filtered_events = match driver {
-            "hid-lenovo-go" => HashSet::from([
-                Capability::Accelerometer(Source::Left),
-                Capability::Accelerometer(Source::Right),
-                Capability::Gyroscope(Source::Left),
-                Capability::Gyroscope(Source::Right),
-            ]),
-
-            _ => HashSet::from(DEFAULT_EVENT_FILTER),
-        };
-
-        Ok(filtered_events)
-    }
-
     /// Poll the device and read input reports
     pub fn poll(&mut self) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
         // Read data from the device into a buffer
         let mut buf = [0; XINPUT_PACKET_SIZE];
         let bytes_read = self.hid_device.read_timeout(&mut buf[..], HID_TIMEOUT)?;
+
+        if bytes_read > XINPUT_PACKET_SIZE {
+            return Err("Invalid packet size for X-Input Data.".into());
+        }
 
         let report_id = buf[0];
         let command_id = buf[2];
@@ -167,25 +130,25 @@ impl Driver {
         //log::debug!(" ---- End Report ----");
 
         // Update the state
-        let old_dinput_state = self.update_xinput_state(input_report);
+        let old_state = self.update_xinput_state(input_report);
 
         // Translate the state into a stream of input events
-        let events = self.translate_xinput(old_dinput_state);
+        let events = self.translate_xinput(old_state);
 
         Ok(events)
     }
 
     /// Update gamepad state
     fn update_xinput_state(&mut self, input_report: XInputDataReport) -> Option<XInputDataReport> {
-        let old_state = self.xinput_state;
-        self.xinput_state = Some(input_report);
+        let old_state = self.state;
+        self.state = Some(input_report);
         old_state
     }
 
     /// Translate the state into individual events
     fn translate_xinput(&mut self, old_state: Option<XInputDataReport>) -> Vec<Event> {
         let mut events = Vec::new();
-        let Some(state) = self.xinput_state else {
+        let Some(state) = self.state else {
             return events;
         };
 
@@ -317,11 +280,6 @@ impl Driver {
                     },
                 )));
             }
-            if state.m1 != old_state.m1 {
-                events.push(Event::GamepadButton(GamepadButtonEvent::M1(BinaryInput {
-                    pressed: state.m1,
-                })));
-            }
             if state.m2 != old_state.m2 {
                 events.push(Event::GamepadButton(GamepadButtonEvent::M2(BinaryInput {
                     pressed: state.m2,
@@ -351,20 +309,6 @@ impl Driver {
                 events.push(Event::GamepadButton(GamepadButtonEvent::MouseClick(
                     BinaryInput {
                         pressed: state.mouse_click,
-                    },
-                )));
-            }
-            if state.show_desktop != old_state.show_desktop {
-                events.push(Event::GamepadButton(GamepadButtonEvent::ShowDesktop(
-                    BinaryInput {
-                        pressed: state.show_desktop,
-                    },
-                )));
-            }
-            if state.alt_tab != old_state.alt_tab {
-                events.push(Event::GamepadButton(GamepadButtonEvent::AltTab(
-                    BinaryInput {
-                        pressed: state.alt_tab,
                     },
                 )));
             }
@@ -427,91 +371,6 @@ impl Driver {
             {
                 log::trace!("Left controller connected state: {:?}", state.l_con_state);
                 log::trace!("Right controller connected state: {:?}", state.r_con_state);
-            }
-            if !self
-                .filtered_events
-                .contains(&Capability::Accelerometer(Source::Left))
-                && (state.left_accel_x != old_state.left_accel_x
-                    || state.left_accel_y != old_state.left_accel_y
-                    || state.left_accel_z != old_state.left_accel_z)
-            {
-                events.push(Event::Axis(AxisEvent::LeftAccel(ImuAxisInput {
-                    pitch: -state.left_accel_x,
-                    roll: state.left_accel_y,
-                    yaw: state.left_accel_z,
-                })))
-            }
-            if !self
-                .filtered_events
-                .contains(&Capability::Accelerometer(Source::Right))
-                && (state.right_accel_x != old_state.right_accel_x
-                    || state.right_accel_y != old_state.right_accel_y
-                    || state.right_accel_z != old_state.right_accel_z)
-            {
-                events.push(Event::Axis(AxisEvent::RightAccel(ImuAxisInput {
-                    pitch: -state.right_accel_x,
-                    roll: -state.right_accel_y,
-                    yaw: state.right_accel_z,
-                })))
-            }
-            if !self
-                .filtered_events
-                .contains(&Capability::Accelerometer(Source::Center))
-                && (state.left_accel_x != old_state.left_accel_x
-                    || state.left_accel_y != old_state.left_accel_y
-                    || state.left_accel_z != old_state.left_accel_z
-                    || state.right_accel_x != old_state.right_accel_x
-                    || state.right_accel_y != old_state.right_accel_y
-                    || state.right_accel_z != old_state.right_accel_z)
-            {
-                events.push(Event::Axis(AxisEvent::MultiAccel(ImuAxisInput {
-                    pitch: -(state.left_accel_x + state.right_accel_x) / 2,
-                    roll: (state.left_accel_y + state.right_accel_y) / 2,
-                    yaw: (state.left_accel_z + state.right_accel_z) / 2,
-                })))
-            }
-            if !self
-                .filtered_events
-                .contains(&Capability::Gyroscope(Source::Left))
-                && (state.left_gyro_x != old_state.left_gyro_x
-                    || state.left_gyro_y != old_state.left_gyro_y
-                    || state.left_gyro_z != old_state.left_gyro_z)
-            {
-                events.push(Event::Axis(AxisEvent::LeftGyro(ImuAxisInput {
-                    pitch: -state.left_gyro_x,
-                    roll: state.left_gyro_y,
-                    yaw: state.left_gyro_z,
-                })))
-            }
-            if !self
-                .filtered_events
-                .contains(&Capability::Gyroscope(Source::Right))
-                && (state.right_gyro_x != old_state.right_gyro_x
-                    || state.right_gyro_y != old_state.right_gyro_y
-                    || state.right_gyro_z != old_state.right_gyro_z)
-            {
-                events.push(Event::Axis(AxisEvent::RightGyro(ImuAxisInput {
-                    pitch: -state.right_gyro_x,
-                    roll: state.right_gyro_y,
-                    yaw: state.right_gyro_z,
-                })))
-            }
-
-            if !self
-                .filtered_events
-                .contains(&Capability::Gyroscope(Source::Center))
-                && (state.left_gyro_x != old_state.left_gyro_x
-                    || state.left_gyro_y != old_state.left_gyro_y
-                    || state.left_gyro_z != old_state.left_gyro_z
-                    || state.right_gyro_x != old_state.right_gyro_x
-                    || state.right_gyro_y != old_state.right_gyro_y
-                    || state.right_gyro_z != old_state.right_gyro_z)
-            {
-                events.push(Event::Axis(AxisEvent::MultiGyro(ImuAxisInput {
-                    pitch: -(state.left_gyro_x + state.right_gyro_x) / 2,
-                    roll: (state.left_gyro_y + state.right_gyro_y) / 2,
-                    yaw: (state.left_gyro_z + state.right_gyro_z) / 2,
-                })))
             }
 
             // Touchpad events

--- a/src/drivers/lego/go2_driver.rs
+++ b/src/drivers/lego/go2_driver.rs
@@ -1,0 +1,609 @@
+use std::collections::HashSet;
+use std::{error::Error, ffi::CString};
+
+use hidapi::HidDevice;
+use packed_struct::PackedStruct;
+use tokio::time::Instant;
+
+use crate::input::capability::{Capability, Source};
+use crate::udev::device::UdevDevice;
+
+use super::{
+    event::{
+        AxisEvent, BinaryInput, Event, GamepadButtonEvent, ImuAxisInput, JoyAxisInput,
+        MouseWheelInput, TouchAxisInput, TouchButtonEvent, TriggerEvent, TriggerInput,
+    },
+    hid_report::{GamepadMode, XInputDataReport},
+    CLICK_DELAY, DEFAULT_EVENT_FILTER, GO2_PIDS, GP_IID, HID_TIMEOUT, PAD_FORCE_NORMAL,
+    RELEASE_DELAY, VID, XINPUT_COMMAND_ID, XINPUT_DATA, XINPUT_PACKET_SIZE,
+};
+
+pub struct Driver {
+    /// HIDRAW device instance
+    hid_device: HidDevice,
+    /// Udev device instance
+    udev_device: UdevDevice,
+    /// List of events that should not be generated
+    filtered_events: HashSet<Capability>,
+    /// Timestamp of the first touch event.
+    first_touch: Instant,
+    /// Whether or not we are currently holding a click-to-click.
+    is_clicked: bool,
+    /// Whether or not we are detecting a touch event currently.
+    is_touching: bool,
+    /// Timestamp of the last touch event.
+    last_touch: Instant,
+    /// Whether or not a touch event was started that hasn't been cleared.
+    touch_started: bool,
+    /// State for the internal gamepad controller
+    state: Option<XInputDataReport>,
+}
+
+impl Driver {
+    pub fn new(udev_device: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
+        let fmtpath = udev_device.devnode().clone();
+        let path = CString::new(fmtpath.clone())?;
+        let api = hidapi::HidApi::new()?;
+        let hid_device = api.open_path(&path)?;
+        let info = hid_device.get_device_info()?;
+
+        if info.vendor_id() != VID
+            || !GO2_PIDS.contains(&info.product_id())
+            || info.interface_number() != GP_IID
+        {
+            return Err(format!("Device '{fmtpath}' is not a Legion Go S Controller").into());
+        }
+
+        Ok(Self {
+            udev_device,
+            hid_device,
+            filtered_events: Default::default(),
+            first_touch: Instant::now(),
+            is_clicked: false,
+            is_touching: false,
+            last_touch: Instant::now(),
+            touch_started: false,
+            state: None,
+        })
+    }
+
+    //TODO: Using InputPlumber Capability enum prevents this driver from having the ability to be
+    //a standalone crate. When this driver is eventually separated, refactor the Event type to
+    //follow the pattern DeviceEvent(Event, Value) and create a match table for
+    //Capability->Event/Event->Capability in the SourceDriver implementation.
+    pub fn update_filtered_events(&mut self, events: HashSet<Capability>) {
+        self.filtered_events = events;
+    }
+
+    pub fn get_default_event_filter(
+        &self,
+    ) -> Result<HashSet<Capability>, Box<dyn Error + Send + Sync>> {
+        let device = self.udev_device.get_device()?;
+        let Some(parent) = device.parent() else {
+            return Ok(HashSet::from(DEFAULT_EVENT_FILTER));
+        };
+
+        let Some(driver) = parent.driver() else {
+            return Ok(HashSet::from(DEFAULT_EVENT_FILTER));
+        };
+
+        let Some(driver) = driver.to_str() else {
+            return Ok(HashSet::from(DEFAULT_EVENT_FILTER));
+        };
+
+        let filtered_events = match driver {
+            "hid-lenovo-go" => HashSet::from([
+                Capability::Accelerometer(Source::Left),
+                Capability::Accelerometer(Source::Right),
+                Capability::Gyroscope(Source::Left),
+                Capability::Gyroscope(Source::Right),
+            ]),
+
+            _ => HashSet::from(DEFAULT_EVENT_FILTER),
+        };
+
+        Ok(filtered_events)
+    }
+
+    /// Poll the device and read input reports
+    pub fn poll(&mut self) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
+        // Read data from the device into a buffer
+        let mut buf = [0; XINPUT_PACKET_SIZE];
+        let bytes_read = self.hid_device.read_timeout(&mut buf[..], HID_TIMEOUT)?;
+
+        if bytes_read > XINPUT_PACKET_SIZE {
+            return Err("Invalid packet size for X-Input Data.".into());
+        }
+
+        let report_id = buf[0];
+        let command_id = buf[2];
+
+        // Configuration event responses happen on the same endpoint. If this data packet isn't
+        // specifically xinput data it can crash the driver, so block it.
+        if command_id != XINPUT_COMMAND_ID {
+            //log::trace!("Got event that isn't xinput data, skipping");
+            return Ok(vec![]);
+        }
+        let slice = &buf[..bytes_read];
+        //log::trace!("Got Report ID: {report_id}");
+        //log::trace!("Got Report Size: {bytes_read}");
+        //log::trace!("Raw Data: {:02x?}", buf);
+
+        let events = match report_id {
+            XINPUT_DATA => {
+                if bytes_read != XINPUT_PACKET_SIZE {
+                    return Err("Invalid packet size for X-Input Data.".into());
+                }
+                // Handle the incoming input report
+                let sized_buf = slice.try_into()?;
+
+                self.handle_xinput_report(sized_buf)?
+            }
+            _ => {
+                //log::trace!("Invalid Report ID.");
+                let events = vec![];
+                events
+            }
+        };
+
+        Ok(events)
+    }
+
+    /// Unpacks the buffer into a [XinputDataReport] structure and updates
+    /// the internal xinput_state
+    fn handle_xinput_report(
+        &mut self,
+        buf: [u8; XINPUT_PACKET_SIZE],
+    ) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
+        let input_report = XInputDataReport::unpack(&buf)?;
+
+        // Print input report for debugging
+        //log::debug!("--- Input report ---");
+        //log::debug!("{input_report}");
+        //log::debug!(" ---- End Report ----");
+
+        // Update the state
+        let old_state = self.update_xinput_state(input_report);
+
+        // Translate the state into a stream of input events
+        let events = self.translate_xinput(old_state);
+
+        Ok(events)
+    }
+
+    /// Update gamepad state
+    fn update_xinput_state(&mut self, input_report: XInputDataReport) -> Option<XInputDataReport> {
+        let old_state = self.state;
+        self.state = Some(input_report);
+        old_state
+    }
+
+    /// Translate the state into individual events
+    fn translate_xinput(&mut self, old_state: Option<XInputDataReport>) -> Vec<Event> {
+        let mut events = Vec::new();
+        let Some(state) = self.state else {
+            return events;
+        };
+
+        // Translate state changes into events if they have changed
+        if let Some(old_state) = old_state {
+            if state.gamepad_mode != old_state.gamepad_mode {
+                log::debug!(
+                    "Gamepad mode changed from {} to {}",
+                    old_state.gamepad_mode,
+                    state.gamepad_mode
+                );
+            }
+
+            if state.gamepad_mode == GamepadMode::Fps {
+                //log::debug!("In FPS Mode, rejecting gamepad input.");
+                if state.legion != old_state.legion {
+                    events.push(Event::GamepadButton(GamepadButtonEvent::Legion(
+                        BinaryInput {
+                            pressed: state.legion,
+                        },
+                    )));
+                }
+                if state.quick_access != old_state.quick_access {
+                    events.push(Event::GamepadButton(GamepadButtonEvent::QuickAccess(
+                        BinaryInput {
+                            pressed: state.quick_access,
+                        },
+                    )));
+                }
+                return events;
+            }
+
+            // Binary Events
+            if state.a != old_state.a {
+                events.push(Event::GamepadButton(GamepadButtonEvent::A(BinaryInput {
+                    pressed: state.a,
+                })));
+            }
+            if state.b != old_state.b {
+                events.push(Event::GamepadButton(GamepadButtonEvent::B(BinaryInput {
+                    pressed: state.b,
+                })));
+            }
+            if state.x != old_state.x {
+                events.push(Event::GamepadButton(GamepadButtonEvent::X(BinaryInput {
+                    pressed: state.x,
+                })));
+            }
+            if state.y != old_state.y {
+                events.push(Event::GamepadButton(GamepadButtonEvent::Y(BinaryInput {
+                    pressed: state.y,
+                })));
+            }
+            if state.menu != old_state.menu {
+                events.push(Event::GamepadButton(GamepadButtonEvent::Menu(
+                    BinaryInput {
+                        pressed: state.menu,
+                    },
+                )));
+            }
+            if state.view != old_state.view {
+                events.push(Event::GamepadButton(GamepadButtonEvent::View(
+                    BinaryInput {
+                        pressed: state.view,
+                    },
+                )));
+            }
+            if state.legion != old_state.legion {
+                events.push(Event::GamepadButton(GamepadButtonEvent::Legion(
+                    BinaryInput {
+                        pressed: state.legion,
+                    },
+                )));
+            }
+            if state.quick_access != old_state.quick_access {
+                events.push(Event::GamepadButton(GamepadButtonEvent::QuickAccess(
+                    BinaryInput {
+                        pressed: state.quick_access,
+                    },
+                )));
+            }
+            if state.down != old_state.down {
+                events.push(Event::GamepadButton(GamepadButtonEvent::DPadDown(
+                    BinaryInput {
+                        pressed: state.down,
+                    },
+                )));
+            }
+            if state.up != old_state.up {
+                events.push(Event::GamepadButton(GamepadButtonEvent::DPadUp(
+                    BinaryInput { pressed: state.up },
+                )));
+            }
+            if state.left != old_state.left {
+                events.push(Event::GamepadButton(GamepadButtonEvent::DPadLeft(
+                    BinaryInput {
+                        pressed: state.left,
+                    },
+                )));
+            }
+            if state.right != old_state.right {
+                events.push(Event::GamepadButton(GamepadButtonEvent::DPadRight(
+                    BinaryInput {
+                        pressed: state.right,
+                    },
+                )));
+            }
+            if state.lb != old_state.lb {
+                events.push(Event::GamepadButton(GamepadButtonEvent::LB(BinaryInput {
+                    pressed: state.lb,
+                })));
+            }
+            if state.rb != old_state.rb {
+                events.push(Event::GamepadButton(GamepadButtonEvent::RB(BinaryInput {
+                    pressed: state.rb,
+                })));
+            }
+            if state.d_trigger_l != old_state.d_trigger_l {
+                events.push(Event::GamepadButton(GamepadButtonEvent::DTriggerL(
+                    BinaryInput {
+                        pressed: state.d_trigger_l,
+                    },
+                )));
+            }
+            if state.d_trigger_r != old_state.d_trigger_r {
+                events.push(Event::GamepadButton(GamepadButtonEvent::DTriggerR(
+                    BinaryInput {
+                        pressed: state.d_trigger_r,
+                    },
+                )));
+            }
+            if state.m1 != old_state.m1 {
+                events.push(Event::GamepadButton(GamepadButtonEvent::M1(BinaryInput {
+                    pressed: state.m1,
+                })));
+            }
+            if state.m2 != old_state.m2 {
+                events.push(Event::GamepadButton(GamepadButtonEvent::M2(BinaryInput {
+                    pressed: state.m2,
+                })));
+            }
+            if state.m3 != old_state.m3 {
+                events.push(Event::GamepadButton(GamepadButtonEvent::M3(BinaryInput {
+                    pressed: state.m3,
+                })));
+            }
+            if state.y1 != old_state.y1 {
+                events.push(Event::GamepadButton(GamepadButtonEvent::Y1(BinaryInput {
+                    pressed: state.y1,
+                })));
+            }
+            if state.y2 != old_state.y2 {
+                events.push(Event::GamepadButton(GamepadButtonEvent::Y2(BinaryInput {
+                    pressed: state.y2,
+                })));
+            }
+            if state.y3 != old_state.y3 {
+                events.push(Event::GamepadButton(GamepadButtonEvent::Y3(BinaryInput {
+                    pressed: state.y3,
+                })));
+            }
+            if state.mouse_click != old_state.mouse_click {
+                events.push(Event::GamepadButton(GamepadButtonEvent::MouseClick(
+                    BinaryInput {
+                        pressed: state.mouse_click,
+                    },
+                )));
+            }
+            if state.show_desktop != old_state.show_desktop {
+                events.push(Event::GamepadButton(GamepadButtonEvent::ShowDesktop(
+                    BinaryInput {
+                        pressed: state.show_desktop,
+                    },
+                )));
+            }
+            if state.alt_tab != old_state.alt_tab {
+                events.push(Event::GamepadButton(GamepadButtonEvent::AltTab(
+                    BinaryInput {
+                        pressed: state.alt_tab,
+                    },
+                )));
+            }
+            if state.thumb_l != old_state.thumb_l {
+                events.push(Event::GamepadButton(GamepadButtonEvent::ThumbL(
+                    BinaryInput {
+                        pressed: state.thumb_l,
+                    },
+                )));
+            }
+            if state.thumb_r != old_state.thumb_r {
+                events.push(Event::GamepadButton(GamepadButtonEvent::ThumbR(
+                    BinaryInput {
+                        pressed: state.thumb_r,
+                    },
+                )));
+            }
+
+            // Axis events
+            if state.l_stick_x != old_state.l_stick_x || state.l_stick_y != old_state.l_stick_y {
+                events.push(Event::Axis(AxisEvent::LStick(JoyAxisInput {
+                    x: state.l_stick_x,
+                    y: state.l_stick_y,
+                })));
+            }
+            if state.r_stick_x != old_state.r_stick_x || state.r_stick_y != old_state.r_stick_y {
+                events.push(Event::Axis(AxisEvent::RStick(JoyAxisInput {
+                    x: state.r_stick_x,
+                    y: state.r_stick_y,
+                })));
+            }
+
+            if state.a_trigger_l != old_state.a_trigger_l {
+                events.push(Event::Trigger(TriggerEvent::ATriggerL(TriggerInput {
+                    value: state.a_trigger_l,
+                })));
+            }
+            if state.a_trigger_r != old_state.a_trigger_r {
+                events.push(Event::Trigger(TriggerEvent::ATriggerR(TriggerInput {
+                    value: state.a_trigger_r,
+                })));
+            }
+            if state.mouse_z != old_state.mouse_z {
+                log::debug!("Raw mouse value: {:b}, {}", state.mouse_z, !state.mouse_z);
+                let value = state.mouse_z.wrapping_sub(128) as i8;
+                let value = match value {
+                    64..=127 => value - 127 - 1,
+                    v => v,
+                };
+
+                log::debug!("Normalized mouse value: {value}");
+                events.push(Event::Trigger(TriggerEvent::MouseWheel(MouseWheelInput {
+                    value,
+                })));
+            }
+
+            // IMU Events
+            if state.l_con_state != old_state.l_con_state
+                || state.r_con_state != old_state.r_con_state
+            {
+                log::trace!("Left controller connected state: {:?}", state.l_con_state);
+                log::trace!("Right controller connected state: {:?}", state.r_con_state);
+            }
+            if !self
+                .filtered_events
+                .contains(&Capability::Accelerometer(Source::Left))
+                && (state.left_accel_x != old_state.left_accel_x
+                    || state.left_accel_y != old_state.left_accel_y
+                    || state.left_accel_z != old_state.left_accel_z)
+            {
+                events.push(Event::Axis(AxisEvent::LeftAccel(ImuAxisInput {
+                    pitch: -state.left_accel_x,
+                    roll: state.left_accel_y,
+                    yaw: state.left_accel_z,
+                })))
+            }
+            if !self
+                .filtered_events
+                .contains(&Capability::Accelerometer(Source::Right))
+                && (state.right_accel_x != old_state.right_accel_x
+                    || state.right_accel_y != old_state.right_accel_y
+                    || state.right_accel_z != old_state.right_accel_z)
+            {
+                events.push(Event::Axis(AxisEvent::RightAccel(ImuAxisInput {
+                    pitch: -state.right_accel_x,
+                    roll: -state.right_accel_y,
+                    yaw: state.right_accel_z,
+                })))
+            }
+            if !self
+                .filtered_events
+                .contains(&Capability::Accelerometer(Source::Center))
+                && (state.left_accel_x != old_state.left_accel_x
+                    || state.left_accel_y != old_state.left_accel_y
+                    || state.left_accel_z != old_state.left_accel_z
+                    || state.right_accel_x != old_state.right_accel_x
+                    || state.right_accel_y != old_state.right_accel_y
+                    || state.right_accel_z != old_state.right_accel_z)
+            {
+                events.push(Event::Axis(AxisEvent::MultiAccel(ImuAxisInput {
+                    pitch: -(state.left_accel_x + state.right_accel_x) / 2,
+                    roll: (state.left_accel_y + state.right_accel_y) / 2,
+                    yaw: (state.left_accel_z + state.right_accel_z) / 2,
+                })))
+            }
+            if !self
+                .filtered_events
+                .contains(&Capability::Gyroscope(Source::Left))
+                && (state.left_gyro_x != old_state.left_gyro_x
+                    || state.left_gyro_y != old_state.left_gyro_y
+                    || state.left_gyro_z != old_state.left_gyro_z)
+            {
+                events.push(Event::Axis(AxisEvent::LeftGyro(ImuAxisInput {
+                    pitch: -state.left_gyro_x,
+                    roll: state.left_gyro_y,
+                    yaw: state.left_gyro_z,
+                })))
+            }
+            if !self
+                .filtered_events
+                .contains(&Capability::Gyroscope(Source::Right))
+                && (state.right_gyro_x != old_state.right_gyro_x
+                    || state.right_gyro_y != old_state.right_gyro_y
+                    || state.right_gyro_z != old_state.right_gyro_z)
+            {
+                events.push(Event::Axis(AxisEvent::RightGyro(ImuAxisInput {
+                    pitch: -state.right_gyro_x,
+                    roll: state.right_gyro_y,
+                    yaw: state.right_gyro_z,
+                })))
+            }
+
+            if !self
+                .filtered_events
+                .contains(&Capability::Gyroscope(Source::Center))
+                && (state.left_gyro_x != old_state.left_gyro_x
+                    || state.left_gyro_y != old_state.left_gyro_y
+                    || state.left_gyro_z != old_state.left_gyro_z
+                    || state.right_gyro_x != old_state.right_gyro_x
+                    || state.right_gyro_y != old_state.right_gyro_y
+                    || state.right_gyro_z != old_state.right_gyro_z)
+            {
+                events.push(Event::Axis(AxisEvent::MultiGyro(ImuAxisInput {
+                    pitch: -(state.left_gyro_x + state.right_gyro_x) / 2,
+                    roll: (state.left_gyro_y + state.right_gyro_y) / 2,
+                    yaw: (state.left_gyro_z + state.right_gyro_z) / 2,
+                })))
+            }
+
+            // Touchpad events
+            // Detect if we are touching or not, x, y will always be 0, 0 when the pad is not
+            // touched.
+            self.is_touching = state.touch_x != 0 && state.touch_y != 0;
+
+            // Handle touching
+            if self.is_touching {
+                self.last_touch = Instant::now();
+
+                // If this is the first event of a new touch, log the time.
+                if !self.touch_started {
+                    log::trace!("START Touch");
+                    log::trace!("Last touch elapsed: {:?}", self.last_touch.elapsed());
+
+                    self.touch_started = true;
+                    self.first_touch = Instant::now();
+                }
+            // Handle tap to click
+            } else if !self.is_touching
+                && self.touch_started
+                && self.first_touch.elapsed() < CLICK_DELAY
+            {
+                // Handle double click
+                if self.is_clicked && self.first_touch.elapsed() < RELEASE_DELAY {
+                    log::trace!("Double Click");
+                    let mut new_events = self.release_click();
+                    events.append(&mut new_events);
+                }
+                let mut click_events = self.start_click();
+                events.append(&mut click_events);
+            // Handle release events
+            } else if !self.is_touching && self.last_touch.elapsed() > RELEASE_DELAY {
+                // Unclick if we we clicking and are no longer touching.
+                if self.is_clicked {
+                    let mut new_events = self.release_click();
+                    events.append(&mut new_events);
+                }
+
+                // Clear this touch sequence
+                if self.touch_started {
+                    self.touch_started = false;
+                    log::trace!("END Touch");
+                }
+            }
+
+            if state.touch_x != old_state.touch_x || state.touch_y != old_state.touch_y {
+                events.push(Event::Axis(AxisEvent::Touchpad(TouchAxisInput {
+                    index: 0,
+                    is_touching: self.is_touching,
+                    x: state.touch_x,
+                    y: state.touch_y,
+                })));
+            }
+        }
+        events
+    }
+
+    fn start_click(&mut self) -> Vec<Event> {
+        if self.is_clicked {
+            log::trace!("Rejecting extra click");
+            return vec![];
+        }
+        log::trace!("Started CLICK event.");
+        log::trace!("First touch elapsed: {:?}", self.first_touch.elapsed());
+        log::trace!("Last touch elapsed: {:?}", self.last_touch.elapsed());
+        self.is_clicked = true;
+        let mut events = Vec::new();
+
+        let event = Event::TouchButton(TouchButtonEvent::Left(BinaryInput { pressed: true }));
+        events.push(event);
+        // The touchpad doesn't have a force sensor. The deck target wont produce a "click"
+        // event in desktop or lizard mode without a force value. Simulate a 1/4 press to work
+        // around this.
+        let event = Event::Trigger(TriggerEvent::RpadForce(TriggerInput {
+            value: PAD_FORCE_NORMAL,
+        }));
+        events.push(event);
+        events
+    }
+
+    fn release_click(&mut self) -> Vec<Event> {
+        log::trace!("Released CLICK event.");
+        log::trace!("First touch elapsed: {:?}", self.first_touch.elapsed());
+        log::trace!("Last touch elapsed: {:?}", self.last_touch.elapsed());
+        self.is_clicked = false;
+        self.touch_started = false;
+        let mut events = Vec::new();
+        let event = Event::TouchButton(TouchButtonEvent::Left(BinaryInput { pressed: false }));
+        events.push(event);
+        // The touchpad doesn't have a force sensor. The deck target wont produce a "click"
+        // event in desktop or lizard mode without a force value. Simulate a 1/4 press to work
+        // around this.
+        let event = Event::Trigger(TriggerEvent::RpadForce(TriggerInput { value: 0 }));
+        events.push(event);
+        events
+    }
+}

--- a/src/drivers/lego/mod.rs
+++ b/src/drivers/lego/mod.rs
@@ -1,5 +1,6 @@
-pub mod driver;
 pub mod event;
+pub mod go1_driver;
+pub mod go2_driver;
 pub mod hid_report;
 
 use std::time::Duration;
@@ -7,27 +8,34 @@ use std::time::Duration;
 use crate::input::capability::{Capability, Source};
 
 // Hardware ID's
+pub const VID: u16 = 0x17ef;
+pub const GP_IID: i32 = 0x02;
+
+// Go 1
 const LEGO_1_XINPUT_PID: u16 = 0x6182;
 const LEGO_1_DINPUT_ATTACHED_PID: u16 = 0x6183;
 const LEGO_1_DINPUT_DETACHED_PID: u16 = 0x6184;
 const LEGO_1_FPS_PID: u16 = 0x6185;
+
+pub const GO1_PIDS: [u16; 4] = [
+    LEGO_1_XINPUT_PID,
+    LEGO_1_DINPUT_ATTACHED_PID,
+    LEGO_1_DINPUT_DETACHED_PID,
+    LEGO_1_FPS_PID,
+];
+
+// Go 2
 const LEGO_2_XINPUT_PID: u16 = 0x61eb;
 const LEGO_2_DINPUT_ATTACHED_PID: u16 = 0x61ec;
 const LEGO_2_DINPUT_DETATCHED_PID: u16 = 0x61ed;
 const LEGO_2_FPS_PID: u16 = 0x61ee;
 
-pub const PIDS: [u16; 8] = [
-    LEGO_1_XINPUT_PID,
-    LEGO_1_DINPUT_ATTACHED_PID,
-    LEGO_1_DINPUT_DETACHED_PID,
-    LEGO_1_FPS_PID,
+pub const GO2_PIDS: [u16; 4] = [
     LEGO_2_XINPUT_PID,
     LEGO_2_DINPUT_ATTACHED_PID,
     LEGO_2_DINPUT_DETATCHED_PID,
     LEGO_2_FPS_PID,
 ];
-pub const VID: u16 = 0x17ef;
-pub const GP_IID: i32 = 0x02;
 
 const CLICK_DELAY: Duration = Duration::from_millis(150);
 const RELEASE_DELAY: Duration = Duration::from_millis(30);

--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -1570,6 +1570,7 @@ impl CompositeDevice {
     /// Executed whenever a source device is added to this [CompositeDevice].
     async fn on_source_device_added(&mut self, device: DeviceInfo) -> Result<(), Box<dyn Error>> {
         if let Err(e) = self.add_source_device(device) {
+            log::error!("add_source_device failed: {:?}", e);
             return Err(e.to_string().into());
         }
         self.run_source_devices().await?;

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -6,6 +6,7 @@ pub mod gpd_win_mini_macro_keyboard;
 pub mod gpd_win_mini_touchpad;
 pub mod horipad_steam;
 pub mod legion_go;
+pub mod legion_go2;
 pub mod legos_imu;
 pub mod legos_touchpad;
 pub mod legos_xinput;
@@ -17,18 +18,6 @@ pub mod xpad_uhid;
 pub mod zotac_zone;
 
 use std::{error::Error, time::Duration};
-
-use blocked::BlockedHidrawDevice;
-use flydigi_vader_4_pro::Vader4Pro;
-use gpd_win_mini_macro_keyboard::GpdWinMiniMacroKeyboard;
-use gpd_win_mini_touchpad::GpdWinMiniTouchpad;
-use horipad_steam::HoripadSteam;
-use legos_imu::LegionSImuController;
-use legos_touchpad::LegionSTouchpadController;
-use oxp_hid::OxpHid;
-use rog_ally::RogAlly;
-use xpad_uhid::XpadUhid;
-use zotac_zone::ZotacZone;
 
 use crate::{
     config,
@@ -42,10 +31,14 @@ use crate::{
 };
 
 use self::{
-    dualsense::DualSenseController, fts3528::Fts3528Touchscreen, legion_go::LegionGoController,
-    legos_xinput::LegionSXInputController, opineo::OrangePiNeoTouchpad, steam_deck::DeckController,
+    blocked::BlockedHidrawDevice, dualsense::DualSenseController, flydigi_vader_4_pro::Vader4Pro,
+    fts3528::Fts3528Touchscreen, gpd_win_mini_macro_keyboard::GpdWinMiniMacroKeyboard,
+    gpd_win_mini_touchpad::GpdWinMiniTouchpad, horipad_steam::HoripadSteam,
+    legion_go::LegionGoController, legion_go2::LegionGo2Controller,
+    legos_imu::LegionSImuController, legos_touchpad::LegionSTouchpadController,
+    legos_xinput::LegionSXInputController, opineo::OrangePiNeoTouchpad, oxp_hid::OxpHid,
+    rog_ally::RogAlly, steam_deck::DeckController, xpad_uhid::XpadUhid, zotac_zone::ZotacZone,
 };
-
 use super::{InputError, OutputError, SourceDeviceCompatible, SourceDriver, SourceDriverOptions};
 
 /// List of available drivers
@@ -53,13 +46,14 @@ enum DriverType {
     Blocked,
     DualSense,
     Fts3528Touchscreen,
-    GpdWinMiniTouchpad,
     GpdWinMiniMacroKeyboard,
+    GpdWinMiniTouchpad,
     HoripadSteam,
+    LegionGo,
+    LegionGo2,
     LegionGoSImu,
     LegionGoSTouchpad,
     LegionGoSXInput,
-    LegionGoXInput,
     OrangePiNeo,
     OxpHid,
     RogAlly,
@@ -76,13 +70,14 @@ pub enum HidRawDevice {
     Blocked(SourceDriver<BlockedHidrawDevice>),
     DualSense(SourceDriver<DualSenseController>),
     Fts3528Touchscreen(SourceDriver<Fts3528Touchscreen>),
-    GpdWinMiniTouchpad(SourceDriver<GpdWinMiniTouchpad>),
     GpdWinMiniMacroKeyboard(SourceDriver<GpdWinMiniMacroKeyboard>),
+    GpdWinMiniTouchpad(SourceDriver<GpdWinMiniTouchpad>),
     HoripadSteam(SourceDriver<HoripadSteam>),
+    LegionGo(SourceDriver<LegionGoController>),
+    LegionGo2(SourceDriver<LegionGo2Controller>),
     LegionGoSImu(SourceDriver<LegionSImuController>),
     LegionGoSTouchpad(SourceDriver<LegionSTouchpadController>),
     LegionGoSXInput(SourceDriver<LegionSXInputController>),
-    LegionGo(SourceDriver<LegionGoController>),
     OrangePiNeo(SourceDriver<OrangePiNeoTouchpad>),
     OxpHid(SourceDriver<OxpHid>),
     RogAlly(SourceDriver<RogAlly>),
@@ -98,13 +93,14 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::Blocked(source_driver) => source_driver.info_ref(),
             HidRawDevice::DualSense(source_driver) => source_driver.info_ref(),
             HidRawDevice::Fts3528Touchscreen(source_driver) => source_driver.info_ref(),
-            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.info_ref(),
             HidRawDevice::GpdWinMiniMacroKeyboard(source_driver) => source_driver.info_ref(),
+            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.info_ref(),
             HidRawDevice::HoripadSteam(source_driver) => source_driver.info_ref(),
+            HidRawDevice::LegionGo(source_driver) => source_driver.info_ref(),
+            HidRawDevice::LegionGo2(source_driver) => source_driver.info_ref(),
             HidRawDevice::LegionGoSImu(source_driver) => source_driver.info_ref(),
             HidRawDevice::LegionGoSTouchpad(source_driver) => source_driver.info_ref(),
             HidRawDevice::LegionGoSXInput(source_driver) => source_driver.info_ref(),
-            HidRawDevice::LegionGo(source_driver) => source_driver.info_ref(),
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.info_ref(),
             HidRawDevice::OxpHid(source_driver) => source_driver.info_ref(),
             HidRawDevice::RogAlly(source_driver) => source_driver.info_ref(),
@@ -120,13 +116,14 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::Blocked(source_driver) => source_driver.get_id(),
             HidRawDevice::DualSense(source_driver) => source_driver.get_id(),
             HidRawDevice::Fts3528Touchscreen(source_driver) => source_driver.get_id(),
-            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.get_id(),
             HidRawDevice::GpdWinMiniMacroKeyboard(source_driver) => source_driver.get_id(),
+            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.get_id(),
             HidRawDevice::HoripadSteam(source_driver) => source_driver.get_id(),
+            HidRawDevice::LegionGo(source_driver) => source_driver.get_id(),
+            HidRawDevice::LegionGo2(source_driver) => source_driver.get_id(),
             HidRawDevice::LegionGoSImu(source_driver) => source_driver.get_id(),
             HidRawDevice::LegionGoSTouchpad(source_driver) => source_driver.get_id(),
             HidRawDevice::LegionGoSXInput(source_driver) => source_driver.get_id(),
-            HidRawDevice::LegionGo(source_driver) => source_driver.get_id(),
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.get_id(),
             HidRawDevice::OxpHid(source_driver) => source_driver.get_id(),
             HidRawDevice::RogAlly(source_driver) => source_driver.get_id(),
@@ -142,13 +139,14 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::Blocked(source_driver) => source_driver.client(),
             HidRawDevice::DualSense(source_driver) => source_driver.client(),
             HidRawDevice::Fts3528Touchscreen(source_driver) => source_driver.client(),
-            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.client(),
             HidRawDevice::GpdWinMiniMacroKeyboard(source_driver) => source_driver.client(),
+            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.client(),
             HidRawDevice::HoripadSteam(source_driver) => source_driver.client(),
+            HidRawDevice::LegionGo(source_driver) => source_driver.client(),
+            HidRawDevice::LegionGo2(source_driver) => source_driver.client(),
             HidRawDevice::LegionGoSImu(source_driver) => source_driver.client(),
             HidRawDevice::LegionGoSTouchpad(source_driver) => source_driver.client(),
             HidRawDevice::LegionGoSXInput(source_driver) => source_driver.client(),
-            HidRawDevice::LegionGo(source_driver) => source_driver.client(),
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.client(),
             HidRawDevice::OxpHid(source_driver) => source_driver.client(),
             HidRawDevice::RogAlly(source_driver) => source_driver.client(),
@@ -164,13 +162,14 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::Blocked(source_driver) => source_driver.run().await,
             HidRawDevice::DualSense(source_driver) => source_driver.run().await,
             HidRawDevice::Fts3528Touchscreen(source_driver) => source_driver.run().await,
-            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.run().await,
             HidRawDevice::GpdWinMiniMacroKeyboard(source_driver) => source_driver.run().await,
+            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.run().await,
             HidRawDevice::HoripadSteam(source_driver) => source_driver.run().await,
+            HidRawDevice::LegionGo(source_driver) => source_driver.run().await,
+            HidRawDevice::LegionGo2(source_driver) => source_driver.run().await,
             HidRawDevice::LegionGoSImu(source_driver) => source_driver.run().await,
             HidRawDevice::LegionGoSTouchpad(source_driver) => source_driver.run().await,
             HidRawDevice::LegionGoSXInput(source_driver) => source_driver.run().await,
-            HidRawDevice::LegionGo(source_driver) => source_driver.run().await,
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.run().await,
             HidRawDevice::OxpHid(source_driver) => source_driver.run().await,
             HidRawDevice::RogAlly(source_driver) => source_driver.run().await,
@@ -186,15 +185,16 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::Blocked(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::DualSense(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::Fts3528Touchscreen(source_driver) => source_driver.get_capabilities(),
-            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::GpdWinMiniMacroKeyboard(source_driver) => {
                 source_driver.get_capabilities()
             }
+            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::HoripadSteam(source_driver) => source_driver.get_capabilities(),
+            HidRawDevice::LegionGo(source_driver) => source_driver.get_capabilities(),
+            HidRawDevice::LegionGo2(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::LegionGoSImu(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::LegionGoSTouchpad(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::LegionGoSXInput(source_driver) => source_driver.get_capabilities(),
-            HidRawDevice::LegionGo(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::OxpHid(source_driver) => source_driver.get_capabilities(),
             HidRawDevice::RogAlly(source_driver) => source_driver.get_capabilities(),
@@ -212,19 +212,20 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::Fts3528Touchscreen(source_driver) => {
                 source_driver.get_output_capabilities()
             }
-            HidRawDevice::GpdWinMiniTouchpad(source_driver) => {
-                source_driver.get_output_capabilities()
-            }
             HidRawDevice::GpdWinMiniMacroKeyboard(source_driver) => {
                 source_driver.get_output_capabilities()
             }
+            HidRawDevice::GpdWinMiniTouchpad(source_driver) => {
+                source_driver.get_output_capabilities()
+            }
             HidRawDevice::HoripadSteam(source_driver) => source_driver.get_output_capabilities(),
+            HidRawDevice::LegionGo(source_driver) => source_driver.get_output_capabilities(),
+            HidRawDevice::LegionGo2(source_driver) => source_driver.get_output_capabilities(),
             HidRawDevice::LegionGoSImu(source_driver) => source_driver.get_output_capabilities(),
             HidRawDevice::LegionGoSTouchpad(source_driver) => {
                 source_driver.get_output_capabilities()
             }
             HidRawDevice::LegionGoSXInput(source_driver) => source_driver.get_output_capabilities(),
-            HidRawDevice::LegionGo(source_driver) => source_driver.get_output_capabilities(),
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.get_output_capabilities(),
             HidRawDevice::OxpHid(source_driver) => source_driver.get_output_capabilities(),
             HidRawDevice::RogAlly(source_driver) => source_driver.get_output_capabilities(),
@@ -240,13 +241,14 @@ impl SourceDeviceCompatible for HidRawDevice {
             HidRawDevice::Blocked(source_driver) => source_driver.get_device_path(),
             HidRawDevice::DualSense(source_driver) => source_driver.get_device_path(),
             HidRawDevice::Fts3528Touchscreen(source_driver) => source_driver.get_device_path(),
-            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.get_device_path(),
             HidRawDevice::GpdWinMiniMacroKeyboard(source_driver) => source_driver.get_device_path(),
+            HidRawDevice::GpdWinMiniTouchpad(source_driver) => source_driver.get_device_path(),
             HidRawDevice::HoripadSteam(source_driver) => source_driver.get_device_path(),
+            HidRawDevice::LegionGo(source_driver) => source_driver.get_device_path(),
+            HidRawDevice::LegionGo2(source_driver) => source_driver.get_device_path(),
             HidRawDevice::LegionGoSImu(source_driver) => source_driver.get_device_path(),
             HidRawDevice::LegionGoSTouchpad(source_driver) => source_driver.get_device_path(),
             HidRawDevice::LegionGoSXInput(source_driver) => source_driver.get_device_path(),
-            HidRawDevice::LegionGo(source_driver) => source_driver.get_device_path(),
             HidRawDevice::OrangePiNeo(source_driver) => source_driver.get_device_path(),
             HidRawDevice::OxpHid(source_driver) => source_driver.get_device_path(),
             HidRawDevice::RogAlly(source_driver) => source_driver.get_device_path(),
@@ -317,11 +319,17 @@ impl HidRawDevice {
                 );
                 Ok(Self::SteamDeck(source_device))
             }
-            DriverType::LegionGoXInput => {
+            DriverType::LegionGo => {
                 let device = LegionGoController::new(device_info.clone())?;
                 let source_device =
                     SourceDriver::new(composite_device, device, device_info.into(), conf);
                 Ok(Self::LegionGo(source_device))
+            }
+            DriverType::LegionGo2 => {
+                let device = LegionGo2Controller::new(device_info.clone())?;
+                let source_device =
+                    SourceDriver::new(composite_device, device, device_info.into(), conf);
+                Ok(Self::LegionGo2(source_device))
             }
             DriverType::LegionGoSImu => {
                 let options = SourceDriverOptions {
@@ -482,13 +490,22 @@ impl HidRawDevice {
             return DriverType::SteamDeck;
         }
 
-        // Legion Go XInput
+        // Legion Go
         if vid == drivers::lego::VID
-            && drivers::lego::PIDS.contains(&pid)
+            && drivers::lego::GO1_PIDS.contains(&pid)
             && iid == drivers::lego::GP_IID
         {
             log::info!("Detected Legion Go Controller");
-            return DriverType::LegionGoXInput;
+            return DriverType::LegionGo;
+        }
+
+        // Legion Go 2
+        if vid == drivers::lego::VID
+            && drivers::lego::GO2_PIDS.contains(&pid)
+            && iid == drivers::lego::GP_IID
+        {
+            log::info!("Detected Legion Go 2 Controller");
+            return DriverType::LegionGo2;
         }
 
         // Legion Go S IMU

--- a/src/input/source/hidraw/legion_go2.rs
+++ b/src/input/source/hidraw/legion_go2.rs
@@ -4,14 +4,14 @@ use std::{error::Error, fmt::Debug};
 use crate::{
     drivers::lego::{
         event::{self, AxisEvent},
-        go1_driver::Driver,
+        go2_driver::Driver,
         PAD_FORCE_MAX, PAD_X_MAX, PAD_Y_MAX, STICK_X_MAX, STICK_X_MIN, STICK_Y_MAX, STICK_Y_MIN,
         TRIGG_MAX,
     },
     input::{
         capability::{
             Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger, Mouse, MouseButton,
-            Touch, TouchButton, Touchpad,
+            Source, Touch, TouchButton, Touchpad,
         },
         event::{
             native::NativeEvent,
@@ -24,11 +24,11 @@ use crate::{
 };
 
 /// Legion Go Controller source device implementation
-pub struct LegionGoController {
+pub struct LegionGo2Controller {
     driver: Driver,
 }
 
-impl LegionGoController {
+impl LegionGo2Controller {
     /// Create a new Legion controller source device with the given udev
     /// device information
     pub fn new(device_info: UdevDevice) -> Result<Self, Box<dyn Error + Send + Sync>> {
@@ -145,11 +145,22 @@ impl LegionGoController {
                     Capability::Gamepad(Gamepad::Button(GamepadButton::RightStickTouch)),
                     InputValue::Bool(value.pressed),
                 ),
+                event::GamepadButtonEvent::M1(value) => NativeEvent::new(
+                    Capability::Gamepad(Gamepad::Button(GamepadButton::LeftStickTouch)),
+                    InputValue::Bool(value.pressed),
+                ),
                 event::GamepadButtonEvent::MouseClick(value) => NativeEvent::new(
                     Capability::Mouse(Mouse::Button(MouseButton::Middle)),
                     InputValue::Bool(value.pressed),
                 ),
-                _ => NativeEvent::new(Capability::NotImplemented, InputValue::None),
+                event::GamepadButtonEvent::ShowDesktop(value) => NativeEvent::new(
+                    Capability::Gamepad(Gamepad::Button(GamepadButton::Keyboard)),
+                    InputValue::Bool(value.pressed),
+                ),
+                event::GamepadButtonEvent::AltTab(value) => NativeEvent::new(
+                    Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess2)),
+                    InputValue::Bool(value.pressed),
+                ),
             },
             event::Event::Axis(axis) => match axis.clone() {
                 AxisEvent::LStick(_) => NativeEvent::new(
@@ -164,7 +175,30 @@ impl LegionGoController {
                     Capability::Touchpad(Touchpad::RightPad(Touch::Motion)),
                     normalize_axis_value(axis),
                 ),
-                _ => NativeEvent::new(Capability::NotImplemented, InputValue::None),
+                AxisEvent::LeftAccel(_) => NativeEvent::new(
+                    Capability::Accelerometer(Source::Left),
+                    normalize_axis_value(axis),
+                ),
+                AxisEvent::LeftGyro(_) => NativeEvent::new(
+                    Capability::Gyroscope(Source::Left),
+                    normalize_axis_value(axis),
+                ),
+                AxisEvent::RightAccel(_) => NativeEvent::new(
+                    Capability::Accelerometer(Source::Right),
+                    normalize_axis_value(axis),
+                ),
+                AxisEvent::RightGyro(_) => NativeEvent::new(
+                    Capability::Gyroscope(Source::Right),
+                    normalize_axis_value(axis),
+                ),
+                AxisEvent::MultiAccel(_) => NativeEvent::new(
+                    Capability::Accelerometer(Source::Center),
+                    normalize_axis_value(axis),
+                ),
+                AxisEvent::MultiGyro(_) => NativeEvent::new(
+                    Capability::Gyroscope(Source::Center),
+                    normalize_axis_value(axis),
+                ),
             },
             event::Event::Trigger(trigg) => match trigg.clone() {
                 event::TriggerEvent::ATriggerL(_) => NativeEvent::new(
@@ -194,7 +228,7 @@ impl LegionGoController {
     }
 }
 
-impl SourceInputDevice for LegionGoController {
+impl SourceInputDevice for LegionGo2Controller {
     /// Poll the source device for input events
     fn poll(&mut self) -> Result<Vec<NativeEvent>, InputError> {
         let events = self.driver.poll()?;
@@ -212,11 +246,22 @@ impl SourceInputDevice for LegionGoController {
         self.driver.update_filtered_events(events);
         Ok(())
     }
+
+    fn get_default_event_filter(&self) -> Result<HashSet<Capability>, InputError> {
+        let filtered_events = self.driver.get_default_event_filter();
+        let filtered_events = match filtered_events {
+            Ok(events) => events,
+            Err(e) => {
+                return Err(format!("Failed to get default event filter: {:?}", e).into());
+            }
+        };
+        Ok(filtered_events)
+    }
 }
 
-impl SourceOutputDevice for LegionGoController {}
+impl SourceOutputDevice for LegionGo2Controller {}
 
-impl Debug for LegionGoController {
+impl Debug for LegionGo2Controller {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LegionController").finish()
     }
@@ -252,6 +297,20 @@ fn normalize_axis_value(event: AxisEvent) -> InputValue {
 
             InputValue::Vector2 { x, y }
         }
+        AxisEvent::LeftAccel(value)
+        | AxisEvent::RightAccel(value)
+        | AxisEvent::MultiAccel(value) => InputValue::Vector3 {
+            x: Some(value.pitch as f64),
+            y: Some(value.roll as f64),
+            z: Some(value.yaw as f64),
+        },
+        AxisEvent::LeftGyro(value) | AxisEvent::RightGyro(value) | AxisEvent::MultiGyro(value) => {
+            InputValue::Vector3 {
+                x: Some(value.pitch as f64),
+                y: Some(value.roll as f64),
+                z: Some(value.yaw as f64),
+            }
+        }
         AxisEvent::Touchpad(value) => {
             let max = PAD_X_MAX;
             let x = normalize_unsigned_value(value.x as f64, max);
@@ -274,7 +333,6 @@ fn normalize_axis_value(event: AxisEvent) -> InputValue {
                 y,
             }
         }
-        _ => InputValue::None,
     }
 }
 
@@ -302,6 +360,9 @@ fn normalize_trigger_value(event: event::TriggerEvent) -> InputValue {
 }
 /// List of all capabilities that the Legion Go driver implements
 pub const CAPABILITIES: &[Capability] = &[
+    Capability::Accelerometer(Source::Center),
+    Capability::Accelerometer(Source::Left),
+    Capability::Accelerometer(Source::Right),
     Capability::Gamepad(Gamepad::Axis(GamepadAxis::LeftStick)),
     Capability::Gamepad(Gamepad::Axis(GamepadAxis::RightStick)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::DPadDown)),
@@ -315,6 +376,7 @@ pub const CAPABILITIES: &[Capability] = &[
     Capability::Gamepad(Gamepad::Button(GamepadButton::LeftPaddle1)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::LeftPaddle2)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::LeftStick)),
+    Capability::Gamepad(Gamepad::Button(GamepadButton::LeftStickTouch)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::LeftTrigger)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::North)),
     Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)),
@@ -333,6 +395,9 @@ pub const CAPABILITIES: &[Capability] = &[
     Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::LeftTrigger)),
     Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::RightTouchpadForce)),
     Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::RightTrigger)),
+    Capability::Gyroscope(Source::Center),
+    Capability::Gyroscope(Source::Left),
+    Capability::Gyroscope(Source::Right),
     Capability::Mouse(Mouse::Wheel),
     Capability::Touchpad(Touchpad::RightPad(Touch::Button(TouchButton::Press))),
     Capability::Touchpad(Touchpad::RightPad(Touch::Motion)),


### PR DESCRIPTION
Fixes multiple regressions on the Legion Go 1 with original firmware by doing the following:
- Split original Go 1 firmware and new Go 2 firmware into separate drivers.
- Remove unsupported events (IMU events, M1, Alt-Tab, and Show Desktop buttons), from the Go 1 driver.
- Remove default event filter from the Go 1 driver.
- Remove Screen based IMU from the Go 2 configuration.

Fixes #597