### PR TITLE
feat(Hardware Support): Add AYN Thor and Odin 2 Mini

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/ayn_type2.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ayn_type2.yaml
@@ -1,0 +1,92 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+version: 2
+kind: CapabilityMap
+name: AYN Type 2
+id: ayn2
+
+mapping:
+  - name: D-Pad Up
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_UP
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadUp
+
+  - name: D-Pad Down
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_DOWN
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadDown
+
+  - name: D-Pad Left
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_LEFT
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadLeft
+
+  - name: D-Pad Right
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_RIGHT
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadRight
+
+  - name: Back Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_BACK
+          value_type: button
+    target_event:
+      gamepad:
+        button: QuickAccess
+
+  - name: AYN Key
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: KEY_F24
+          value_type: button
+    target_event:
+      gamepad:
+        button: QuickAccess2
+
+  # Kernel reports NORTH/WEST by physical position, but Xbox layout 
+  # relies on these swapped. This results in NORTH/WEST swapped in
+  # evtest, but produces expected behaviour in games.
+
+  - name: West Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_NORTH
+          value_type: button
+    target_event:
+      gamepad:
+        button: West
+
+  - name: North Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_WEST
+          value_type: button
+    target_event:
+      gamepad:
+        button: North
+
+filtered_events: []

--- a/rootfs/usr/share/inputplumber/capability_maps/ayn_type3.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ayn_type3.yaml
@@ -1,0 +1,82 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+version: 2
+kind: CapabilityMap
+name: AYN Type 3
+id: ayn3
+
+mapping:
+  - name: D-Pad Up
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_UP
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadUp
+
+  - name: D-Pad Down
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_DOWN
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadDown
+
+  - name: D-Pad Left
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_LEFT
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadLeft
+
+  - name: D-Pad Right
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_RIGHT
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadRight
+
+  - name: Back Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_BACK
+          value_type: button
+    target_event:
+      gamepad:
+        button: QuickAccess
+
+  # Kernel reports NORTH/WEST by physical position, but Xbox layout 
+  # relies on these swapped. This results in NORTH/WEST swapped in
+  # evtest, but produces expected behaviour in games.
+
+  - name: West Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_NORTH
+          value_type: button
+    target_event:
+      gamepad:
+        button: West
+
+  - name: North Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_WEST
+          value_type: button
+    target_event:
+      gamepad:
+        button: North
+
+filtered_events: []

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_odin2_mini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_odin2_mini.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: AYN Odin 2 Mini
+
+options:
+  auto_manage: true
+
+matches:
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible
+          value: ayn,odin2mini
+
+source_devices:
+  - group: gamepad
+    capability_map_id: ayn3
+    evdev:
+      name: AYN Odin2 Gamepad
+      phys_path: rsinput-gamepad/input0
+      vendor_id: "2020"
+      product_id: "3001"
+      handler: event*
+
+target_devices:
+  - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-ayn_thor.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_thor.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: AYN Thor
+
+options:
+  auto_manage: true
+
+matches:
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible
+          value: ayn,thor
+
+source_devices:
+  - group: gamepad
+    capability_map_id: ayn2
+    evdev:
+      name: AYN Odin2 Gamepad
+      phys_path: rsinput-gamepad/input0
+      handler: event*
+      vendor_id: "2020"
+      product_id: "3001"
+
+  - group: gamepad
+    capability_map_id: ayn2
+    evdev:
+      name: gpio-keys-ayn
+      phys_path: gpio-keys-ayn/input0
+      handler: event*
+
+target_devices:
+  - xbox-elite


### PR DESCRIPTION
Needs separate compatibility maps from #659 because of no back buttons (paddles) on these models.

The differences from the `rsinput1` map is that the Thor has 1 extra button that can be used for QAM2, and both devices have no back buttons:
- `ayn2` has the AYN key and no back buttons
- `ayn3` has no AYN key and no back buttons