### PR TITLE
fix(Configuration): Add hidraw uaccess rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,7 @@ uninstall: ## Uninstall inputplumber
 	rm $(PREFIX)/lib/systemd/system/$(NAME)-suspend.service
 	rm $(PREFIX)/lib/udev/hwdb.d/59-inputplumber.hwdb
 	rm $(PREFIX)/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
+	rm $(PREFIX)/lib/udev/hwdb.d/60-inputplumber-uaccess.hwdb
 	rm $(PREFIX)/lib/udev/rules.d/90-inputplumber-autostart.rules
 	rm $(PREFIX)/lib/udev/rules.d/99-inputplumber-device-setup.rules
 	rm -rf $(PREFIX)/share/$(NAME)/devices/

--- a/rootfs/usr/lib/udev/rules.d/60-inputplumber-uaccess.rules
+++ b/rootfs/usr/lib/udev/rules.d/60-inputplumber-uaccess.rules
@@ -1,0 +1,5 @@
+# Valve HID devices hidraw
+SUBSYSTEM=="hidraw", KERNELS=="000[356]:28DE:*", MODE="0660", TAG+="uaccess"
+
+# Sony Controllers hidraw
+SUBSYSTEM=="hidraw", KERNELS=="000[356]:054C:*", MODE="0660", TAG+="uaccess"


### PR DESCRIPTION
Currently we rely on distros to ship uaccess udev rules that make our target devices work. Recently a change to the udev rules in SteamOS (which are then consumed by downstream distros) broke uaccess for the deck-uhid target.

Instead of relying on distros and upstream rules, ship basic rules that ensure full support for our target devices.

Closes #616 