### PR TITLE
Add missing key mappings for F15-F18 and Right Ctrl for Ayaneo Air 1S

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_air_1s.yaml
@@ -45,10 +45,12 @@ source_devices:
         - "*"
       include:
         - Keyboard:KeyD
-        - Keyboard:KeyLeftAlt
-        - Keyboard:KeyLeftCtrl
+        - Keyboard:KeyF15
+        - Keyboard:KeyF16
+        - Keyboard:KeyF17
+        - Keyboard:KeyF18
         - Keyboard:KeyLeftMeta
-        - Keyboard:KeyO
+        - Keyboard:KeyRightCtrl
         - Keyboard:KeyVolumeDown
         - Keyboard:KeyVolumeUp
   - group: imu


### PR DESCRIPTION
Hey! First contribution here.

I just updated to Bazzite 44 as there has been a call for testers.

The PR at https://github.com/ShadowBlip/InputPlumber/pull/617 introduced an allowlist for keys. The Ayaneo Air 1S (7840U+780M) sends and expects:

- <kbd>LeftMeta</kbd> + <kbd>D</kbd> -> QAM 
- <kbd>RightCtrl</kbd> + <kbd>LeftMeta</kbd> + <kbd>F15</kbd> -> TopLeft
- <kbd>RightCtrl</kbd> + <kbd>LeftMeta</kbd> + <kbd>F16</kbd> -> TopRight
- <kbd>RightCtrl</kbd> + <kbd>LeftMeta</kbd> + <kbd>F17</kbd> -> Guide
- <kbd>RightCtrl</kbd> + <kbd>LeftMeta</kbd> + <kbd>F18</kbd> -> Keyboard

The only button that was working with the previous allowlist was QAM as RightCtrl and F15-F18 were not included. This commit adds those missing keys to the allowlist so that the Ayaneo Air 1S can properly be used with InputPlumber.

This allowlist matches the chord mapping in `rootfs/usr/share/inputplumber/capability_maps/ayaneo_type4.yaml`. I verified this using an override in 

Partly fixes https://github.com/ublue-os/bazzite/issues/5373

---

I verified this is working as expected by creating an override in `/etc/inputplumber/devices.d/50-ayaneo_air_1s.yaml` reflecting the diff of this PR. Also I tested what chord the device is sending by stopping inputplumber and running `evtest`.