### PR TITLE
fix(device): support AYADEVICE AYANEO 2021

### DIFF
--- a/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
+++ b/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
@@ -22,6 +22,7 @@ dmi:*svnAYANEO:pnGEEK:*
 dmi:*svnMystenLabs,Inc.:pnSuiPlay0X1:*
 # AYANEO 2021
 dmi:*svnAYANEO:pnAYANEO2021:*
+dmi:*svnAYADEVICE:pnAYANEO2021:*
 dmi:*svnAYANEO:pnAYANEO2021Pro:*
 dmi:*svnAYANEO:pnAYANEO2021ProRetroPower:*
 dmi:*svnAYANEO:pnAYANEOFOUNDER:*

--- a/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
+++ b/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
@@ -21,8 +21,8 @@ dmi:*svnAYANEO:pnGEEK1S:*
 dmi:*svnAYANEO:pnGEEK:*
 dmi:*svnMystenLabs,Inc.:pnSuiPlay0X1:*
 # AYANEO 2021
-dmi:*svnAYANEO:pnAYANEO2021:*
 dmi:*svnAYADEVICE:pnAYANEO2021:*
+dmi:*svnAYANEO:pnAYANEO2021:*
 dmi:*svnAYANEO:pnAYANEO2021Pro:*
 dmi:*svnAYANEO:pnAYANEO2021ProRetroPower:*
 dmi:*svnAYANEO:pnAYANEOFOUNDER:*

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2021.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2021.yaml
@@ -22,6 +22,9 @@ matches:
       product_name: AYA NEO 2021
       sys_vendor: AYANEO
   - dmi_data:
+      product_name: AYA NEO 2021
+      sys_vendor: AYADEVICE
+  - dmi_data:
       product_name: AYANEO 2021
       sys_vendor: AYANEO
   - dmi_data:

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2021.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2021.yaml
@@ -20,10 +20,10 @@ matches:
       sys_vendor: AYA NEO
   - dmi_data:
       product_name: AYA NEO 2021
-      sys_vendor: AYANEO
+      sys_vendor: AYADEVICE
   - dmi_data:
       product_name: AYA NEO 2021
-      sys_vendor: AYADEVICE
+      sys_vendor: AYANEO
   - dmi_data:
       product_name: AYANEO 2021
       sys_vendor: AYANEO


### PR DESCRIPTION
Closes #665.

## Summary

- add the observed `AYADEVICE` vendor identity to the existing `AYA NEO 2021` device profile
- add the corresponding DMI hardware-database rule so InputPlumber starts automatically
- retain all existing AYANEO 2021 matches and button mappings

The affected unit is an original AYANEO 2021 with a Ryzen 5 4500U. Its firmware reports:

```text
product_name: AYA NEO 2021
sys_vendor: AYADEVICE
modalias: dmi:*svnAYADEVICE:pnAYANEO2021:*
```

## Testing

Tested on the physical device running Bazzite Deck 44 (`44.20260820`), kernel `7.2.0-ogc4.1.fc44.x86_64`, and InputPlumber `0.78.0-5.fc44.x86_64`:

- copied the profile to `/etc/inputplumber/devices.d/` and added the proposed `AYADEVICE` match
- added the proposed DMI match to a local hwdb override; the live modalias query returned `USE_INPUTPLUMBER=1`
- confirmed the complete udev rule resolved to `SYSTEMD_WANTS=inputplumber.service`
- stopped InputPlumber, confirmed it was inactive, triggered an `add` event for `/sys/class/dmi/id`, and confirmed the service automatically returned to `active`
- restarted InputPlumber and confirmed it selected the `AYANEO 2021` composite profile
- confirmed the Xbox 360 gamepad, AT keyboard, and `i2c-10EC5280:00` IMU were attached and the virtual targets were created
- confirmed TM opens QAM and ESC opens QAM 2
- confirmed WIN remains unmapped, as intended
- confirmed KB is decoded as `Gamepad:Button:Keyboard` and reaches OpenGamepadUI as `Trigger Steam OSK`

The Steam on-screen keyboard did not become visible, but Steam's standard Home+X shortcut and a direct `steam://open/keyboard` request also failed. That appears to be a separate Steam OSK issue rather than a failure of this device profile.

Repository-side checks:

- `git diff --check`: passed
- YAML parsing and assertion for the new DMI entry: passed
- assertion that the new hwdb rule exists exactly once: passed
- `cargo fmt --check`: not run locally because the Rust toolchain is unavailable; this data-only change does not modify Rust source

## AI disclosure

OpenAI Codex was used to gather and structure SSH diagnostics from the test device, compare the observed DMI identity with the existing profile, draft the two data additions, and organize this pull-request description. The prompt scope was to add the observed `AYADEVICE` profile and autostart matches, reference #665, and report the physical-device validation. I reviewed every changed line and the test results before submission.