### PR TITLE
test: lock Xbox Ally button mappings

### DIFF
--- a/src/config/capability_map.rs
+++ b/src/config/capability_map.rs
@@ -218,6 +218,44 @@ pub struct GamepadCapability {
     pub dial: Option<DialCapability>,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn xbox_ally_special_buttons_keep_their_distinct_capabilities() {
+        let config = CapabilityMapConfig::from_yaml_file(
+            "./rootfs/usr/share/inputplumber/capability_maps/ally_type2.yaml",
+        )
+        .expect("Ally Type 2 capability map should load");
+        let CapabilityMapConfig::V1(config) = config else {
+            panic!("Ally Type 2 should use capability map version 1");
+        };
+
+        let actual: HashMap<&str, &str> = config
+            .mapping
+            .iter()
+            .filter_map(|mapping| {
+                let source = mapping.source_events.as_slice();
+                let [source] = source else {
+                    return None;
+                };
+                Some((
+                    source.keyboard.as_deref()?,
+                    mapping.target_event.gamepad.as_ref()?.button.as_deref()?,
+                ))
+            })
+            .collect();
+
+        assert_eq!(actual.get("KeyF16"), Some(&"Keyboard"));
+        assert_eq!(actual.get("KeyF21"), Some(&"LeftTop"));
+        assert_eq!(actual.get("KeyProg1"), Some(&"QuickAccess"));
+        assert_eq!(actual.get("KeyF22"), Some(&"RightTop"));
+        assert_eq!(actual.get("KeyF14"), Some(&"LeftPaddle2"));
+        assert_eq!(actual.get("KeyF15"), Some(&"RightPaddle2"));
+    }
+}
+
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub struct AxisCapability {

--- a/src/config/config_test.rs
+++ b/src/config/config_test.rs
@@ -11,6 +11,7 @@ use crate::config::CompositeDeviceConfig;
 
 const AUTOSTART_HWDB_FILE: &str = "./rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb";
 const DEVICE_CONFIG_DIR: &str = "./rootfs/usr/share/inputplumber/devices";
+const XBOX_ALLY_CONFIG_FILE: &str = "./rootfs/usr/share/inputplumber/devices/50-rog_xbox_ally.yaml";
 
 const RED: &str = "\x1b[31m";
 const YELLOW: &str = "\x1b[33m";
@@ -142,6 +143,22 @@ async fn check_autostart_rules() -> Result<(), Box<dyn Error>> {
     println!("Failed!");
 
     assert_eq!(failures.len(), 0);
+
+    Ok(())
+}
+
+#[test]
+fn xbox_ally_uses_the_paddle_capable_xbox_target() -> Result<(), Box<dyn Error>> {
+    let config = CompositeDeviceConfig::from_yaml_file(XBOX_ALLY_CONFIG_FILE.to_string())?;
+
+    assert_eq!(
+        config.target_devices,
+        Some(vec![
+            "xbox-elite".to_string(),
+            "mouse".to_string(),
+            "keyboard".to_string(),
+        ])
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Add regression coverage for the existing ROG Xbox Ally / Xbox Ally X capability map and target selection introduced by #629.

## Why

The special controls intentionally expose distinct actions and virtual Steam Input controls:

| Source | InputPlumber capability |
| --- | --- |
| `KEY_F16` | `Keyboard` |
| `KEY_F21` | `LeftTop` |
| `KEY_PROG1` | `QuickAccess` |
| `KEY_F22` | `RightTop` |
| `KEY_F14` | `LeftPaddle2` |
| `KEY_F15` | `RightPaddle2` |

The `xbox-elite` target is also intentional: Steam presents the long-press controls and rear paddles as virtual L4/R4/L5/R5 inputs that users can assign without changing the raw hardware map.

PR #662 incorrectly tried to remap these actions and switch the target, which caused multiple special buttons to trigger screenshots. It was closed and none of those runtime changes are included here.

## Validation

```text
make in-docker TARGET=test
```

- 12 unit tests passed, including the two new mapping/config tests
- 4 doctests passed
- Clippy passed with `-D warnings`
- `git diff --check` passed

This PR changes tests only; shipped device behavior is unchanged.
