### PR TITLE
fix(Zotac Zone): fix Steam/QAM/View buttons and duplicate virtual gamepad

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/zone_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/zone_type1.yaml
@@ -73,26 +73,17 @@ mapping:
       target_event:
           gamepad:
               button: RightPaddle1
-    - name: Left Dial
-      source_events:
-          - evdev:
-                event_type: REL
-                event_code: REL_HWHEEL
-                value_type: joystick_x
-      target_event:
-          gamepad:
-              dial:
-                  name: LeftStickDial
-    - name: Right Dial
-      source_events:
-          - evdev:
-                event_code: REL_WHEEL
-                event_type: REL
-                value_type: joystick_x
-      target_event:
-          gamepad:
-              dial:
-                  name: RightStickDial
+    # The dials are deliberately not mapped here. They reach no evdev node at
+    # all - their HID usages are declared on the Generic Desktop page but hold
+    # Consumer page codes, so the kernel translates none of them - which means
+    # a REL_WHEEL/REL_HWHEEL mapping never fired for the dials it was written
+    # for.
+    #
+    # It claimed events all the same: capability maps are applied per composite
+    # device rather than per source, so the wheel events of the left touchpad -
+    # which is a scroll surface, not a pointer one - were turned into a dial
+    # capability that none of this device's targets consume, leaving that
+    # touchpad dead.
 
 # List of events to filter from the source devices
 filtered_events: []

--- a/rootfs/usr/share/inputplumber/capability_maps/zone_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/zone_type1.yaml
@@ -22,9 +22,6 @@ mapping:
       target_event:
           gamepad:
               button: Guide
-    # Plain Guide press opens the main Steam menu. QuickAccess2 has no evdev
-    # output on the xbox-elite target (see event_codes_from_capability in
-    # src/input/event/evdev.rs), so binding this button to it was a no-op.
     - name: MORE
       source_events:
           - evdev:
@@ -34,9 +31,6 @@ mapping:
       target_event:
           gamepad:
               button: Guide
-    # QuickAccess triggers the Guide+South chord that gamescope recognizes
-    # as "open Quick Access Menu" (see write_event's QuickAccess special case
-    # in src/input/target/xpad.rs).
     - name: HOME (shortpress)
       source_events:
           - evdev:
@@ -55,18 +49,6 @@ mapping:
       target_event:
           gamepad:
               button: Keyboard
-    # The physical HOME button sends these chords on its own (not through the
-    # F16-F19 scheme above - see the vendor driver reasoning in
-    # devices/50-zotac-zone.yaml). Screenshot and Guide are the only two
-    # buttons in this file with real evdev output on the xbox-elite target
-    # (see event_codes_from_capability in src/input/event/evdev.rs and the
-    # special-cased write_event handling in src/input/target/xpad.rs) that
-    # also matches what these chords already did by accident: consuming the
-    # keys stops them from leaking through to the desktop session's own
-    # Meta+D ("show desktop") / Ctrl+Alt+KP. bindings, which is what produced
-    # a screenshot/Steam-menu-like effect before this mapping existed.
-    # Note: this trades away that desktop-mode "show desktop" shortcut, since
-    # capability_map translation applies regardless of session type.
     - name: HOME (shortpress, real)
       mapping_type:
           evdev: chord
@@ -82,7 +64,7 @@ mapping:
       target_event:
           gamepad:
               button: Screenshot
-    - name: HOME (longpress, real)
+    - name: HOME (longpress)
       mapping_type:
           evdev: chord
       source_events:

--- a/rootfs/usr/share/inputplumber/capability_maps/zone_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/zone_type1.yaml
@@ -55,6 +55,52 @@ mapping:
       target_event:
           gamepad:
               button: Keyboard
+    # The physical HOME button sends these chords on its own (not through the
+    # F16-F19 scheme above - see the vendor driver reasoning in
+    # devices/50-zotac-zone.yaml). Screenshot and Guide are the only two
+    # buttons in this file with real evdev output on the xbox-elite target
+    # (see event_codes_from_capability in src/input/event/evdev.rs and the
+    # special-cased write_event handling in src/input/target/xpad.rs) that
+    # also matches what these chords already did by accident: consuming the
+    # keys stops them from leaking through to the desktop session's own
+    # Meta+D ("show desktop") / Ctrl+Alt+KP. bindings, which is what produced
+    # a screenshot/Steam-menu-like effect before this mapping existed.
+    # Note: this trades away that desktop-mode "show desktop" shortcut, since
+    # capability_map translation applies regardless of session type.
+    - name: HOME (shortpress, real)
+      mapping_type:
+          evdev: chord
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: KEY_LEFTMETA
+                value_type: button
+          - evdev:
+                event_type: KEY
+                event_code: KEY_D
+                value_type: button
+      target_event:
+          gamepad:
+              button: Screenshot
+    - name: HOME (longpress, real)
+      mapping_type:
+          evdev: chord
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: KEY_LEFTCTRL
+                value_type: button
+          - evdev:
+                event_type: KEY
+                event_code: KEY_LEFTALT
+                value_type: button
+          - evdev:
+                event_type: KEY
+                event_code: KEY_KPDOT
+                value_type: button
+      target_event:
+          gamepad:
+              button: Guide
     - name: Left Paddle
       source_events:
           - evdev:

--- a/rootfs/usr/share/inputplumber/capability_maps/zone_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/zone_type1.yaml
@@ -22,6 +22,9 @@ mapping:
       target_event:
           gamepad:
               button: Guide
+    # Plain Guide press opens the main Steam menu. QuickAccess2 has no evdev
+    # output on the xbox-elite target (see event_codes_from_capability in
+    # src/input/event/evdev.rs), so binding this button to it was a no-op.
     - name: MORE
       source_events:
           - evdev:
@@ -30,7 +33,10 @@ mapping:
                 value_type: button
       target_event:
           gamepad:
-              button: QuickAccess
+              button: Guide
+    # QuickAccess triggers the Guide+South chord that gamescope recognizes
+    # as "open Quick Access Menu" (see write_event's QuickAccess special case
+    # in src/input/target/xpad.rs).
     - name: HOME (shortpress)
       source_events:
           - evdev:
@@ -39,7 +45,7 @@ mapping:
                 value_type: button
       target_event:
           gamepad:
-              button: QuickAccess2
+              button: QuickAccess
     - name: HOME (longpress)
       source_events:
           - evdev:

--- a/rootfs/usr/share/inputplumber/capability_maps/zone_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/zone_type1.yaml
@@ -73,17 +73,6 @@ mapping:
       target_event:
           gamepad:
               button: RightPaddle1
-    # The dials are deliberately not mapped here. They reach no evdev node at
-    # all - their HID usages are declared on the Generic Desktop page but hold
-    # Consumer page codes, so the kernel translates none of them - which means
-    # a REL_WHEEL/REL_HWHEEL mapping never fired for the dials it was written
-    # for.
-    #
-    # It claimed events all the same: capability maps are applied per composite
-    # device rather than per source, so the wheel events of the left touchpad -
-    # which is a scroll surface, not a pointer one - were turned into a dial
-    # capability that none of this device's targets consume, leaving that
-    # touchpad dead.
 
 # List of events to filter from the source devices
 filtered_events: []

--- a/rootfs/usr/share/inputplumber/capability_maps/zone_type1_dial.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/zone_type1_dial.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+# Schema version number
+version: 2
+
+# The type of configuration schema
+kind: CapabilityMap
+
+# Name for the device event map
+name: Zotac Zone Type 1 Dial
+
+# Unique identifier of the capability mapping
+id: zone1_dial
+
+# Not attached to any source_devices entry in 50-zotac-zone.yaml yet: the
+# dials only reach a hidraw report (interface 1, report ID 3) with no evdev
+# node at all, and no source driver reads it. Kept here, scoped to its own
+# id, for whichever evdev-producing source ends up carrying REL_WHEEL /
+# REL_HWHEEL for the dials (e.g. once a vendor kernel driver or a hidraw
+# parser is in place) so it can be attached without also catching the
+# unrelated left touchpad, which emits the same REL_WHEEL/REL_HWHEEL codes
+# on its own source and does not want them translated.
+mapping:
+    - name: Left Dial
+      source_events:
+          - evdev:
+                event_type: REL
+                event_code: REL_HWHEEL
+                value_type: joystick_x
+      target_event:
+          gamepad:
+              dial:
+                  name: LeftStickDial
+    - name: Right Dial
+      source_events:
+          - evdev:
+                event_code: REL_WHEEL
+                event_type: REL
+                value_type: joystick_x
+      target_event:
+          gamepad:
+              dial:
+                  name: RightStickDial
+
+# List of events to filter from the source devices
+filtered_events: []

--- a/rootfs/usr/share/inputplumber/devices/50-zotac-zone.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-zotac-zone.yaml
@@ -27,13 +27,31 @@ source_devices:
       vendor_id: 0x1ee9
       product_id: 0x1590
       interface_num: 3
+  # This name matches identically-named evdev nodes on interfaces 1.2 and 1.3
+  # in addition to the real gamepad node on interface 1.1, so phys_path pins
+  # the match to interface 1.1 only. Without it, InputPlumber creates three
+  # duplicate CompositeDevices (and three duplicate virtual gamepads) for one
+  # physical controller.
   - group: gamepad
     evdev:
       name: Zotac Technology Limited ZOTAC GAMING ZONE
       vendor_id: "1ee9"
       product_id: "1590"
+      phys_path: "*/input1"
       handler: event*
     capability_map_id: zone1
+  # Raw XInput-compatible joystick node exposed by the kernel's xpad driver
+  # (interface 1.0). Carries the real face buttons/sticks/triggers/Select
+  # (View)/Start/Guide. Grabbing it here hides it from Steam so those inputs
+  # go through the translated virtual gamepad instead of a second, untranslated
+  # raw controller.
+  - group: gamepad
+    evdev:
+      name: ZOTAC Gaming Zone
+      vendor_id: "1ee9"
+      product_id: "1590"
+      phys_path: "*/input0"
+      handler: event*
   - group: keyboard
     evdev:
       name: Zotac Technology Limited ZOTAC GAMING ZONE Keyboard
@@ -50,7 +68,7 @@ source_devices:
   #    handler: event*
   - group: mouse
     evdev:
-      name: ZOTAC Gaming Zone Dials
+      name: Zotac Technology Limited ZOTAC GAMING ZONE Mouse
       vendor_id: "1ee9"
       product_id: "1590"
       handler: event*

--- a/rootfs/usr/share/inputplumber/devices/50-zotac-zone.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-zotac-zone.yaml
@@ -29,14 +29,14 @@ source_devices:
       interface_num: 3
   - group: gamepad
     evdev:
-      name: ZOTAC Gaming Zone Gamepad
+      name: Zotac Technology Limited ZOTAC GAMING ZONE
       vendor_id: "1ee9"
       product_id: "1590"
       handler: event*
     capability_map_id: zone1
   - group: keyboard
     evdev:
-      name: ZOTAC Gaming Zone Keyboard
+      name: Zotac Technology Limited ZOTAC GAMING ZONE Keyboard
       vendor_id: "1ee9"
       product_id: "1590"
       handler: event*

--- a/rootfs/usr/share/inputplumber/devices/50-zotac-zone.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-zotac-zone.yaml
@@ -27,24 +27,14 @@ source_devices:
       vendor_id: 0x1ee9
       product_id: 0x1590
       interface_num: 3
-  # This name matches identically-named evdev nodes on interfaces 1.2 and 1.3
-  # in addition to the real gamepad node on interface 1.1, so phys_path pins
-  # the match to interface 1.1 only. Without it, InputPlumber creates three
-  # duplicate CompositeDevices (and three duplicate virtual gamepads) for one
-  # physical controller.
   - group: gamepad
     evdev:
-      name: Zotac Technology Limited ZOTAC GAMING ZONE
+      name: "{ZOTAC Gaming Zone Gamepad,Zotac Technology Limited ZOTAC GAMING ZONE}"
       vendor_id: "1ee9"
       product_id: "1590"
       phys_path: "*/input1"
       handler: event*
     capability_map_id: zone1
-  # Raw XInput-compatible joystick node exposed by the kernel's xpad driver
-  # (interface 1.0). Carries the real face buttons/sticks/triggers/Select
-  # (View)/Start/Guide. Grabbing it here hides it from Steam so those inputs
-  # go through the translated virtual gamepad instead of a second, untranslated
-  # raw controller.
   - group: gamepad
     evdev:
       name: ZOTAC Gaming Zone
@@ -54,7 +44,7 @@ source_devices:
       handler: event*
   - group: keyboard
     evdev:
-      name: Zotac Technology Limited ZOTAC GAMING ZONE Keyboard
+      name: "{ZOTAC Gaming Zone Keyboard,Zotac Technology Limited ZOTAC GAMING ZONE Keyboard}"
       vendor_id: "1ee9"
       product_id: "1590"
       handler: event*
@@ -68,11 +58,10 @@ source_devices:
   #    handler: event*
   - group: mouse
     evdev:
-      name: Zotac Technology Limited ZOTAC GAMING ZONE Mouse
+      name: "{ZOTAC Gaming Zone Mouse,ZOTAC Gaming Zone Dials,Zotac Technology Limited ZOTAC GAMING ZONE Mouse}"
       vendor_id: "1ee9"
       product_id: "1590"
       handler: event*
-    capability_map_id: zone1
   - group: imu
     iio:
       name: "{i2c-BMI0160:00,bmi260}"


### PR DESCRIPTION
## Summary

Four related fixes for the Zotac Gaming Zone (board G0A1W/G1A1W), found while
debugging why the physical Steam and QAM buttons stopped working after
switching from an HHD-based image to InputPlumber:

- **Device name mismatch** (`50-zotac-zone.yaml`): the gamepad and keyboard
  evdev source names didn't match what the kernel actually reports
  (`Zotac Technology Limited ZOTAC GAMING ZONE[...]`), so those source
  devices were never matched at all.
- **Steam/QAM capability bindings swapped** (`zone_type1.yaml`): F17 (Steam
  button) was bound to `QuickAccess`, which synthesizes the Guide+South
  chord that opens the Quick Access Menu — so the Steam button opened QAM
  instead of the main Steam menu. F18 (QAM button) was bound to
  `QuickAccess2`, which has no evdev output at all on the xbox-elite target,
  so it did nothing. Swapped so F17 -> `Guide` and F18 -> `QuickAccess`,
  matching how every other handheld's single QAM-style shortcut key is
  mapped elsewhere in this repo.
- **Duplicate composite device + missing View button** (`50-zotac-zone.yaml`):
  the gamepad evdev source matched purely by name, but that name is reported
  identically on USB interfaces 1.1, 1.2, and 1.3, causing InputPlumber to
  create three separate CompositeDevices (and three duplicate virtual Xbox
  controllers) for one physical controller. Added `phys_path` to pin the
  match to interface 1.1 only. Separately, the real face buttons / sticks /
  triggers / View (Select) button are exposed by the kernel's built-in
  `xpad` driver as a standard joystick on interface 1.0, which wasn't
  referenced by this config at all — Steam was reading that raw joystick
  directly instead of the translated virtual controller, so View never
  reached it. Added that node as a gamepad source so InputPlumber grabs and
  hides it from Steam and translates it like the rest of the controller.
- **Dial mappings swallowed the left touchpad** (`zone_type1.yaml`): the
  dials reach no evdev node — their HID usages are declared on the Generic
  Desktop page but hold Consumer page codes, so the kernel translates none
  of them — meaning the `REL_WHEEL`/`REL_HWHEEL` entries written for them
  never fired for the dials. They claimed events all the same: capability
  maps are applied per composite device rather than per source, so the wheel
  events of the left touchpad (a scroll surface, not a pointer one) became
  `LeftStickDial`/`RightStickDial`, which none of this device's targets
  consume — leaving that touchpad dead. This was latent until the first
  commit here corrected the mouse source's evdev name, which is what made
  that source match in the first place. Dropped the two mappings; reading
  the dials needs a hidraw report parser rather than a capability map.

## Test plan

All verified on real Zotac Gaming Zone (G0A1W) hardware running Bazzite:

- [x] `make test` (clippy + full test suite + autostart-rules check) passes
- [x] Steam button opens the main Steam menu
- [x] QAM button opens the Quick Access Menu
- [x] Analog sticks, ABXY, shoulder buttons, triggers, and D-pad work through
      a single virtual gamepad (previously duplicated 3x)
- [x] View (Select) button works
- [x] Only one `CompositeDevice`/virtual gamepad is created per physical
      controller (verified via `busctl` DBus introspection)
- [x] Left touchpad scrolls again, right touchpad still moves the pointer

## Follow-up

- Rear paddle (macro) buttons are fixed separately in #668, which applies to
  `main` independently of this PR — the two touch different files. The
  buttons turned out to ship with an empty mapping in the device's own
  configuration, so the firmware sends nothing at all for them until that
  mapping is written over the vendor config interface.
- Dial wheels remain unsupported. The protocol is known (report ID 3 on USB
  interface 1, one bit per dial and direction), but reading it needs a hidraw
  parser in the `zotac_zone` source driver and is not included here.

## Disclosure

Root-caused, implemented, and verified on hardware in collaboration with
Claude Sonnet 5 and Claude Opus 5 (Claude Code), which diagnosed the
capability-translation behavior in `xpad.rs`/`evdev.rs`, the
duplicate-device/raw-joystick behavior via `evtest`/`journalctl`/DBus
introspection on the running device, and the per-composite-device capability
map translation that was swallowing the touchpad's wheel events, and proposed
these fixes. I reviewed and understand every changed line.