### PR TITLE
fix(Ayaneo 3): match the joystick rings LED sys_name by glob

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_3.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_3.yaml
@@ -85,7 +85,7 @@ source_devices:
       subsystem: leds
   - group: led
     udev: # Updated
-      sys_name: ayaneo:rgb:joystick_rings
+      sys_name: "*:rgb:joystick_rings"
       subsystem: leds
 
 # Optional configuration for the composite device


### PR DESCRIPTION
The `hid-ayaneo` driver just merged in [OpenGamingCollective/linux-unstable#3](https://github.com/OpenGamingCollective/linux-unstable/pull/3) registers the AYANEO 3 joystick-rings LED with a per-device name (`<hid device name>:rgb:joystick_rings`, e.g. `0003:1C4F:0002.0003:rgb:joystick_rings`) instead of the fixed `ayaneo:rgb:joystick_rings` this config expects — the prefix was changed to `dev_name()` during kernel review, since a fixed LED name can collide.

`sys_name` is matched with `glob_match()`, so a wildcard prefix keeps this entry working with **both** the old fixed name and the new per-device one (the composite device is DMI-gated to the AYANEO 3, so the glob can't over-match on other hardware).

Verified on an AYANEO 3 on Bazzite 44 with the merged driver: the LED registers as `0003:1C4F:0002.0003:rgb:joystick_rings` and the HID device (and thus the LED path) is recreated on every controller power cycle, which is why matching by exact name is brittle.

Related: ShadowBlip/OpenGamepadUI#528 (magic-modules integration coordination).