### PR TITLE
fix(Hardware Support): Add HandHeld Legend GC Ultimate

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/60-hhl_gc_ultimate.yaml
+++ b/rootfs/usr/share/inputplumber/devices/60-hhl_gc_ultimate.yaml
@@ -1,0 +1,43 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: HHL GC Ultimate
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches: []
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# Maximum number of source devices per CompositeDevice.
+maximum_sources: 2
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  # Dinput/SteamInput Mode
+  - group: gamepad
+    blocked: true
+    evdev:
+      name: "SInput Gamepad"
+      vendor_id: "2e8a"
+      product_id: "10dd"
+    capability_map_id: dinput_generic
+  - group: gamepad
+    hidraw:
+      vendor_id: 0x2e8a
+      product_id: 0x10dd
+      interface_num: 0
+
+# The target input device(s) to emulate by default
+target_devices:
+  - gamepad
+  - mouse
+  - keyboard


### PR DESCRIPTION
blocking the DInput evdev makes the controller function as expected in steam.
This device is a native DInput/Steam input device when used in wireless mode, with duplex triggers and gyro
<img width="4000" height="2256" alt="IMG_20260711_162741" src="https://github.com/user-attachments/assets/af4dcb1c-0ca9-43f6-8d3d-f9f58412579e" />

Again if more info is wanted i will happily provide it, although this is an extremely niche controller