### PR TITLE
fix(Manager): keep devices in gamepad order during target device changes

### DIFF
--- a/src/input/manager.rs
+++ b/src/input/manager.rs
@@ -402,6 +402,14 @@ impl Manager {
                     });
                 }
                 ManagerCommand::RemoveFromGamepadOrder { device_path } => {
+                    // A gamepad target may have been re-attached while this
+                    // request was in flight (e.g. during a profile switch).
+                    // If so, the device should keep its place in the order.
+                    if self.has_gamepad_target_attached(&device_path).await {
+                        log::debug!("Device {device_path} still has a gamepad target attached, skipping removal from gamepad order");
+                        continue;
+                    }
+
                     let new_order = self
                         .target_gamepad_order
                         .drain(..)
@@ -753,6 +761,29 @@ impl Manager {
         log::debug!("Finished handling attach request for: {target_path}");
 
         Ok(())
+    }
+
+    /// Returns true if the given composite device currently has at least one
+    /// gamepad target device attached.
+    async fn has_gamepad_target_attached(&self, composite_path: &str) -> bool {
+        let Some(target_paths) = self.composite_device_targets.get(composite_path) else {
+            return false;
+        };
+        for target_path in target_paths {
+            let Some(target) = self.target_devices.get(target_path) else {
+                continue;
+            };
+            let Ok(kind) = target.get_type().await else {
+                continue;
+            };
+            let Ok(target_type) = TargetDeviceTypeId::try_from(kind.as_str()) else {
+                continue;
+            };
+            if target_type.is_gamepad() {
+                return true;
+            }
+        }
+        false
     }
 
     /// Create and start the given type of target device and return a mapping


### PR DESCRIPTION
When a composite device switches profiles, its target devices are stopped and re-attached. The RemoveFromGamepadOrder request is sent from a spawned task after the suspended state check, so it can arrive after a new gamepad target has already been attached. When that happens the device is dropped from the gamepad order even though it still has a gamepad target, and it is never re-added until the next gamepad attach. On systems where the session manager reloads profiles several times at boot this reliably left GamepadOrder empty with a controller connected and working.

Only remove a device from the gamepad order if it no longer has any gamepad target attached.