### PR TITLE
feat(Hardware Support): Add Ayaneo Pocket S2

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type9.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type9.yaml
@@ -1,0 +1,51 @@
+version: 2
+kind: CapabilityMap
+name: AYANEO Type 9
+id: aya9
+
+mapping:
+    - name: Ayaneo Button to QuickAccess
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN6
+                value_type: button
+      target_event:
+          gamepad:
+              button: QuickAccess
+    - name: Ayaneo Button2 to Screenshot
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN5
+                value_type: button
+      target_event:
+          gamepad:
+              button: Screenshot
+    - name: L3
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN3
+                value_type: button
+      target_event:
+          gamepad:
+              button: LeftPaddle1
+    - name: R3
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN4
+                value_type: button
+      target_event:
+          gamepad:
+              button: RightPaddle1
+    - name: Side button to Keyboard
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN7
+                value_type: button
+      target_event:
+          gamepad:
+              button: Keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_pocket_s2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_pocket_s2.yaml
@@ -1,0 +1,43 @@
+version: 1
+kind: CompositeDevice
+name: AYANEO Pocket S2 (Pro)
+
+maximum_sources: 0
+options:
+    auto_manage: true
+
+matches:
+    - udev:
+          sys_path: /sys/firmware/devicetree/base
+          attributes:
+              - name: compatible
+                value: ayaneo,pocket-s2
+
+source_devices:
+    # Ayaneo mode
+    - group: gamepad
+      capability_map_id: dinput_generic
+      evdev:
+          name: AYANEO Controller
+          vendor_id: 4001
+          product_id: 0428
+          handler: event*
+    # Xinput mode
+    - group: gamepad
+      evdev:
+          phys_path: usb-0001:01:00.0-1/input0
+          vendor_id: 045e
+          product_id: 028e
+          handler: event*
+    - group: keyboard
+      capability_map_id: aya9
+      evdev:
+          name: AYANEO DEVICE
+          vendor_id: 1c4f
+          product_id: 0002
+          handler: event*
+
+target_devices:
+    - xbox-elite
+    - keyboard
+    - mouse


### PR DESCRIPTION
Adds capability maps and device conf for the Ayaneo Pocket S2 (Pro).

I am not 100% sure that everything in here is best practice as I had to go by other device files mostly where documentation was slightly lacking, but it has been tested and works on postmarketOS. (See https://gitlab.postmarketos.org/postmarketOS/pmaports/-/merge_requests/8979 if interested.)

Couple of notes:
- The device is an ARM device with an Android Bootloader and as such does not have DMI strings. As such matching is based on the upstream device tree.
- The device exposes it's internal controller as two devices in "Ayaneo Mode". One is exposed a as a normal "controller", while the other handes all "special" buttons, which is likely done so that the ayaneo utility on android can grab the second controller, while the first is picked up by games.
  - (There is a way to communicate over a serial interface with the internal controller to expose the device as a single "Xbox" controller, but that disables a couple of buttons and does not really need a inputplumber profile.)
- As such I created a capability-file per device. I am not sure that is the best way to handle this or if the files could be combined somehow?
- I am mostly targetting steam with this so I am using "deck-uhid" as the default target device. I guess steamos-manager already puts the device into this target mode, so maybe something like "xbox-series" or "xbox-elite" would be a better default?

Thanks for this utility!