### PR TITLE
fix(Zotac Zone): bind rear paddles without the vendor kernel driver

### DIFF
--- a/src/drivers/zotac_zone/driver.rs
+++ b/src/drivers/zotac_zone/driver.rs
@@ -87,9 +87,8 @@ fn configure_via_sysfs(udevice: &UdevDevice) -> bool {
     true
 }
 
-/// Configure the device over hidraw. This is a one-shot, uncommitted
-/// configuration, so it doesn't override the user's saved device settings and
-/// lasts only until the device is power cycled.
+/// Configure the device over hidraw. Oneshot config prevents overriding user
+/// set config.
 fn configure_via_hidraw(udevice: &UdevDevice) -> Result<(), Box<dyn Error + Send + Sync>> {
     let path = CString::new(udevice.devnode())?;
     let api = hidapi::HidApi::new()?;

--- a/src/drivers/zotac_zone/driver.rs
+++ b/src/drivers/zotac_zone/driver.rs
@@ -1,8 +1,16 @@
 use std::error::Error;
+use std::ffi::CString;
+use std::time::Duration;
 
+use hidapi::HidDevice;
 use udev::Device;
 
-use crate::udev::device::{AttributeGetter, AttributeSetter, UdevDevice};
+use crate::udev::device::{AttributeSetter, UdevDevice};
+
+use super::hid_report::{
+    mapping_status, set_keyboard_mapping, BUTTON_M1, BUTTON_M2, HID_KEY_END, HID_KEY_HOME,
+    REPORT_SIZE,
+};
 
 // Hardware ID's
 const ZONE_PID: u16 = 0x1590;
@@ -11,6 +19,9 @@ pub const PIDS: [u16; 1] = [ZONE_PID];
 pub const VID: u16 = 0x1ee9;
 pub const VID_ALT: u16 = 0x1e19;
 pub const VIDS: [u16; 2] = [VID, VID_ALT];
+
+/// How long to wait for the device to acknowledge a configuration command.
+const COMMAND_TIMEOUT: Duration = Duration::from_millis(500);
 
 pub struct Driver {
     _device: UdevDevice,
@@ -24,28 +35,114 @@ impl Driver {
             return Err(format!("'{}' is not an Zotac Zone controller", udevice.devnode()).into());
         }
 
-        // Set the controller buttons to the correct values at startup
-        let mut device = udevice.get_device()?;
-        let Some(parent) = device.parent() else {
-            return Err("Failed to get device parent".into());
-        };
-        let Some(driver) = parent.driver() else {
-            return Err("Failed to identify device driver".into());
-        };
-        // Apply settings for the controller. Do error and crash IP as the
-        // device is still usable.
-        let drv_name = driver.to_str().unwrap();
-        if drv_name == "zotac_zone_hid" || drv_name == "hid_zotac_zone" {
-            if device.interface_number() == ZONE_CFG_IF_NUM {
-                set_attribute(&mut device, "qam_mode", "0");
-                set_attribute(&mut device, "btn_m2/remap/keyboard", "home");
-                set_attribute(&mut device, "btn_m1/remap/keyboard", "end");
-            }
-        } else {
-            return Err("Device is not using the zotac_zone driver.".into());
+        // Set the controller buttons to the correct values at startup. The
+        // device is perfectly usable if this fails, so only warn about it.
+        if udevice.interface_number() == ZONE_CFG_IF_NUM {
+            configure_macro_buttons(&udevice);
         }
 
         Ok(Self { _device: udevice })
+    }
+}
+
+/// Bind the rear macro buttons to Home and End, which the `zone1` capability
+/// map translates into the paddle capabilities.
+///
+/// The buttons ship with an empty mapping, so the firmware sends nothing at all
+/// while they're unbound - they show up on no evdev node and in no HID report.
+/// The vendor kernel driver binds them through sysfs; where that driver isn't
+/// loaded, the same thing can be asked of the device directly over hidraw.
+fn configure_macro_buttons(udevice: &UdevDevice) {
+    if configure_via_sysfs(udevice) {
+        return;
+    }
+
+    if let Err(e) = configure_via_hidraw(udevice) {
+        log::warn!("Could not configure Zotac Zone macro buttons: {e}");
+    }
+}
+
+/// Configure the device through the sysfs attributes of the vendor kernel
+/// driver, returning whether that driver was there to handle it.
+fn configure_via_sysfs(udevice: &UdevDevice) -> bool {
+    let Ok(mut device) = udevice.get_device() else {
+        return false;
+    };
+    let Some(parent) = device.parent() else {
+        return false;
+    };
+    let Some(driver) = parent.driver().and_then(|driver| driver.to_str()) else {
+        return false;
+    };
+    if driver != "zotac_zone_hid" && driver != "hid_zotac_zone" {
+        log::debug!(
+            "Zotac Zone config interface is bound to '{driver}' rather than the vendor driver; \
+             configuring it over hidraw instead."
+        );
+        return false;
+    }
+
+    set_attribute(&mut device, "qam_mode", "0");
+    set_attribute(&mut device, "btn_m2/remap/keyboard", "home");
+    set_attribute(&mut device, "btn_m1/remap/keyboard", "end");
+
+    true
+}
+
+/// Configure the device by speaking the vendor protocol over hidraw.
+///
+/// The mapping is deliberately not committed with the protocol's save command,
+/// so it lasts only until the device is power cycled and the user's stored
+/// configuration is left untouched.
+fn configure_via_hidraw(udevice: &UdevDevice) -> Result<(), Box<dyn Error + Send + Sync>> {
+    let path = CString::new(udevice.devnode())?;
+    let api = hidapi::HidApi::new()?;
+    let device = api.open_path(&path)?;
+
+    // M2 is the left paddle, M1 the right one. Each button is mapped
+    // independently so that one of them failing still leaves the other bound.
+    for (sequence, button_id, key) in [(0, BUTTON_M2, HID_KEY_HOME), (1, BUTTON_M1, HID_KEY_END)] {
+        if let Err(e) = send_mapping(&device, sequence, button_id, key) {
+            log::warn!("Could not map Zotac Zone button {button_id:#04x}: {e}");
+        }
+    }
+
+    Ok(())
+}
+
+/// Send a single button mapping command and wait for the device to accept it.
+fn send_mapping(
+    device: &HidDevice,
+    sequence: u8,
+    button_id: u8,
+    key: u8,
+) -> Result<(), Box<dyn Error + Send + Sync>> {
+    device.write(&set_keyboard_mapping(sequence, button_id, key))?;
+
+    // The device also emits unsolicited status frames on this interface, so
+    // read until its answer to *this* command turns up.
+    let deadline = std::time::Instant::now() + COMMAND_TIMEOUT;
+    loop {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(format!("Timed out mapping button {button_id:#04x}").into());
+        }
+
+        let mut buf = [0; REPORT_SIZE];
+        let bytes_read = device.read_timeout(&mut buf, remaining.as_millis() as i32)?;
+        let Some(status) = mapping_status(&buf[..bytes_read]) else {
+            continue;
+        };
+
+        if status != 0 {
+            return Err(format!(
+                "Device rejected mapping for button {button_id:#04x}: {status:#04x}"
+            )
+            .into());
+        }
+
+        log::debug!("Mapped Zotac Zone button {button_id:#04x} to key {key:#04x}");
+        return Ok(());
     }
 }
 

--- a/src/drivers/zotac_zone/driver.rs
+++ b/src/drivers/zotac_zone/driver.rs
@@ -3,13 +3,13 @@ use std::ffi::CString;
 use std::time::Duration;
 
 use hidapi::HidDevice;
+use packed_struct::PrimitiveEnum;
 use udev::Device;
 
 use crate::udev::device::{AttributeSetter, UdevDevice};
 
 use super::hid_report::{
-    mapping_status, set_keyboard_mapping, BUTTON_M1, BUTTON_M2, HID_KEY_END, HID_KEY_HOME,
-    REPORT_SIZE,
+    ButtonId, ButtonMappingRequest, ButtonMappingResponse, HID_KEY_END, HID_KEY_HOME, REPORT_SIZE,
 };
 
 // Hardware ID's
@@ -48,10 +48,8 @@ impl Driver {
 /// Bind the rear macro buttons to Home and End, which the `zone1` capability
 /// map translates into the paddle capabilities.
 ///
-/// The buttons ship with an empty mapping, so the firmware sends nothing at all
-/// while they're unbound - they show up on no evdev node and in no HID report.
-/// The vendor kernel driver binds them through sysfs; where that driver isn't
-/// loaded, the same thing can be asked of the device directly over hidraw.
+/// Attempts first to bind with the vendor kernel driver and falls back to
+/// raw HID commands over hidraw.
 fn configure_macro_buttons(udevice: &UdevDevice) {
     if configure_via_sysfs(udevice) {
         return;
@@ -89,11 +87,9 @@ fn configure_via_sysfs(udevice: &UdevDevice) -> bool {
     true
 }
 
-/// Configure the device by speaking the vendor protocol over hidraw.
-///
-/// The mapping is deliberately not committed with the protocol's save command,
-/// so it lasts only until the device is power cycled and the user's stored
-/// configuration is left untouched.
+/// Configure the device over hidraw. This is a one-shot, uncommitted
+/// configuration, so it doesn't override the user's saved device settings and
+/// lasts only until the device is power cycled.
 fn configure_via_hidraw(udevice: &UdevDevice) -> Result<(), Box<dyn Error + Send + Sync>> {
     let path = CString::new(udevice.devnode())?;
     let api = hidapi::HidApi::new()?;
@@ -101,9 +97,12 @@ fn configure_via_hidraw(udevice: &UdevDevice) -> Result<(), Box<dyn Error + Send
 
     // M2 is the left paddle, M1 the right one. Each button is mapped
     // independently so that one of them failing still leaves the other bound.
-    for (sequence, button_id, key) in [(0, BUTTON_M2, HID_KEY_HOME), (1, BUTTON_M1, HID_KEY_END)] {
-        if let Err(e) = send_mapping(&device, sequence, button_id, key) {
-            log::warn!("Could not map Zotac Zone button {button_id:#04x}: {e}");
+    for (button_id, key) in [(ButtonId::M2, HID_KEY_HOME), (ButtonId::M1, HID_KEY_END)] {
+        if let Err(e) = send_mapping(&device, button_id, key) {
+            log::warn!(
+                "Could not map Zotac Zone button {:#04x}: {e}",
+                button_id.to_primitive()
+            );
         }
     }
 
@@ -113,11 +112,10 @@ fn configure_via_hidraw(udevice: &UdevDevice) -> Result<(), Box<dyn Error + Send
 /// Send a single button mapping command and wait for the device to accept it.
 fn send_mapping(
     device: &HidDevice,
-    sequence: u8,
-    button_id: u8,
+    button_id: ButtonId,
     key: u8,
 ) -> Result<(), Box<dyn Error + Send + Sync>> {
-    device.write(&set_keyboard_mapping(sequence, button_id, key))?;
+    device.write(&ButtonMappingRequest::new(button_id, key).to_bytes()?)?;
 
     // The device also emits unsolicited status frames on this interface, so
     // read until its answer to *this* command turns up.
@@ -125,23 +123,29 @@ fn send_mapping(
     loop {
         let remaining = deadline.saturating_duration_since(std::time::Instant::now());
         if remaining.is_zero() {
-            return Err(format!("Timed out mapping button {button_id:#04x}").into());
+            return Err(
+                format!("Timed out mapping button {:#04x}", button_id.to_primitive()).into(),
+            );
         }
 
         let mut buf = [0; REPORT_SIZE];
         let bytes_read = device.read_timeout(&mut buf, remaining.as_millis() as i32)?;
-        let Some(status) = mapping_status(&buf[..bytes_read]) else {
+        let Some(status) = ButtonMappingResponse::status(&buf[..bytes_read]) else {
             continue;
         };
 
         if status != 0 {
             return Err(format!(
-                "Device rejected mapping for button {button_id:#04x}: {status:#04x}"
+                "Device rejected mapping for button {:#04x}: {status:#04x}",
+                button_id.to_primitive()
             )
             .into());
         }
 
-        log::debug!("Mapped Zotac Zone button {button_id:#04x} to key {key:#04x}");
+        log::debug!(
+            "Mapped Zotac Zone button {:#04x} to key {key:#04x}",
+            button_id.to_primitive()
+        );
         return Ok(());
     }
 }

--- a/src/drivers/zotac_zone/hid_report.rs
+++ b/src/drivers/zotac_zone/hid_report.rs
@@ -7,7 +7,7 @@
 //! clause. Values were verified against live captures from a Zotac Zone
 //! running firmware 1.3.9.
 
-use packed_struct::prelude::*;
+use packed_struct::prelude::{PackedStruct, PackingError, PrimitiveEnum_u8};
 
 /// Size of a command frame, excluding the leading hidraw report number.
 pub const REPORT_SIZE: usize = 64;

--- a/src/drivers/zotac_zone/hid_report.rs
+++ b/src/drivers/zotac_zone/hid_report.rs
@@ -7,48 +7,125 @@
 //! clause. Values were verified against live captures from a Zotac Zone
 //! running firmware 1.3.9.
 
+use packed_struct::prelude::*;
+
 /// Size of a command frame, excluding the leading hidraw report number.
 pub const REPORT_SIZE: usize = 64;
 
 const HEADER_TAG: u8 = 0xE1;
 const PAYLOAD_SIZE: u8 = 0x3C;
 
-// Byte offsets within a command frame.
-const HEADER_TAG_POS: usize = 0x00;
-const RESERVED_POS: usize = 0x01;
-const SEQUENCE_POS: usize = 0x02;
-const PAYLOADSIZE_POS: usize = 0x03;
-const COMMAND_POS: usize = 0x04;
-const CRC_H_POS: usize = 0x3E;
-const CRC_L_POS: usize = 0x3F;
-
 // The checksum covers the command and its payload, but not the framing bytes
-// that precede them - notably not the sequence number.
-const CRC_START: usize = 0x04;
-const CRC_END: usize = 0x3E;
-
-const CMD_SET_BUTTON_MAPPING: u8 = 0xA1;
-
-// Offsets of a button mapping payload, relative to the start of the frame. The
-// bytes in between hold gamepad button, modifier key and mouse button
-// bindings, all of which are left cleared here.
-const MAP_SOURCE_POS: usize = 0x05;
-const MAP_KEYBOARD_POS: usize = 0x0C;
-
-/// Status byte of a `CMD_SET_BUTTON_MAPPING` response. Commands that carry a
-/// setting byte report their status one byte later than the rest do.
-const MAP_STATUS_POS: usize = 0x06;
-
-/// Button ids used by the mapping commands.
-pub const BUTTON_M1: u8 = 0x01;
-pub const BUTTON_M2: u8 = 0x02;
+// that precede them - notably not the sequence number. Indices below are
+// absolute, counting the leading hidraw report number (always zero) as byte 0.
+const CRC_START: usize = 0x05;
+const CRC_END: usize = 0x3F;
+const CRC_H_POS: usize = 0x3F;
+const CRC_L_POS: usize = 0x40;
 
 /// HID keyboard usage codes.
 pub const HID_KEY_HOME: u8 = 0x4A;
 pub const HID_KEY_END: u8 = 0x4D;
 
-/// Checksum over the command and payload bytes of a frame.
-fn calc_crc(frame: &[u8; REPORT_SIZE]) -> u16 {
+/// Commands understood by the configuration interface.
+#[derive(PrimitiveEnum_u8, Debug, Clone, Copy, PartialEq)]
+pub enum Command {
+    SetButtonMapping = 0xA1,
+}
+
+/// Rear macro buttons that can be remapped over this protocol.
+#[derive(PrimitiveEnum_u8, Debug, Clone, Copy, PartialEq)]
+pub enum ButtonId {
+    M1 = 0x01,
+    M2 = 0x02,
+}
+
+impl ButtonId {
+    /// Sequence number to stamp on this button's mapping command. The two
+    /// buttons are always mapped together at startup, so a fixed, distinct
+    /// number per button is enough to match each response to its own request
+    /// on the shared command interface.
+    fn sequence(self) -> u8 {
+        match self {
+            ButtonId::M2 => 0,
+            ButtonId::M1 => 1,
+        }
+    }
+}
+
+/// A `CMD_SET_BUTTON_MAPPING` request binding a button to a single keyboard
+/// key, clearing any gamepad, modifier and mouse bindings it previously had.
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", size_bytes = "65")]
+pub struct ButtonMappingRequest {
+    #[packed_field(bytes = "1")]
+    header_tag: u8,
+    #[packed_field(bytes = "3")]
+    sequence: u8,
+    #[packed_field(bytes = "4")]
+    payload_size: u8,
+    #[packed_field(bytes = "5", ty = "enum")]
+    command: Command,
+    #[packed_field(bytes = "6", ty = "enum")]
+    button_id: ButtonId,
+    #[packed_field(bytes = "13")]
+    key: u8,
+}
+
+impl ButtonMappingRequest {
+    pub fn new(button_id: ButtonId, key: u8) -> Self {
+        Self {
+            header_tag: HEADER_TAG,
+            sequence: button_id.sequence(),
+            payload_size: PAYLOAD_SIZE,
+            command: Command::SetButtonMapping,
+            button_id,
+            key,
+        }
+    }
+
+    /// Packs this request into a hidraw write buffer with its checksum filled
+    /// in. The command interface uses unnumbered reports, so the leading
+    /// report number byte is always zero.
+    pub fn to_bytes(self) -> Result<[u8; REPORT_SIZE + 1], PackingError> {
+        let mut report = self.pack()?;
+        let crc = calc_crc(&report);
+        report[CRC_H_POS] = (crc >> 8) as u8;
+        report[CRC_L_POS] = crc as u8;
+        Ok(report)
+    }
+}
+
+/// A `CMD_SET_BUTTON_MAPPING` response. Commands that carry a setting byte
+/// report their status one byte later than the rest do.
+#[derive(PackedStruct, Debug, Copy, Clone, PartialEq)]
+#[packed_struct(bit_numbering = "msb0", size_bytes = "64")]
+pub struct ButtonMappingResponse {
+    #[packed_field(bytes = "4", ty = "enum")]
+    command: Command,
+    #[packed_field(bytes = "6")]
+    status: u8,
+}
+
+impl ButtonMappingResponse {
+    /// The status a response reports, or `None` if `bytes` isn't an answer to
+    /// a button mapping command. A status of zero means the device accepted
+    /// it.
+    pub fn status(bytes: &[u8]) -> Option<u8> {
+        let mut frame = [0; REPORT_SIZE];
+        let len = bytes.len().min(REPORT_SIZE);
+        frame[..len].copy_from_slice(&bytes[..len]);
+
+        Self::unpack(&frame).ok().map(|response| response.status)
+    }
+}
+
+/// Checksum over the command and payload bytes of a request frame. Exposed
+/// crate-internally so the frame layout can be verified against a captured
+/// device frame in `hid_report_test.rs`, which isn't otherwise reachable
+/// through the type-safe [ButtonMappingRequest] API (a raw capture's command
+/// byte is not necessarily a [Command] this module knows about).
+pub(crate) fn calc_crc(frame: &[u8; REPORT_SIZE + 1]) -> u16 {
     let mut crc: u16 = 0;
 
     for byte in &frame[CRC_START..CRC_END] {
@@ -61,91 +138,4 @@ fn calc_crc(frame: &[u8; REPORT_SIZE]) -> u16 {
     }
 
     crc
-}
-
-/// Build a command frame with the framing bytes filled in.
-fn build_frame(sequence: u8, command: u8) -> [u8; REPORT_SIZE] {
-    let mut frame = [0; REPORT_SIZE];
-    frame[HEADER_TAG_POS] = HEADER_TAG;
-    frame[RESERVED_POS] = 0x00;
-    frame[SEQUENCE_POS] = sequence;
-    frame[PAYLOADSIZE_POS] = PAYLOAD_SIZE;
-    frame[COMMAND_POS] = command;
-    frame
-}
-
-/// Append the checksum to a frame and prefix the hidraw report number. The
-/// command interface uses unnumbered reports, so that number is always zero.
-fn finish_frame(mut frame: [u8; REPORT_SIZE]) -> [u8; REPORT_SIZE + 1] {
-    let crc = calc_crc(&frame);
-    frame[CRC_H_POS] = (crc >> 8) as u8;
-    frame[CRC_L_POS] = crc as u8;
-
-    let mut report = [0; REPORT_SIZE + 1];
-    report[1..].copy_from_slice(&frame);
-    report
-}
-
-/// Build a command binding `button_id` to a single keyboard `key`, clearing any
-/// gamepad, modifier and mouse bindings it previously had.
-pub fn set_keyboard_mapping(sequence: u8, button_id: u8, key: u8) -> [u8; REPORT_SIZE + 1] {
-    let mut frame = build_frame(sequence, CMD_SET_BUTTON_MAPPING);
-    frame[MAP_SOURCE_POS] = button_id;
-    frame[MAP_KEYBOARD_POS] = key;
-    finish_frame(frame)
-}
-
-/// The status a button mapping response reports, or `None` if `response` isn't
-/// an answer to a button mapping command. A status of zero means the device
-/// accepted it.
-pub fn mapping_status(response: &[u8]) -> Option<u8> {
-    if response.get(COMMAND_POS) != Some(&CMD_SET_BUTTON_MAPPING) {
-        return None;
-    }
-    response.get(MAP_STATUS_POS).copied()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Checksum of a frame captured from a Zotac Zone's command interface:
-    /// `e1 00 c5 3c b2 00 .. 00 fc 8d`. The sequence byte varied between
-    /// captures while the checksum did not, which is what places the sequence
-    /// number outside the checksummed range.
-    #[test]
-    fn crc_matches_device_frame() {
-        let mut frame = [0; REPORT_SIZE];
-        frame[HEADER_TAG_POS] = HEADER_TAG;
-        frame[SEQUENCE_POS] = 0xC5;
-        frame[PAYLOADSIZE_POS] = PAYLOAD_SIZE;
-        frame[COMMAND_POS] = 0xB2;
-
-        assert_eq!(calc_crc(&frame), 0xFC8D);
-    }
-
-    #[test]
-    fn mapping_command_is_framed_correctly() {
-        let report = set_keyboard_mapping(0, BUTTON_M2, HID_KEY_HOME);
-
-        assert_eq!(report[0], 0x00, "hidraw report number");
-
-        let frame = &report[1..];
-        assert_eq!(frame[HEADER_TAG_POS], HEADER_TAG);
-        assert_eq!(frame[PAYLOADSIZE_POS], PAYLOAD_SIZE);
-        assert_eq!(frame[COMMAND_POS], CMD_SET_BUTTON_MAPPING);
-        assert_eq!(frame[MAP_SOURCE_POS], BUTTON_M2);
-        assert_eq!(frame[MAP_KEYBOARD_POS], HID_KEY_HOME);
-    }
-
-    #[test]
-    fn mapping_status_ignores_other_commands() {
-        let mut response = [0; REPORT_SIZE];
-        response[COMMAND_POS] = 0xB2;
-        assert_eq!(mapping_status(&response), None);
-
-        response[COMMAND_POS] = CMD_SET_BUTTON_MAPPING;
-        response[MAP_STATUS_POS] = 0x00;
-        assert_eq!(mapping_status(&response), Some(0));
-    }
 }

--- a/src/drivers/zotac_zone/hid_report.rs
+++ b/src/drivers/zotac_zone/hid_report.rs
@@ -1,0 +1,151 @@
+//! Vendor configuration protocol spoken on the Zotac Zone's command interface.
+//!
+//! The frame layout, CRC and command codes were derived from the vendor kernel
+//! driver at <https://github.com/OpenZotacZone/ZotacZone-Drivers>
+//! (`driver/hid/zotac-zone-hid-config.c`, GPL-2.0-or-later, Copyright (c) 2025
+//! Luke D. Jones), which InputPlumber may use under that license's "or later"
+//! clause. Values were verified against live captures from a Zotac Zone
+//! running firmware 1.3.9.
+
+/// Size of a command frame, excluding the leading hidraw report number.
+pub const REPORT_SIZE: usize = 64;
+
+const HEADER_TAG: u8 = 0xE1;
+const PAYLOAD_SIZE: u8 = 0x3C;
+
+// Byte offsets within a command frame.
+const HEADER_TAG_POS: usize = 0x00;
+const RESERVED_POS: usize = 0x01;
+const SEQUENCE_POS: usize = 0x02;
+const PAYLOADSIZE_POS: usize = 0x03;
+const COMMAND_POS: usize = 0x04;
+const CRC_H_POS: usize = 0x3E;
+const CRC_L_POS: usize = 0x3F;
+
+// The checksum covers the command and its payload, but not the framing bytes
+// that precede them - notably not the sequence number.
+const CRC_START: usize = 0x04;
+const CRC_END: usize = 0x3E;
+
+const CMD_SET_BUTTON_MAPPING: u8 = 0xA1;
+
+// Offsets of a button mapping payload, relative to the start of the frame. The
+// bytes in between hold gamepad button, modifier key and mouse button
+// bindings, all of which are left cleared here.
+const MAP_SOURCE_POS: usize = 0x05;
+const MAP_KEYBOARD_POS: usize = 0x0C;
+
+/// Status byte of a `CMD_SET_BUTTON_MAPPING` response. Commands that carry a
+/// setting byte report their status one byte later than the rest do.
+const MAP_STATUS_POS: usize = 0x06;
+
+/// Button ids used by the mapping commands.
+pub const BUTTON_M1: u8 = 0x01;
+pub const BUTTON_M2: u8 = 0x02;
+
+/// HID keyboard usage codes.
+pub const HID_KEY_HOME: u8 = 0x4A;
+pub const HID_KEY_END: u8 = 0x4D;
+
+/// Checksum over the command and payload bytes of a frame.
+fn calc_crc(frame: &[u8; REPORT_SIZE]) -> u16 {
+    let mut crc: u16 = 0;
+
+    for byte in &frame[CRC_START..CRC_END] {
+        let h1 = (crc as u32 ^ *byte as u32) & 0xFF;
+        let h2 = h1 & 0x0F;
+        let h3 = (h2 << 4) ^ h1;
+        let h4 = h3 >> 4;
+
+        crc = (((((h3 << 1) ^ h4) << 4) ^ h2) << 3) as u16 ^ h4 as u16 ^ (crc >> 8);
+    }
+
+    crc
+}
+
+/// Build a command frame with the framing bytes filled in.
+fn build_frame(sequence: u8, command: u8) -> [u8; REPORT_SIZE] {
+    let mut frame = [0; REPORT_SIZE];
+    frame[HEADER_TAG_POS] = HEADER_TAG;
+    frame[RESERVED_POS] = 0x00;
+    frame[SEQUENCE_POS] = sequence;
+    frame[PAYLOADSIZE_POS] = PAYLOAD_SIZE;
+    frame[COMMAND_POS] = command;
+    frame
+}
+
+/// Append the checksum to a frame and prefix the hidraw report number. The
+/// command interface uses unnumbered reports, so that number is always zero.
+fn finish_frame(mut frame: [u8; REPORT_SIZE]) -> [u8; REPORT_SIZE + 1] {
+    let crc = calc_crc(&frame);
+    frame[CRC_H_POS] = (crc >> 8) as u8;
+    frame[CRC_L_POS] = crc as u8;
+
+    let mut report = [0; REPORT_SIZE + 1];
+    report[1..].copy_from_slice(&frame);
+    report
+}
+
+/// Build a command binding `button_id` to a single keyboard `key`, clearing any
+/// gamepad, modifier and mouse bindings it previously had.
+pub fn set_keyboard_mapping(sequence: u8, button_id: u8, key: u8) -> [u8; REPORT_SIZE + 1] {
+    let mut frame = build_frame(sequence, CMD_SET_BUTTON_MAPPING);
+    frame[MAP_SOURCE_POS] = button_id;
+    frame[MAP_KEYBOARD_POS] = key;
+    finish_frame(frame)
+}
+
+/// The status a button mapping response reports, or `None` if `response` isn't
+/// an answer to a button mapping command. A status of zero means the device
+/// accepted it.
+pub fn mapping_status(response: &[u8]) -> Option<u8> {
+    if response.get(COMMAND_POS) != Some(&CMD_SET_BUTTON_MAPPING) {
+        return None;
+    }
+    response.get(MAP_STATUS_POS).copied()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Checksum of a frame captured from a Zotac Zone's command interface:
+    /// `e1 00 c5 3c b2 00 .. 00 fc 8d`. The sequence byte varied between
+    /// captures while the checksum did not, which is what places the sequence
+    /// number outside the checksummed range.
+    #[test]
+    fn crc_matches_device_frame() {
+        let mut frame = [0; REPORT_SIZE];
+        frame[HEADER_TAG_POS] = HEADER_TAG;
+        frame[SEQUENCE_POS] = 0xC5;
+        frame[PAYLOADSIZE_POS] = PAYLOAD_SIZE;
+        frame[COMMAND_POS] = 0xB2;
+
+        assert_eq!(calc_crc(&frame), 0xFC8D);
+    }
+
+    #[test]
+    fn mapping_command_is_framed_correctly() {
+        let report = set_keyboard_mapping(0, BUTTON_M2, HID_KEY_HOME);
+
+        assert_eq!(report[0], 0x00, "hidraw report number");
+
+        let frame = &report[1..];
+        assert_eq!(frame[HEADER_TAG_POS], HEADER_TAG);
+        assert_eq!(frame[PAYLOADSIZE_POS], PAYLOAD_SIZE);
+        assert_eq!(frame[COMMAND_POS], CMD_SET_BUTTON_MAPPING);
+        assert_eq!(frame[MAP_SOURCE_POS], BUTTON_M2);
+        assert_eq!(frame[MAP_KEYBOARD_POS], HID_KEY_HOME);
+    }
+
+    #[test]
+    fn mapping_status_ignores_other_commands() {
+        let mut response = [0; REPORT_SIZE];
+        response[COMMAND_POS] = 0xB2;
+        assert_eq!(mapping_status(&response), None);
+
+        response[COMMAND_POS] = CMD_SET_BUTTON_MAPPING;
+        response[MAP_STATUS_POS] = 0x00;
+        assert_eq!(mapping_status(&response), Some(0));
+    }
+}

--- a/src/drivers/zotac_zone/hid_report_test.rs
+++ b/src/drivers/zotac_zone/hid_report_test.rs
@@ -1,0 +1,52 @@
+use std::error::Error;
+
+use super::hid_report::{
+    calc_crc, ButtonId, ButtonMappingRequest, ButtonMappingResponse, HID_KEY_HOME, REPORT_SIZE,
+};
+
+/// Checksum of a frame captured from a Zotac Zone's command interface:
+/// `e1 00 c5 3c b2 00 .. 00 fc 8d`. The sequence byte varied between captures
+/// while the checksum did not, which is what places the sequence number
+/// outside the checksummed range. The command byte (`0xB2`, an unsolicited
+/// telemetry frame) isn't a [`Command`](super::hid_report::Command) this
+/// module knows how to send, so this frame is built by hand rather than
+/// through [`ButtonMappingRequest`].
+#[tokio::test]
+async fn crc_matches_device_frame() -> Result<(), Box<dyn Error>> {
+    let mut frame = [0u8; REPORT_SIZE + 1];
+    frame[1] = 0xE1; // header tag
+    frame[3] = 0xC5; // sequence
+    frame[4] = 0x3C; // payload size
+    frame[5] = 0xB2; // command
+
+    assert_eq!(calc_crc(&frame), 0xFC8D);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn mapping_command_is_framed_correctly() -> Result<(), Box<dyn Error>> {
+    let report = ButtonMappingRequest::new(ButtonId::M2, HID_KEY_HOME).to_bytes()?;
+
+    assert_eq!(report[0], 0x00, "hidraw report number");
+    assert_eq!(report[1], 0xE1, "header tag");
+    assert_eq!(report[4], 0x3C, "payload size");
+    assert_eq!(report[5], 0xA1, "command");
+    assert_eq!(report[6], ButtonId::M2 as u8, "button id");
+    assert_eq!(report[13], HID_KEY_HOME, "key");
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn mapping_status_ignores_other_commands() -> Result<(), Box<dyn Error>> {
+    let mut response = [0u8; REPORT_SIZE];
+    response[4] = 0xB2; // an unrelated command
+    assert_eq!(ButtonMappingResponse::status(&response), None);
+
+    response[4] = 0xA1; // CMD_SET_BUTTON_MAPPING
+    response[6] = 0x00; // status: accepted
+    assert_eq!(ButtonMappingResponse::status(&response), Some(0));
+
+    Ok(())
+}

--- a/src/drivers/zotac_zone/mod.rs
+++ b/src/drivers/zotac_zone/mod.rs
@@ -1,2 +1,4 @@
 pub mod driver;
 pub mod hid_report;
+#[cfg(test)]
+pub mod hid_report_test;

--- a/src/drivers/zotac_zone/mod.rs
+++ b/src/drivers/zotac_zone/mod.rs
@@ -1,1 +1,2 @@
 pub mod driver;
+pub mod hid_report;


### PR DESCRIPTION
## Problem

On the Zotac Gaming Zone the rear macro buttons (M1/M2) do nothing. They produce no input on any evdev node, and no HID report on any of the device's hidraw interfaces — pressing and holding one for five seconds yields nothing at all.

The cause is in the device rather than in the driver stack. Querying the button mapping table over the vendor config interface shows M1 and M2 with an entirely empty mapping, while ordinary buttons have one:

```
button M1 (0x01):  gamepad=00 00 00 00  mod=00  kbd=00 00 00 00 00 00  mouse=00
button M2 (0x02):  gamepad=00 00 00 00  mod=00  kbd=00 00 00 00 00 00  mouse=00
button A  (0x0F):  gamepad=00 10 00 00  ...
```

With nothing bound, the firmware sends nothing, so no amount of work on the host side can recover these buttons — the mapping has to be written to the device.

That is what the existing code intends to do:

```rust
set_attribute(&mut device, "btn_m2/remap/keyboard", "home");
set_attribute(&mut device, "btn_m1/remap/keyboard", "end");
```

but those sysfs attributes only exist when the out-of-tree `zotac_zone_hid` driver is loaded. On a stock kernel (Bazzite 44 here) that module is absent and all three of the device's HID interfaces bind to `hid-generic`, so the paddles stay permanently silent.

## Change

When the vendor driver isn't loaded, ask the device for the same binding directly, speaking its configuration protocol over hidraw: M2 → Home, M1 → End. The `zone1` capability map already translates those into `LeftPaddle1`/`RightPaddle1`, so no config changes are needed.

`CMD_SAVE_CONFIG` is deliberately not sent. The binding stays volatile and is re-applied on each start, leaving the user's stored device configuration untouched.

This also removes the early `Err` return when the vendor driver is absent. That previously made the whole hidraw source fail to be created, which left no way to configure the device at all — the source has to exist for the commands above to be sent.

## Provenance

The frame layout, CRC and command codes were derived from `driver/hid/zotac-zone-hid-config.c` in [OpenZotacZone/ZotacZone-Drivers](https://github.com/OpenZotacZone/ZotacZone-Drivers) (GPL-2.0-or-later, Copyright (c) 2025 Luke D. Jones), used here under that license's "or later" clause, and verified against live captures from the hardware.

## Testing

Hardware: Zotac Gaming Zone (G0A1W), firmware 1.3.9, Bazzite 44.20260820, no vendor kernel module present.

- Unit tests cover the frame construction and the checksum, the latter against a frame captured from the device (`e1 00 c5 3c b2 … fc 8d`).
- With the paddle mapping cleared beforehand, starting InputPlumber binds both buttons and the device acknowledges each command with a zero status:
  ```
  Zotac Zone config interface is bound to 'hid-generic' rather than the vendor driver; configuring it over hidraw instead.
  Mapped Zotac Zone button 0x02 to key 0x4a
  Mapped Zotac Zone button 0x01 to key 0x4d
  ```
- The paddles then register as paddle buttons in Steam Game Mode, with no regression in the existing buttons (Steam, QAM, View, sticks, face buttons, shoulders, triggers, D-pad).
- `make test` passes.

## Note

This is independent of #664 and applies to `main` on its own; the two touch different files.

## AI disclosure

Per CONTRIBUTING.md: the protocol reverse engineering (hidraw capture and report descriptor analysis), the `hid_report.rs` frame/CRC implementation and its unit tests, and the `driver.rs` sysfs/hidraw fallback were developed with Claude Opus 5 in an interactive session. Prompts were investigative rather than code-generating — the work proceeded by capturing HID traffic under controlled inputs, cross-checking the results against the vendor driver source, and validating the CRC against captured frames before any write to the device. Every line has been reviewed and can be explained.