### PR TITLE
withdrawn: remap Xbox Ally special buttons

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml
@@ -13,12 +13,12 @@ id: aly2
 
 # List of mapped events that are activated by a specific set of activation keys.
 mapping:
-  - name: Control Center (Short)
+  - name: Armory Crate (Short)
     source_events:
       - keyboard: KeyF16
     target_event:
       gamepad:
-        button: Keyboard
+        button: QuickAccess
   - name: Control Center (Long)
     source_events:
       - keyboard: KeyF21

--- a/rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml
@@ -30,7 +30,7 @@ mapping:
       - keyboard: KeyProg1
     target_event:
       gamepad:
-        button: QuickAccess
+        button: Guide
   - name: Armory Crate (Long)
     source_events:
       - keyboard: KeyF22

--- a/rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml
@@ -39,13 +39,13 @@ mapping:
         button: RightTop
   - name: Left Paddle
     source_events:
-      - keyboard: KeyF14
+      - keyboard: KeyF15
     target_event:
       gamepad:
         button: LeftPaddle2
   - name: Right Paddle
     source_events:
-      - keyboard: KeyF15
+      - keyboard: KeyF14
     target_event:
       gamepad:
         button: RightPaddle2

--- a/rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml
@@ -39,13 +39,13 @@ mapping:
         button: RightTop
   - name: Left Paddle
     source_events:
-      - keyboard: KeyF15
+      - keyboard: KeyF14
     target_event:
       gamepad:
         button: LeftPaddle2
   - name: Right Paddle
     source_events:
-      - keyboard: KeyF14
+      - keyboard: KeyF15
     target_event:
       gamepad:
         button: RightPaddle2

--- a/rootfs/usr/share/inputplumber/devices/50-rog_xbox_ally.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-rog_xbox_ally.yaml
@@ -62,7 +62,7 @@ options:
 
 # The target input device(s) to emulate by default
 target_devices:
-  - xbox-elite
+  - deck-uhid
   - mouse
   - keyboard
 

--- a/src/config/capability_map.rs
+++ b/src/config/capability_map.rs
@@ -123,6 +123,35 @@ mod tests {
             Some("QuickAccess")
         );
     }
+
+    #[test]
+    fn ally_type2_rear_buttons_preserve_m1_m2_direction() {
+        let config = CapabilityMapConfig::from_yaml_file(
+            "./rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml",
+        )
+        .expect("Ally Type 2 capability map should parse");
+
+        let CapabilityMapConfig::V1(config) = config else {
+            panic!("Ally Type 2 capability map must use schema version 1");
+        };
+
+        let target_for_key = |key: &str| {
+            config
+                .mapping
+                .iter()
+                .find(|mapping| {
+                    mapping
+                        .source_events
+                        .iter()
+                        .any(|source| source.keyboard.as_deref() == Some(key))
+                })
+                .and_then(|mapping| mapping.target_event.gamepad.as_ref())
+                .and_then(|gamepad| gamepad.button.as_deref())
+        };
+
+        assert_eq!(target_for_key("KeyF15"), Some("LeftPaddle2"));
+        assert_eq!(target_for_key("KeyF14"), Some("RightPaddle2"));
+    }
 }
 
 /// [CapabilityMapConfigHeader] is used to check the version/kind to determine which

--- a/src/config/capability_map.rs
+++ b/src/config/capability_map.rs
@@ -88,6 +88,43 @@ impl CapabilityMapConfig {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::CapabilityMapConfig;
+
+    #[test]
+    fn ally_type2_armory_button_maps_to_quick_access() {
+        let config = CapabilityMapConfig::from_yaml_file(
+            "./rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml",
+        )
+        .expect("Ally Type 2 capability map should parse");
+
+        let CapabilityMapConfig::V1(config) = config else {
+            panic!("Ally Type 2 capability map must use schema version 1");
+        };
+
+        let mapping = config
+            .mapping
+            .iter()
+            .find(|mapping| {
+                mapping
+                    .source_events
+                    .iter()
+                    .any(|source| source.keyboard.as_deref() == Some("KeyF16"))
+            })
+            .expect("Ally Type 2 map should contain a KeyF16 mapping");
+
+        assert_eq!(
+            mapping
+                .target_event
+                .gamepad
+                .as_ref()
+                .and_then(|gamepad| gamepad.button.as_deref()),
+            Some("QuickAccess")
+        );
+    }
+}
+
 /// [CapabilityMapConfigHeader] is used to check the version/kind to determine which
 /// capability map schema to use.
 #[derive(Debug, Deserialize, Serialize, Clone)]

--- a/src/config/capability_map.rs
+++ b/src/config/capability_map.rs
@@ -122,6 +122,26 @@ mod tests {
                 .and_then(|gamepad| gamepad.button.as_deref()),
             Some("QuickAccess")
         );
+
+        let library_mapping = config
+            .mapping
+            .iter()
+            .find(|mapping| {
+                mapping
+                    .source_events
+                    .iter()
+                    .any(|source| source.keyboard.as_deref() == Some("KeyProg1"))
+            })
+            .expect("Ally Type 2 map should contain a KeyProg1 mapping");
+
+        assert_eq!(
+            library_mapping
+                .target_event
+                .gamepad
+                .as_ref()
+                .and_then(|gamepad| gamepad.button.as_deref()),
+            Some("Guide")
+        );
     }
 
     #[test]

--- a/src/config/capability_map.rs
+++ b/src/config/capability_map.rs
@@ -149,8 +149,8 @@ mod tests {
                 .and_then(|gamepad| gamepad.button.as_deref())
         };
 
-        assert_eq!(target_for_key("KeyF15"), Some("LeftPaddle2"));
-        assert_eq!(target_for_key("KeyF14"), Some("RightPaddle2"));
+        assert_eq!(target_for_key("KeyF14"), Some("LeftPaddle2"));
+        assert_eq!(target_for_key("KeyF15"), Some("RightPaddle2"));
     }
 }
 

--- a/src/config/config_test.rs
+++ b/src/config/config_test.rs
@@ -11,6 +11,7 @@ use crate::config::CompositeDeviceConfig;
 
 const AUTOSTART_HWDB_FILE: &str = "./rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb";
 const DEVICE_CONFIG_DIR: &str = "./rootfs/usr/share/inputplumber/devices";
+const XBOX_ALLY_CONFIG: &str = "./rootfs/usr/share/inputplumber/devices/50-rog_xbox_ally.yaml";
 
 const RED: &str = "\x1b[31m";
 const YELLOW: &str = "\x1b[33m";
@@ -144,4 +145,19 @@ async fn check_autostart_rules() -> Result<(), Box<dyn Error>> {
     assert_eq!(failures.len(), 0);
 
     Ok(())
+}
+
+#[test]
+fn xbox_ally_uses_steam_deck_target_for_quick_access() {
+    let config = CompositeDeviceConfig::from_yaml_file(XBOX_ALLY_CONFIG.to_string())
+        .expect("ROG Xbox Ally profile should parse");
+
+    assert_eq!(
+        config.target_devices,
+        Some(vec![
+            "deck-uhid".to_string(),
+            "mouse".to_string(),
+            "keyboard".to_string(),
+        ])
+    );
 }


### PR DESCRIPTION
## Withdrawn

This proposed mapping change was incorrect and must not be merged.

The existing `ally_type2` map from #629 is intentional:

- `KEY_F16` -> `Keyboard`
- `KEY_F21` -> `LeftTop`
- `KEY_PROG1` -> `QuickAccess`
- `KEY_F22` -> `RightTop`
- `KEY_F14` -> `LeftPaddle2`
- `KEY_F15` -> `RightPaddle2`
- target: `xbox-elite`, plus mouse and keyboard

The top/long/rear capabilities become assignable virtual L4/R4/L5/R5 controls in Steam Input. Changing `KEY_F16` to `QuickAccess`, `KEY_PROG1` to `Guide`, and the target to `deck-uhid` caused multiple special buttons to be interpreted as screenshots during testing.

The runtime patch was removed from the test device and this PR was closed. A tests-only follow-up protects the existing upstream behavior without changing device mappings.
