### PR TITLE
feat(Hardware Support): Add RP 5, Mini, Mini V2 and Flip 2

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/retroid_type1.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/retroid_type1.yaml
@@ -1,0 +1,105 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+version: 2
+kind: CapabilityMap
+name: Retroid Type 1
+id: ret1
+
+mapping:
+  - name: D-Pad Up
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_UP
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadUp
+
+  - name: D-Pad Down
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_DOWN
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadDown
+
+  - name: D-Pad Left
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_LEFT
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadLeft
+
+  - name: D-Pad Right
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_RIGHT
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadRight
+
+  - name: Back Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_BACK
+          value_type: button
+    target_event:
+      gamepad:
+        button: QuickAccess
+
+  # Kernel reports NORTH/WEST by physical position, but Xbox layout 
+  # relies on these swapped. This results in NORTH/WEST swapped in
+  # evtest, but produces expected behaviour in games.
+
+  - name: West Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_NORTH
+          value_type: button
+    target_event:
+      gamepad:
+        button: West
+
+  - name: North Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_WEST
+          value_type: button
+    target_event:
+      gamepad:
+        button: North
+
+  - name: Right Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT2Y
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: RightTrigger
+
+  - name: Left Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT2X
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: LeftTrigger
+
+# List of events to filter from the source devices
+filtered_events: []

--- a/rootfs/usr/share/inputplumber/capability_maps/retroid_type2.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/retroid_type2.yaml
@@ -1,0 +1,95 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+version: 2
+kind: CapabilityMap
+name: Retroid Type 2
+id: ret2
+
+mapping:
+  - name: D-Pad Up
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_UP
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadUp
+
+  - name: D-Pad Down
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_DOWN
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadDown
+
+  - name: D-Pad Left
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_LEFT
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadLeft
+
+  - name: D-Pad Right
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_DPAD_RIGHT
+          value_type: button
+    target_event:
+      gamepad:
+        button: DPadRight
+
+  # Kernel reports NORTH/WEST by physical position, but Xbox layout 
+  # relies on these swapped. This results in NORTH/WEST swapped in
+  # evtest, but produces expected behaviour in games.
+
+  - name: West Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_NORTH
+          value_type: button
+    target_event:
+      gamepad:
+        button: West
+
+  - name: North Button
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_WEST
+          value_type: button
+    target_event:
+      gamepad:
+        button: North
+
+  - name: Right Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT2Y
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: RightTrigger
+
+  - name: Left Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_HAT2X
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: LeftTrigger
+
+# List of events to filter from the source devices
+filtered_events: []

--- a/rootfs/usr/share/inputplumber/devices/50-retroid_pocket5.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-retroid_pocket5.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: Retroid Pocket 5
+
+options:
+  auto_manage: true
+
+matches:
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible
+          value: retroidpocket,rp5
+
+source_devices:
+  - group: gamepad
+    capability_map_id: ret1
+    evdev:
+      name: Retroid Pocket Gamepad
+      phys_path: retroid-pocket-gamepad/input0
+      vendor_id: "2020"
+      product_id: "3001"
+      handler: event*
+
+target_devices:
+  - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-retroid_pocket_flip2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-retroid_pocket_flip2.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: Retroid Pocket Flip 2
+
+options:
+  auto_manage: true
+
+matches:
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible
+          value: retroidpocket,rpflip2
+
+source_devices:
+  - group: gamepad
+    capability_map_id: ret2
+    evdev:
+      name: Retroid Pocket Gamepad
+      phys_path: retroid-pocket-gamepad/input0
+      vendor_id: "2020"
+      product_id: "3001"
+      handler: event*
+
+target_devices:
+  - xbox-elite

--- a/rootfs/usr/share/inputplumber/devices/50-retroid_pocket_mini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-retroid_pocket_mini.yaml
@@ -12,6 +12,11 @@ matches:
       attributes:
         - name: compatible
           value: retroidpocket,rpmini
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible
+          value: retroidpocket,rpminiv2
 
 source_devices:
   - group: gamepad

--- a/rootfs/usr/share/inputplumber/devices/50-retroid_pocket_mini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-retroid_pocket_mini.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: Retroid Pocket Mini
+
+options:
+  auto_manage: true
+
+matches:
+  - udev:
+      sys_path: /sys/firmware/devicetree/base
+      attributes:
+        - name: compatible
+          value: retroidpocket,rpmini
+
+source_devices:
+  - group: gamepad
+    capability_map_id: ret1
+    evdev:
+      name: Retroid Pocket Gamepad
+      phys_path: retroid-pocket-gamepad/input0
+      vendor_id: "2020"
+      product_id: "3001"
+      handler: event*
+
+target_devices:
+  - xbox-elite


### PR DESCRIPTION
Adds `ret1` capability map for the RP5, RPMini and RPMiniV2, and `ret2` for the Flip 2, which doesnt have the android back button for QAM