### PR TITLE
feat(Hardware Support): Add AYANEO NEXT 2 device and capability map

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type10.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type10.yaml
@@ -1,0 +1,57 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v1.json
+version: 1
+kind: CapabilityMap
+name: AYANEO Type 10
+id: aya10
+
+mapping:
+  - name: LC
+    source_events:
+      - keyboard: KeyF21
+    target_event:
+      gamepad:
+        button: LeftTop
+  - name: RC
+    source_events:
+      - keyboard: KeyF22
+    target_event:
+      gamepad:
+        button: RightTop
+  - name: LC1
+    source_events:
+      - keyboard: KeyF19
+    target_event:
+      gamepad:
+        button: LeftPaddle1
+  - name: LC2
+    source_events:
+      - keyboard: KeyF17
+    target_event:
+      gamepad:
+        button: LeftPaddle2
+  - name: RC1
+    source_events:
+      - keyboard: KeyF20
+    target_event:
+      gamepad:
+        button: RightPaddle1
+  - name: RC2
+    source_events:
+      - keyboard: KeyF18
+    target_event:
+      gamepad:
+        button: RightPaddle2
+  - name: Ayaneo Button
+    source_events:
+      - keyboard: KeyF23
+    target_event:
+      gamepad:
+        button: QuickAccess
+  - name: T Button
+    source_events:
+      - keyboard: KeyF16
+    target_event:
+      gamepad:
+        button: QuickAccess2
+
+filtered_events: []

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_next2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_next2.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: AYANEO NEXT 2
+
+single_source: false
+
+matches:
+  - dmi_data:
+      product_name: AB09
+      sys_vendor: AYA
+
+source_devices:
+  - group: gamepad
+    evdev:
+      name: Microsoft X-Box 360 pad
+      handler: event*
+  - group: gamepad
+    evdev:
+      name: AYANEO COMPOSITE DEVICE
+      handler: event*
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyF16
+        - Keyboard:KeyF17
+        - Keyboard:KeyF18
+        - Keyboard:KeyF19
+        - Keyboard:KeyF20
+        - Keyboard:KeyF21
+        - Keyboard:KeyF22
+        - Keyboard:KeyF23
+        - Keyboard:KeyLeftMeta
+  - group: imu
+    iio:
+      name: bmi323-imu
+
+  # RGB
+  - group: led
+    udev:
+      sys_name: ayaneo:rgb:joystick_rings
+      subsystem: leds
+
+options:
+  auto_manage: true
+
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+
+capability_map_id: aya10


### PR DESCRIPTION
This PR implements support for the AYANEO NEXT 2, according to the issue opened [here](https://github.com/ShadowBlip/InputPlumber/issues/654). After looking through the repo it seemed simple enough to implement myself, though I did hand off the legwork of writing the YAML files to Claude Sonnet 5, as well as having it verify I wasn't missing a file that needed to be modified.

The exact prompt I gave to Claude was:
> If I wanted to add support for my AYANEO NEXT 2 according to this issue: https://github.com/ShadowBlip/InputPlumber/issues/654 what modifications would I need to perform to the files in the repo?

That spat out the device and capability map, mostly cribbed from existing Ayaneo config. I went back and forth with Claude to see if there were better options than an Xbox Elite controller for this device, and to check up on LC/RC button functions, but in the end the only change I made to the generated config was renaming the "Ayaneo Button" from "Logo". I named it "Logo" in the issue, but it's labeled "Ayaneo Button" in existing capability maps, so that seemed like the better convention.

Tested on Bazzite Deck 44 by installing to `/etc/inputplumber/devices.d/` and `/etc/inputplumber/capability_maps.d/`. After restarting InputPlumber, the built-in controller appeared as an Xbox Elite controller as expected. Back buttons were visible and successfully mapped/tested in Steam. The "Ayaneo Button" also correctly summons Quick Access. "T" button is mapped to QuickAccess2, which seems to take a screenshot in-game at the moment.

A second, "ghost" Xbox Elite 2 controller also appeared on the system, though I've read reports of other users encountering the same behavior, so I'm assuming that's not a misconfiguration with these files. Claude seems to think it's InputPlumber generating a child Xbox Elite controller from my remapped physical controller. Surfacing it just in case that's not expected.

The "=" button was left emitting its default key combo since there didn't seem to be a better unopinionated option.

The LC and RC buttons, of course, weren't visible in Steam for mapping, since they aren't present on an Xbox Elite controller.

I haven't yet found a completely satisfactory way to test the gyro/accelerometer orientation, since that's not implemented on the Xbox Elite controller. There's no kernel-level mount matrix for this under `/sys/bus/iio/devices/iio:device0/in_mount_matrix`, but watching the raw accelerometer output with `watch -n 0.2 'for f in /sys/bus/iio/devices/iio:device0/in_accel_x_raw; do echo "$f: $(cat $f)"; done'` (repeat for Y and Z) it _seemed_ to generate sensible values.

Likewise I could not test setting the controller LED rings via InputPlumber in any way I or Claude could determine.

Happy to test further on either of those features if a more thorough test regimen can be recommended.