### PR TITLE
fix(Legion Go 1): fix gyro not working on latest controller firmware, enable gyro right handle IMU

### DIFF
--- a/rootfs/usr/lib/udev/rules.d/99-inputplumber-device-setup.rules
+++ b/rootfs/usr/lib/udev/rules.d/99-inputplumber-device-setup.rules
@@ -8,7 +8,7 @@ ACTION=="add|change|bind", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="e31[01]",
 ACTION=="add|change|bind", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="e31[01]", SUBSYSTEM=="hid", DRIVER=="hid-lenovo-go-s", ATTR{gamepad/auto_sleep_time}="0", ATTR{gamepad/dpad_mode}="8-way", ATTR{gamepad/mode}="xinput", ATTR{gamepad/poll_rate}="250", ATTR{os_mode}="linux", ATTR{touchpad/linux_mode}="absolute", GOTO="end"
 
 # Legion Go/Go2 Controller Settings
-ACTION=="add|change|bind", ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="61e[bcde]", SUBSYSTEM=="hid", DRIVER=="hid-lenovo-go", ATTR{os_mode}="linux", ATTR{left_handle/imu_bypass_enable}="true", ATTR{right_handle/imu_bypass_enable}="true", ATTR{touchpad/vibration_enable}="false", GOTO="end"
+ACTION=="add|change|bind", ATTRS{idVendor}=="17ef", ATTRS{idProduct}=="61e[bcde]", SUBSYSTEM=="hid", DRIVER=="hid-lenovo-go", ATTR{os_mode}="linux", ATTR{left_handle/imu_enabled}="true", ATTR{left_handle/imu_bypass_enabled}="true", ATTR{right_handle/imu_enabled}="true", ATTR{right_handle/imu_bypass_enabled}="true", ATTR{touchpad/vibration_enable}="false", GOTO="end"
 
 # ASUS
 # ROG Ally Controller Settings

--- a/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go.yaml
@@ -164,6 +164,9 @@ source_devices:
         x: [0, 1, 0]
         y: [1, 0, 0]
         z: [0, 0, 1]
+    events:
+      exclude:
+        - "Gyroscope:Center"
 
 # Optional configuration for the composite device
 options:

--- a/src/drivers/lego/go2_driver.rs
+++ b/src/drivers/lego/go2_driver.rs
@@ -5,6 +5,7 @@ use hidapi::HidDevice;
 use packed_struct::PackedStruct;
 use tokio::time::Instant;
 
+use crate::dmi::get_dmi_data;
 use crate::input::capability::{Capability, Source};
 use crate::udev::device::UdevDevice;
 
@@ -91,7 +92,16 @@ impl Driver {
             return Ok(HashSet::from(DEFAULT_EVENT_FILTER));
         };
 
+        let is_legion_go_1 = get_dmi_data().product_name == "83E1";
         let filtered_events = match driver {
+            // Updated Go 1 controller firmware uses Go 2-format reports. Use the right handle IMU
+            // so gyro and acceleration continue to work while the controllers are detached.
+            "hid-lenovo-go" if is_legion_go_1 => HashSet::from([
+                Capability::Accelerometer(Source::Left),
+                Capability::Accelerometer(Source::Center),
+                Capability::Gyroscope(Source::Left),
+                Capability::Gyroscope(Source::Center),
+            ]),
             "hid-lenovo-go" => HashSet::from([
                 Capability::Accelerometer(Source::Left),
                 Capability::Accelerometer(Source::Right),


### PR DESCRIPTION
## Summary

Newer Legion Go 1 controller firmware exposes the controllers as hardware generation 2 (`17ef:61eb`), routing their input through the Go 2 driver. On the Legion Go 1 (`83E1`), the handle IMU was disabled or filtered make gyro not working at all, this PR re enable gyro on right controller which will work for both handheld and detached controller mode (Note it is possible to implement the gyro to use middle body gyro, I prefer the right controller)

This change:

- Uses the current `hid-lenovo-go` sysfs attributes.
- Enables IMU and IMU bypass for both handles.
- Keeps the right-handle accelerometer and gyroscope on Legion Go 1 while filtering the left and center controller sensors.
- Excludes the center IIO gyroscope to avoid competing motion streams.

## Testing

Tested on a Legion Go 1 (`83E1`) running SteamOS 3.8.26 with controller PID `17ef:61eb`.

Verified that accelerometer and gyroscope input from the right controller work while detached.