### PR TITLE
fix(compilation): Fix Rust 1.97 clippy build errors

### DIFF
--- a/src/dbus/interface/mod.rs
+++ b/src/dbus/interface/mod.rs
@@ -193,7 +193,7 @@ impl DBusInterfaceManager {
 impl Debug for DBusInterfaceManager {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut dbus_ifaces: HashMap<String, &str> = HashMap::with_capacity(self.dbus_ifaces.len());
-        for (key, _value) in self.dbus_ifaces.iter() {
+        for key in self.dbus_ifaces.keys() {
             dbus_ifaces.insert(key.to_string(), "<UnregisterFn>");
         }
         f.debug_struct("DBusInterfaceManager")

--- a/src/drivers/iio_imu/driver.rs
+++ b/src/drivers/iio_imu/driver.rs
@@ -464,7 +464,7 @@ fn read_sample_rates_available(
     channels: &HashMap<String, Channel>,
     channel_type: &ChannelType,
 ) -> Vec<f64> {
-    for (_, channel) in channels.iter() {
+    for channel in channels.values() {
         if let Ok(val) = channel.attr_read_str("sampling_frequency_available") {
             let rates: Vec<f64> = val
                 .split_whitespace()

--- a/src/input/composite_device/targets.rs
+++ b/src/input/composite_device/targets.rs
@@ -186,7 +186,7 @@ impl CompositeDeviceTargets {
         for (path, target) in targets_to_stop.clone().into_iter() {
             log::debug!("[{dbus_path}] Stopping old target device: {path}");
             self.target_devices.remove(&path);
-            for (_, target_devices) in self.target_devices_by_capability.iter_mut() {
+            for target_devices in self.target_devices_by_capability.values_mut() {
                 target_devices.remove(&path);
             }
             stop_tasks.spawn(async move { target.stop().await });
@@ -560,7 +560,7 @@ impl CompositeDeviceTargets {
 
             self.target_devices_suspended.push(target_type);
             self.target_devices.remove(&path);
-            for (_, target_devices) in self.target_devices_by_capability.iter_mut() {
+            for target_devices in self.target_devices_by_capability.values_mut() {
                 target_devices.remove(&path);
             }
             if let Err(e) = target.stop().await {


### PR DESCRIPTION
Rust 1.97 introduced/enabled the clippy::for_kv_map lint. This breaks the compilation with Rust 1.97, these style changes fix it. :)