### PR TITLE
feat(Hardware Support): Add AYN Thor

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-ayn_thor.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_thor.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+# Schema version number
+version: 1
+
+# The type of configuration schema
+kind: CompositeDevice
+
+# Name of the composite device mapping
+name: AYN Thor
+
+# Only use this profile if *any* of the given matches matches. If this list is
+# empty, then the source devices will *always* be checked.
+# /sys/class/dmi/id/product_name
+matches:
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible
+          value: ayn,thor
+
+# Only allow a single source device per composite device of this type.
+single_source: false
+
+# One or more source devices to combine into a single virtual device. The events
+# from these devices will be watched and translated according to the key map.
+source_devices:
+  - group: gamepad
+    evdev:
+      name: AYN Odin2 Gamepad
+      phys_path: rsinput-gamepad/input0
+      handler: event*
+      vendor_id: "2020"
+      product_id: "3001"
+    capability_map_id: ayn2
+
+  - group: gamepad
+    evdev:
+      name: gpio-keys-ayn
+      phys_path: gpio-keys-ayn/input0
+      handler: event*
+    capability_map_id: ayn2
+
+# Optional configuration for the composite device
+options:
+  # If true, InputPlumber will automatically try to manage the input device. If
+  # this is false, InputPlumber will not try to manage the device unless an
+  # external service enables management of the device. Defaults to 'false'
+  auto_manage: true
+
+# The target input device(s) to emulate by default
+target_devices:
+  - xbox-elite


### PR DESCRIPTION
depends on #659 for the capabilitymap

in theory, a lot of ayn/retroid devices can use a single file, currently i have made separate ones for each but this can be refactored if thats preferred