### PR TITLE
fix(Hardware Support): Fix Claw 8 EX Config

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/msiclaw_type2.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/msiclaw_type2.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CapabilityMap
+
+# Name for the device event map
+name: MSI Claw Type 2
+
+# Unique identifier of the capability mapping
+id: claw2
+
+# List of mapped events that are activated by a specific set of activation keys.
+mapping:
+  - name: Guide (Short)
+    source_events:
+      - keyboard: KeyF15
+      - keyboard: KeyG
+    target_event:
+      gamepad:
+        button: Guide
+  - name: Guide (Long)
+    source_events:
+      - keyboard: KeyF15
+      - keyboard: KeyTab
+    target_event:
+      gamepad:
+        button: Guide
+  - name: QuickAccess
+    source_events:
+      - keyboard: KeyF16
+    target_event:
+      gamepad:
+        button: QuickAccess
+
+  # Driver hid-msi-claw maps the M-Keys to these events with our udev rule
+  - name: M1
+    source_events:
+      - keyboard: KeyRightBrace
+    target_event:
+      gamepad:
+        button: RightPaddle1
+  - name: M2
+    source_events:
+      - keyboard: KeyLeftBrace
+    target_event:
+      gamepad:
+        button: LeftPaddle1
+
+# List of events to filter from the source devices
+filtered_events: []

--- a/rootfs/usr/share/inputplumber/devices/50-msi_claw8_ex_ai_cg3em.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-msi_claw8_ex_ai_cg3em.yaml
@@ -37,7 +37,6 @@ source_devices:
         - Keyboard:KeyF15
         - Keyboard:KeyF16
         - Keyboard:KeyG
-        - Keyboard:KeyLeftMeta
         - Keyboard:KeyTab
         - Keyboard:KeyVolumeDown
         - Keyboard:KeyVolumeUp
@@ -140,4 +139,4 @@ target_devices:
   - keyboard
 
 # The ID of a device event mapping in the 'event_maps' folder
-capability_map_id: claw1
+capability_map_id: claw2


### PR DESCRIPTION
The Claw 8 EX has enough variation to warrant its own capability map. This improves detection of the guide button dramatically compared to the previous config.