### PR TITLE
feat(Hardware Support): Add MSI Claw 8 EX AI+ profile

### DIFF
--- a/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
+++ b/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
@@ -77,10 +77,11 @@ dmi:*svnLENOVO:pn83Q3:*
 dmi:*svnLENOVO:pn83N0:*
 dmi:*svnLENOVO:pn83N1:*
 # MSI Claw
-dmi:*:svnMicro-StarInternationalCo.,Ltd.:pnClaw7AI+A2VM:*
-dmi:*:svnMicro-StarInternationalCo.,Ltd.:pnClaw8AI+A2VM:*
-dmi:*:svnMicro-StarInternationalCo.,Ltd.:pnClawA8BZ2EM:*
-dmi:*:svnMicro-StarInternationalCo.,Ltd.:pnClawA1M:*
+dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T41:*
+dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T42:*
+dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T52:*
+dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T8K:*
+dmi:*:rvnMicro-StarInternationalCo.,Ltd.:rnMS-1T91:*
 # OneXPlayer Old models
 dmi:*svnONE-NETBOOK:pnONEXPLAYER:*
 dmi:*svnONE-NETBOOKTECHNOLOGYCO.,LTD.:pnONEXPLAYER:*

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw7_a2vm.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw7_a2vm.yaml
@@ -16,8 +16,8 @@ single_source: false
 # /sys/class/dmi/id/product_name
 matches:
   - dmi_data:
-      product_name: "Claw 7 AI+ A2VM"
-      sys_vendor: "Micro-Star International Co., Ltd."
+      board_name: "MS-1T42"
+      board_vendor: "Micro-Star International Co., Ltd."
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw8_a2vm.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw8_a2vm.yaml
@@ -16,8 +16,8 @@ single_source: false
 # /sys/class/dmi/id/product_name
 matches:
   - dmi_data:
-      product_name: "Claw 8 AI+ A2VM*"
-      sys_vendor: "Micro-Star International Co., Ltd."
+      board_name: "MS-1T52"
+      board_vendor: "Micro-Star International Co., Ltd."
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw8_ex_ai_cg3em.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw8_ex_ai_cg3em.yaml
@@ -6,7 +6,7 @@ version: 1
 kind: CompositeDevice
 
 # Name of the composite device mapping
-name: MSI Claw A8 BZ2EM
+name: MSI Claw 8 EX AI+ CG3EM
 
 # Only allow a single source device per composite device of this type.
 single_source: false
@@ -16,13 +16,13 @@ single_source: false
 # /sys/class/dmi/id/product_name
 matches:
   - dmi_data:
-      board_name: "MS-1T8K"
+      board_name: "MS-1T91"
       board_vendor: "Micro-Star International Co., Ltd."
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.
 source_devices:
-  # Face Quick Access
+  # Face Extra Buttons
   - group: keyboard
     udev:
       attributes:
@@ -42,8 +42,9 @@ source_devices:
         - Keyboard:KeyVolumeDown
         - Keyboard:KeyVolumeUp
 
-  # Face Guide
+  # Conflicts, block
   - group: keyboard
+    blocked: true
     udev:
       attributes:
         - name: name
@@ -53,8 +54,6 @@ source_devices:
     events:
       exclude:
         - "*"
-      include:
-        - Keyboard:KeyF15
 
   # Xinput Gamepad
   - group: gamepad
@@ -68,7 +67,7 @@ source_devices:
         - name: id/product
           value: "1901"
         - name: phys
-          value: "usb-0000:c6:00.0-3/input0"
+          value: "usb-0000:00:14.0-4/input0"
 
   # Xinput Mkey Extra Buttons
   - group: gamepad
@@ -82,7 +81,7 @@ source_devices:
         - name: id/product
           value: "1901"
         - name: phys
-          value: "usb-0000:c6:00.0-3/input2"
+          value: "usb-0000:00:14.0-4/input2"
     events:
       exclude:
         - "*"
@@ -102,7 +101,7 @@ source_devices:
         - name: id/product
           value: "1902"
         - name: phys
-          value: "usb-0000:c6:00.0-3/input0"
+          value: "usb-0000:00:14.0-4/input0"
     capability_map_id: claw1-dinput
 
   # Dinput Mkey Extra Buttons
@@ -117,7 +116,7 @@ source_devices:
         - name: id/product
           value: "1902"
         - name: phys
-          value: "usb-0000:c6:00.0-3/input1"
+          value: "usb-0000:00:14.0-4/input1"
     events:
       exclude:
         - "*"
@@ -126,14 +125,6 @@ source_devices:
         - Keyboard:KeyRightBrace
 
   # IMU
-  - group: imu
-    iio:
-      name: gyro_3d
-      mount_matrix:
-        # TODO: Verify
-        x: [0, 1, 0]
-        y: [-1, 0, 0]
-        z: [0, 0, -1]
 
 # Optional configuration for the composite device
 options:

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw_a1m.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw_a1m.yaml
@@ -16,8 +16,8 @@ single_source: false
 # /sys/class/dmi/id/product_name
 matches:
   - dmi_data:
-      product_name: "Claw A1M"
-      sys_vendor: "Micro-Star International Co., Ltd."
+      board_name: "MS-1T41"
+      board_vendor: "Micro-Star International Co., Ltd."
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.

--- a/src/config/config_test.rs
+++ b/src/config/config_test.rs
@@ -71,6 +71,11 @@ async fn check_autostart_rules() -> Result<(), Box<dyn Error>> {
                 let pattern_part = format!("pn{product}:");
                 patterns.push(pattern_part);
             }
+            if let Some(board_vendor) = dmi.board_vendor.as_ref() {
+                let board_vendor = board_vendor.replace(" ", ""); // Remove spaces
+                let pattern_part = format!("rvn{board_vendor}:");
+                patterns.push(pattern_part);
+            }
             if let Some(board_name) = dmi.board_name.as_ref() {
                 let board_name = board_name.replace(" ", ""); // Remove spaces
                 let pattern_part = format!("rn{board_name}:");

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -212,6 +212,8 @@ pub struct DMIMatch {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub board_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub board_vendor: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub product_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub product_version: Option<String>,
@@ -1077,6 +1079,13 @@ impl CompositeDeviceConfig {
 
                 if let Some(board_name) = dmi_config.board_name {
                     if !glob_match(board_name.as_str(), data.board_name.as_str()) {
+                        continue;
+                    }
+                    has_matches = true;
+                }
+
+                if let Some(board_vendor) = dmi_config.board_vendor {
+                    if !glob_match(board_vendor.as_str(), data.board_vendor.as_str()) {
                         continue;
                     }
                     has_matches = true;

--- a/src/input/target/steam_deck.rs
+++ b/src/input/target/steam_deck.rs
@@ -890,6 +890,11 @@ impl TargetInputDevice for SteamDeckDevice {
                     device_config.name = "Claw Controller".to_string();
                     device_config.product_id = ProductId::MsiClaw;
                 }
+                "MSI Claw 8 EX AI+ CG3EM" => {
+                    device_config.vendor = "MSI".to_string();
+                    device_config.name = "Claw Controller".to_string();
+                    device_config.product_id = ProductId::MsiClaw;
+                }
                 "MSI Claw A8 BZ2EM" => {
                     device_config.vendor = "MSI".to_string();
                     device_config.name = "Claw Controller".to_string();

--- a/src/input/target/steam_deck_uhid.rs
+++ b/src/input/target/steam_deck_uhid.rs
@@ -698,6 +698,11 @@ impl TargetInputDevice for SteamDeckUhidDevice {
                     device_config.name = "Claw Controller".to_string();
                     device_config.product_id = ProductId::MsiClaw;
                 }
+                "MSI Claw 8 EX AI+ CG3EM" => {
+                    device_config.vendor = "MSI".to_string();
+                    device_config.name = "Claw Controller".to_string();
+                    device_config.product_id = ProductId::MsiClaw;
+                }
                 "MSI Claw A8 BZ2EM" => {
                     device_config.vendor = "MSI".to_string();
                     device_config.name = "Claw Controller".to_string();


### PR DESCRIPTION
Also fix all the Claws to use board_name, like we do everywhere else.