### PR TITLE
feat(Hardware Support): Add AYN Odin 3 and other RSInput devices

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/rsinput_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/rsinput_type1.yaml
@@ -1,0 +1,102 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+version: 2
+kind: CapabilityMap
+name: RSInput Type 1
+id: rsinput1
+
+mapping:
+  - name: D-Pad Up
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_UP
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadUp
+
+  - name: D-Pad Down
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_DOWN
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadDown
+
+  - name: D-Pad Left
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_LEFT
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadLeft
+
+  - name: D-Pad Right
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_RIGHT
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadRight
+
+  - name: Back Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_BACK
+          value_type: button
+    target_event:
+      gamepad:
+        button: QuickAccess
+
+  - name: Left Back Paddle
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_Z
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftPaddle1
+
+  - name: Right Back Paddle
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_C
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightPaddle1
+
+  # Kernel reports NORTH/WEST by physical position, but Xbox layout 
+  # relies on these swapped. This results in NORTH/WEST swapped in
+  # evtest, but produces expected behaviour in games.
+
+  - name: West Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_NORTH
+          value_type: button
+    target_event:
+      gamepad:
+        button: West
+
+  - name: North Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_WEST
+          value_type: button
+    target_event:
+      gamepad:
+        button: North
+
+filtered_events: []

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_odin2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_odin2.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: AYN Odin 2
+
+options:
+  auto_manage: true
+
+matches:
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible 
+          value: ayn,odin2
+
+source_devices:
+  - group: gamepad
+    capability_map_id: rsinput1
+    evdev:
+      name: AYN Odin2 Gamepad
+      phys_path: rsinput-gamepad/input0
+      vendor_id: "2020"
+      product_id: "3001"
+      handler: event*
+
+  - group: gamepad
+    capability_map_id: rsinput1
+    evdev:
+      name: gpio-keys-paddles
+      handler: event*
+
+target_devices:
+  - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_odin2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_odin2.yaml
@@ -12,6 +12,11 @@ matches:
       attributes:
         - name: compatible 
           value: ayn,odin2
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible
+          value: ayn,odin2portal
 
 source_devices:
   - group: gamepad

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_odin3.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_odin3.yaml
@@ -1,0 +1,39 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: AYN Odin 3
+
+# TODO: Add support for gyroscope, see
+# https://github.com/ShadowBlip/InputPlumber/pull/590
+# This command proves gyroscope is present and supported with libssc:
+# ssccli --sensor=gyroscope
+
+options:
+  auto_manage: true
+
+matches:
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible
+          value: ayn,odin3
+
+source_devices:
+  - group: gamepad
+    capability_map_id: rsinput1
+    evdev:
+      name: AYN Odin3 Gamepad
+      phys_path: rsinput-gamepad/input0
+      vendor_id: "2020"
+      product_id: "3001"
+      handler: event*
+
+  - group: gamepad
+    capability_map_id: rsinput1
+    evdev:
+      name: gpio-keys-paddles
+      phys_path: gpio-keys/input0
+      handler: event*
+
+target_devices:
+  - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-retroid_pocket6.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-retroid_pocket6.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: Retroid Pocket 6
+
+options:
+  auto_manage: true
+
+matches:
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible
+          value: retroidpocket,rp6
+
+source_devices:
+  - group: gamepad
+    evdev:
+      name: AYN Odin2 Gamepad
+      phys_path: rsinput-gamepad/input0
+      vendor_id: "2020"
+      product_id: "3001"
+      handler: event*
+    capability_map_id: rsinput1
+
+  - group: gamepad
+    evdev:
+      name: gpio-keys
+      phys_path: gpio-keys/input0
+      handler: event*
+    capability_map_id: rsinput1
+
+target_devices:
+  - xbox-elite
+  # gpio-keys node is shared between gamepad and volume up key,
+  # we need keyboard target here for volume up to work
+  - keyboard

--- a/rootfs/usr/share/inputplumber/devices/50-retroid_pocket_nova.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-retroid_pocket_nova.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: Retroid Pocket Nova
+
+options:
+  auto_manage: true
+
+matches:
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible
+          value: retroidpocket,rpnova
+
+source_devices:
+  - group: gamepad
+    capability_map_id: rsinput1
+    evdev:
+      name: AYN Odin2 Gamepad
+      phys_path: rsinput-gamepad/input0
+      vendor_id: "2020"
+      product_id: "3001"
+      handler: event*
+
+  - group: gamepad
+    capability_map_id: rsinput1
+    evdev:
+      name: gpio-keys
+      phys_path: gpio-keys/input0
+      handler: event*
+
+target_devices:
+  - xbox-elite
+  # gpio-keys node is shared between gamepad and volume up key,
+  # we need keyboard target here for volume up to work
+  - keyboard


### PR DESCRIPTION
Adds support for AYN Odin 3.

This follows https://github.com/ShadowBlip/InputPlumber/pull/627 to make use of this in postmarketOS: https://wiki.postmarketos.org/wiki/AYN_Odin_3_(ayn-odin-3). I haven't tested it in UI yet (since https://gitlab.postmarketos.org/postmarketOS/pmaports/-/merge_requests/8979 is not merged), but `evtest` seems to produce expected results

It combines 2 input devices (gamepad + gpio-keys for paddles). It maps D-Pad, paddles and also maps back button to `QuickAccess` (please let me know whether it's a good choice). 

Note that this device kernel support is not upstreamed yet, so if anything changes during upstreaming there would have to be a follow-up PR. pmOS uses ROCKNIX kernel patches, so we should be on the same page between different distributions.
