### PR TITLE
fix: preserve QuickAccess chord duration for pulse events

### DIFF
--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -1142,14 +1142,8 @@ impl CompositeDevice {
         let cap = event.as_capability();
         if self.translated_recent_events.contains(&cap) {
             log::debug!("Event emitted too quickly. Delaying emission.");
-            let tx = self.tx.clone();
-            tokio::task::spawn(async move {
-                tokio::time::sleep(sleep_time).await;
-                if let Err(e) = tx.send(CompositeCommand::WriteEvent(event)).await {
-                    log::error!("Failed to send delayed event command: {:?}", e);
-                }
-            });
-
+            self.wait_for_translated_event(&cap, sleep_time).await;
+            self.tx.send(CompositeCommand::WriteEvent(event)).await?;
             return Ok(());
         }
 
@@ -1441,14 +1435,8 @@ impl CompositeDevice {
             let cap = event.as_capability();
             if self.translated_recent_events.contains(&cap) {
                 log::debug!("Event emitted too quickly. Delaying emission.");
-                let tx = self.tx.clone();
-                tokio::task::spawn(async move {
-                    tokio::time::sleep(sleep_time).await;
-                    if let Err(e) = tx.send(CompositeCommand::HandleEvent(event)).await {
-                        log::error!("Failed to send delayed event command: {:?}", e);
-                    }
-                });
-
+                self.wait_for_translated_event(&cap, sleep_time).await;
+                self.tx.send(CompositeCommand::HandleEvent(event)).await?;
                 continue;
             }
 
@@ -1469,6 +1457,14 @@ impl CompositeDevice {
         }
 
         Ok(())
+    }
+
+    /// Wait for a recently translated capability before emitting its next
+    /// event. This stays in the composite-device command loop so event
+    /// ordering cannot race the debounce-expiry command.
+    async fn wait_for_translated_event(&mut self, cap: &Capability, delay: Duration) {
+        tokio::time::sleep(delay).await;
+        self.translated_recent_events.remove(cap);
     }
 
     /// Translates the given event into a Vec of events based on the currently loaded

--- a/src/input/composite_device/mod.rs
+++ b/src/input/composite_device/mod.rs
@@ -1142,8 +1142,14 @@ impl CompositeDevice {
         let cap = event.as_capability();
         if self.translated_recent_events.contains(&cap) {
             log::debug!("Event emitted too quickly. Delaying emission.");
-            self.wait_for_translated_event(&cap, sleep_time).await;
-            self.tx.send(CompositeCommand::WriteEvent(event)).await?;
+            let tx = self.tx.clone();
+            tokio::task::spawn(async move {
+                tokio::time::sleep(sleep_time).await;
+                if let Err(e) = tx.send(CompositeCommand::WriteEvent(event)).await {
+                    log::error!("Failed to send delayed event command: {:?}", e);
+                }
+            });
+
             return Ok(());
         }
 
@@ -1435,8 +1441,14 @@ impl CompositeDevice {
             let cap = event.as_capability();
             if self.translated_recent_events.contains(&cap) {
                 log::debug!("Event emitted too quickly. Delaying emission.");
-                self.wait_for_translated_event(&cap, sleep_time).await;
-                self.tx.send(CompositeCommand::HandleEvent(event)).await?;
+                let tx = self.tx.clone();
+                tokio::task::spawn(async move {
+                    tokio::time::sleep(sleep_time).await;
+                    if let Err(e) = tx.send(CompositeCommand::HandleEvent(event)).await {
+                        log::error!("Failed to send delayed event command: {:?}", e);
+                    }
+                });
+
                 continue;
             }
 
@@ -1457,14 +1469,6 @@ impl CompositeDevice {
         }
 
         Ok(())
-    }
-
-    /// Wait for a recently translated capability before emitting its next
-    /// event. This stays in the composite-device command loop so event
-    /// ordering cannot race the debounce-expiry command.
-    async fn wait_for_translated_event(&mut self, cap: &Capability, delay: Duration) {
-        tokio::time::sleep(delay).await;
-        self.translated_recent_events.remove(cap);
     }
 
     /// Translates the given event into a Vec of events based on the currently loaded

--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -2,7 +2,7 @@
 //! The DualSense implementation is based on the great work done by NeroReflex
 //! and the ROGueENEMY project:
 //! https://github.com/NeroReflex/ROGueENEMY/
-use std::{cmp::Ordering, error::Error, fmt::Debug, fs::File, time::Duration};
+use std::{cmp::Ordering, error::Error, fmt::Debug, fs::File};
 
 use packed_struct::prelude::*;
 use rand::Rng;
@@ -44,7 +44,9 @@ use crate::{
     },
 };
 
-use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
+use super::{
+    quick_access::QuickAccessChord, InputError, OutputError, TargetInputDevice, TargetOutputDevice,
+};
 
 /// The type of DualSense device to emulate. Currently two models are supported:
 /// DualSense and DualSense Edge.
@@ -124,6 +126,7 @@ pub struct DualSenseDevice {
     context: u8,
     hardware: DualSenseHardware,
     queued_events: Vec<ScheduledNativeEvent>,
+    quick_access_chord: QuickAccessChord,
     /// Last report written, used to skip re-emitting identical reports.
     last_written: Option<Vec<u8>>,
     /// Whether a consumer has the device open, writes are skipped while closed.
@@ -141,6 +144,7 @@ impl DualSenseDevice {
             context: Default::default(),
             hardware,
             queued_events: Vec::new(),
+            quick_access_chord: QuickAccessChord::default(),
             last_written: None,
             is_open: false,
         })
@@ -199,7 +203,7 @@ impl DualSenseDevice {
 
     /// Write the current device state to the device
     fn write_state(&mut self) -> Result<(), Box<dyn Error>> {
-        // No consumer so don't bother emitting. 
+        // No consumer so don't bother emitting.
         if !self.is_open {
             return Ok(());
         }
@@ -934,27 +938,8 @@ impl TargetInputDevice for DualSenseDevice {
         let cap = event.as_capability();
         if cap == Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)) {
             let pressed = event.pressed();
-            let guide = NativeEvent::new(
-                Capability::Gamepad(Gamepad::Button(GamepadButton::Guide)),
-                event.get_value(),
-            );
-            let south = NativeEvent::new(
-                Capability::Gamepad(Gamepad::Button(GamepadButton::South)),
-                event.get_value(),
-            );
-
-            let (guide, south) = if pressed {
-                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
-                (guide, south)
-            } else {
-                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(240));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
-                (guide, south)
-            };
-
-            self.queued_events.push(guide);
-            self.queued_events.push(south);
+            let events = self.quick_access_chord.schedule(pressed, event.get_value());
+            self.queued_events.extend(events);
             return Ok(());
         }
         self.update_state(event);

--- a/src/input/target/mod.rs
+++ b/src/input/target/mod.rs
@@ -6,6 +6,7 @@ pub mod dualsense;
 pub mod horipad_steam;
 pub mod keyboard;
 pub mod mouse;
+mod quick_access;
 pub mod steam_deck;
 pub mod steam_deck_uhid;
 pub mod touchpad;

--- a/src/input/target/quick_access.rs
+++ b/src/input/target/quick_access.rs
@@ -1,0 +1,107 @@
+use std::time::{Duration, Instant};
+
+use crate::input::{
+    capability::{Capability, Gamepad, GamepadButton},
+    event::{
+        native::{NativeEvent, ScheduledNativeEvent},
+        value::InputValue,
+    },
+};
+
+const SOUTH_PRESS_DELAY: Duration = Duration::from_millis(160);
+const SOUTH_RELEASE_DELAY: Duration = Duration::from_millis(160);
+const GUIDE_RELEASE_DELAY: Duration = Duration::from_millis(240);
+// The existing chord releases Guide 80 ms after South. Reuse that established
+// interval as the minimum time each phase remains visible to Steam when the
+// source firmware emits an almost instantaneous press/release pulse.
+const MIN_BUTTON_HOLD: Duration = Duration::from_millis(80);
+
+/// Schedules the Guide+South chord used to expose QuickAccess on targets that
+/// do not have a native QuickAccess button.
+#[derive(Debug, Default)]
+pub(super) struct QuickAccessChord {
+    pressed_at: Option<Instant>,
+}
+
+impl QuickAccessChord {
+    pub(super) fn schedule(
+        &mut self,
+        pressed: bool,
+        value: InputValue,
+    ) -> [ScheduledNativeEvent; 2] {
+        let guide = NativeEvent::new(
+            Capability::Gamepad(Gamepad::Button(GamepadButton::Guide)),
+            value.clone(),
+        );
+        let south = NativeEvent::new(
+            Capability::Gamepad(Gamepad::Button(GamepadButton::South)),
+            value,
+        );
+
+        if pressed {
+            self.pressed_at = Some(Instant::now());
+            return [
+                ScheduledNativeEvent::new(guide, Duration::ZERO),
+                ScheduledNativeEvent::new(south, SOUTH_PRESS_DELAY),
+            ];
+        }
+
+        let held_for = self
+            .pressed_at
+            .take()
+            .map(|pressed_at| pressed_at.elapsed());
+        let (south_delay, guide_delay) = release_delays(held_for);
+        [
+            ScheduledNativeEvent::new(south, south_delay),
+            ScheduledNativeEvent::new(guide, guide_delay),
+        ]
+    }
+}
+
+fn release_delays(held_for: Option<Duration>) -> (Duration, Duration) {
+    let Some(held_for) = held_for else {
+        return (SOUTH_RELEASE_DELAY, GUIDE_RELEASE_DELAY);
+    };
+
+    let earliest_south_release = SOUTH_PRESS_DELAY + MIN_BUTTON_HOLD;
+    let earliest_guide_release = earliest_south_release + MIN_BUTTON_HOLD;
+    (
+        SOUTH_RELEASE_DELAY.max(earliest_south_release.saturating_sub(held_for)),
+        GUIDE_RELEASE_DELAY.max(earliest_guide_release.saturating_sub(held_for)),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_pulses_keep_each_qam_chord_button_pressed_for_a_full_interval() {
+        let held_for = Duration::from_millis(1);
+        let (south_release, guide_release) = release_delays(Some(held_for));
+
+        assert_eq!(south_release, Duration::from_millis(239));
+        assert_eq!(guide_release, Duration::from_millis(319));
+        assert_eq!(
+            held_for + south_release - SOUTH_PRESS_DELAY,
+            MIN_BUTTON_HOLD
+        );
+        assert_eq!(guide_release - south_release, MIN_BUTTON_HOLD);
+    }
+
+    #[test]
+    fn normal_presses_keep_existing_qam_chord_timing() {
+        let (south_release, guide_release) = release_delays(Some(Duration::from_millis(80)));
+
+        assert_eq!(south_release, SOUTH_RELEASE_DELAY);
+        assert_eq!(guide_release, GUIDE_RELEASE_DELAY);
+    }
+
+    #[test]
+    fn release_without_a_press_uses_existing_qam_chord_timing() {
+        assert_eq!(
+            release_delays(None),
+            (SOUTH_RELEASE_DELAY, GUIDE_RELEASE_DELAY)
+        );
+    }
+}

--- a/src/input/target/ulitmate_2.rs
+++ b/src/input/target/ulitmate_2.rs
@@ -29,7 +29,9 @@ use crate::{
     },
 };
 
-use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
+use super::{
+    quick_access::QuickAccessChord, InputError, OutputError, TargetInputDevice, TargetOutputDevice,
+};
 
 const GRAVITY: f64 = 9.80665;
 
@@ -37,6 +39,7 @@ pub struct Ultimate2WirelessDevice {
     device: UHIDDevice<File>,
     state: PackedInputDataReport,
     queued_events: Vec<ScheduledNativeEvent>,
+    quick_access_chord: QuickAccessChord,
 }
 
 impl Ultimate2WirelessDevice {
@@ -56,6 +59,7 @@ impl Ultimate2WirelessDevice {
             device,
             state: PackedInputDataReport::default(),
             queued_events: Vec::new(),
+            quick_access_chord: QuickAccessChord::default(),
         })
     }
 
@@ -279,27 +283,8 @@ impl TargetInputDevice for Ultimate2WirelessDevice {
         if event.as_capability() == Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess))
         {
             let pressed = event.pressed();
-            let guide = NativeEvent::new(
-                Capability::Gamepad(Gamepad::Button(GamepadButton::Guide)),
-                event.get_value(),
-            );
-            let south = NativeEvent::new(
-                Capability::Gamepad(Gamepad::Button(GamepadButton::South)),
-                event.get_value(),
-            );
-            let (guide, south) = if pressed {
-                (
-                    ScheduledNativeEvent::new(guide, Duration::from_millis(0)),
-                    ScheduledNativeEvent::new(south, Duration::from_millis(160)),
-                )
-            } else {
-                (
-                    ScheduledNativeEvent::new(guide, Duration::from_millis(240)),
-                    ScheduledNativeEvent::new(south, Duration::from_millis(160)),
-                )
-            };
-            self.queued_events.push(guide);
-            self.queued_events.push(south);
+            let events = self.quick_access_chord.schedule(pressed, event.get_value());
+            self.queued_events.extend(events);
             return Ok(());
         }
 

--- a/src/input/target/xpad.rs
+++ b/src/input/target/xpad.rs
@@ -20,13 +20,16 @@ use crate::input::event::value::InputValue;
 use crate::input::output_capability::OutputCapability;
 use crate::input::output_event::{OutputEvent, UinputOutputEvent};
 
-use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
+use super::{
+    quick_access::QuickAccessChord, InputError, OutputError, TargetInputDevice, TargetOutputDevice,
+};
 
 #[derive(Debug)]
 pub struct XBoxController {
     device: VirtualDevice,
     axis_map: HashMap<AbsoluteAxisCode, AbsInfo>,
     queued_events: Vec<ScheduledNativeEvent>,
+    quick_access_chord: QuickAccessChord,
     capabilities: Vec<Capability>,
 }
 
@@ -39,6 +42,7 @@ impl XBoxController {
             device,
             axis_map,
             queued_events: Vec::new(),
+            quick_access_chord: QuickAccessChord::default(),
             capabilities,
         })
     }
@@ -240,27 +244,8 @@ impl TargetInputDevice for XBoxController {
         let cap = event.as_capability();
         if cap == Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)) {
             let pressed = event.pressed();
-            let guide = NativeEvent::new(
-                Capability::Gamepad(Gamepad::Button(GamepadButton::Guide)),
-                event.get_value(),
-            );
-            let south = NativeEvent::new(
-                Capability::Gamepad(Gamepad::Button(GamepadButton::South)),
-                event.get_value(),
-            );
-
-            let (guide, south) = if pressed {
-                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
-                (guide, south)
-            } else {
-                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(240));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
-                (guide, south)
-            };
-
-            self.queued_events.push(guide);
-            self.queued_events.push(south);
+            let events = self.quick_access_chord.schedule(pressed, event.get_value());
+            self.queued_events.extend(events);
             return Ok(());
         }
         // Check for Screenshot


### PR DESCRIPTION
## Summary

Preserve the synthesized Steam Quick Access chord when source firmware emits an almost instantaneous press/release pulse.

Fixes #657.

## Root cause

The `Event emitted too quickly. Delaying emission.` message does not mean the event was dropped. That branch already re-queues the translated event. The message is emitted only while the same translated capability remains in InputPlumber's 4 ms debounce set, so the report itself establishes that the next edge arrived less than 4 ms after the first. After the existing debounce delay, the target still sees only a few milliseconds of effective hold time.

Targets without a native Quick Access button synthesize Steam's Guide+South chord:

- Guide press: immediately
- South press: after 160 ms
- South release: 160 ms after the source release
- Guide release: 240 ms after the source release

For a pulse-style source, South is consequently pressed and released only a few milliseconds apart. Steam can miss that chord even though InputPlumber delivered both translated events.

## Why 80 ms

This is based on the existing QAM timing established by #216, not an arbitrary new delay. That change introduced the current 160/240 ms cadence in 80 ms steps and was hardware-tested on MSI Claw, Win600, ROG Ally, and Ayaneo Air Plus.

For a source pulse shorter than 80 ms, this change schedules the same sequence produced by an 80 ms physical press:

```text
0 ms    Guide down
160 ms  South down
240 ms  South up
320 ms  Guide up
```

Each chord phase therefore remains visible for one established 80 ms interval. Source presses of 80 ms or longer keep the existing timing unchanged.

## Implementation

The common scheduler records when Quick Access was pressed and extends only releases that would make a chord phase shorter than 80 ms. Xbox, DualSense, and Ultimate 2 use the shared implementation so their identical behavior cannot drift.

The composite-device command loop remains non-blocking. This replaces the earlier revision that serialized delayed events in that loop; the current PR diff contains none of that approach.

## Validation

Ran the repository's supported container test target:

```text
make in-docker TARGET=test
```

- 13 unit tests passed
- focused coverage verifies a 1 ms pulse, an 80 ms normal press, and an unmatched release
- 4 doctests passed
- Clippy passed with `-D warnings`
- `git diff --check` passed

The failing pulse duration is derived directly from #657's debounce log, while the minimum cadence and cross-device hardware evidence come from #216.
