### PR TITLE
feat(input): add AYANEO Pocket S Mini support

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type10.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type10.yaml
@@ -1,0 +1,81 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+version: 2
+kind: CapabilityMap
+name: AYANEO Type 10
+id: aya10
+
+mapping:
+    - name: South Button
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN_EAST
+                value_type: button
+      target_event:
+          gamepad:
+              button: South
+    - name: East Button
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN_SOUTH
+                value_type: button
+      target_event:
+          gamepad:
+              button: East
+    - name: West Button
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN_NORTH
+                value_type: button
+      target_event:
+          gamepad:
+              button: West
+    - name: North Button
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN_WEST
+                value_type: button
+      target_event:
+          gamepad:
+              button: North
+    - name: Left Trigger
+      source_events:
+          - evdev:
+                event_type: ABS
+                event_code: ABS_BRAKE
+                value_type: trigger
+      target_event:
+          gamepad:
+              trigger:
+                  name: LeftTrigger
+    - name: Right Trigger
+      source_events:
+          - evdev:
+                event_type: ABS
+                event_code: ABS_GAS
+                value_type: trigger
+      target_event:
+          gamepad:
+              trigger:
+                  name: RightTrigger
+    - name: AYANEO Button
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: KEY_A
+                value_type: button
+      target_event:
+          gamepad:
+              button: Guide
+    - name: Quick Access Button
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: KEY_EQUAL
+                value_type: button
+      target_event:
+          gamepad:
+              button: QuickAccess

--- a/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type10.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type10.yaml
@@ -5,7 +5,7 @@ name: AYANEO Type 10
 id: aya10
 
 mapping:
-    - name: South Button
+    - name: A Button
       source_events:
           - evdev:
                 event_type: KEY
@@ -14,7 +14,7 @@ mapping:
       target_event:
           gamepad:
               button: South
-    - name: East Button
+    - name: B Button
       source_events:
           - evdev:
                 event_type: KEY
@@ -23,7 +23,7 @@ mapping:
       target_event:
           gamepad:
               button: East
-    - name: West Button
+    - name: X Button
       source_events:
           - evdev:
                 event_type: KEY
@@ -32,7 +32,7 @@ mapping:
       target_event:
           gamepad:
               button: West
-    - name: North Button
+    - name: Y Button
       source_events:
           - evdev:
                 event_type: KEY
@@ -70,7 +70,7 @@ mapping:
       target_event:
           gamepad:
               button: Guide
-    - name: Quick Access Button
+    - name: Home Button
       source_events:
           - evdev:
                 event_type: KEY

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_pocket_s_mini.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_pocket_s_mini.yaml
@@ -1,0 +1,44 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: AYANEO Pocket S Mini
+
+maximum_sources: 0
+options:
+    auto_manage: true
+
+matches:
+    - udev:
+          sys_path: /sys/firmware/devicetree/base
+          attributes:
+              - name: compatible
+                value: ayaneo,pocket-s-mini
+
+source_devices:
+    # AYANEO/DirectInput mode
+    - group: gamepad
+      capability_map_id: aya10
+      evdev:
+          name: AYANEO Controller
+          vendor_id: "4001"
+          product_id: "0428"
+          handler: event*
+    # XInput mode
+    - group: gamepad
+      capability_map_id: aya10
+      evdev:
+          phys_path: usb-0001:01:00.0-1/input0
+          vendor_id: "045e"
+          product_id: "028e"
+          handler: event*
+    # Dedicated AYANEO and quick-access GPIO buttons
+    - group: keyboard
+      capability_map_id: aya10
+      evdev:
+          name: gpio-keys-pocket-s-mini
+          handler: event*
+
+target_devices:
+    - xbox-elite
+    - keyboard
+    - mouse


### PR DESCRIPTION
## Summary

I have an AYANEO Pocket S Mini running ROCKNIX. Device support was merged in ROCKNIX/distribution#3177, but its InputPlumber configuration remained distribution-local.

This PR adds:

- a device profile matched through `ayaneo,pocket-s-mini`
- a dedicated `aya10` capability map
- support for AYANEO/DirectInput `4001:0428` and internal XInput `045e:028e`
- face-button translation matching the Xbox-style prompts used by ROCKNIX
- Guide and Quick Access mappings for the two GPIO system buttons
- an Xbox Elite virtual controller target

The capability map only contains inputs that differ from InputPlumber's default evdev behavior.

## Button mapping

| Physical control | Source event | Virtual output |
| --- | --- | --- |
| A / B / X / Y | `BTN_EAST` / `BTN_SOUTH` / `BTN_NORTH` / `BTN_WEST` | South / East / West / North |
| Start / Select | `BTN_START` / `BTN_SELECT` | Start / Select |
| L1 / R1 | `BTN_TL` / `BTN_TR` | Left / Right bumper |
| L2 / R2 | `ABS_BRAKE/GAS` in AYANEO mode, `ABS_Z/RZ` in XInput mode | Left / Right trigger |
| Left and right sticks | `ABS_X/Y` and `ABS_RX/RY` | Left and right sticks |
| L3 / R3 | `BTN_THUMBL` / `BTN_THUMBR` | Left and right stick click |
| D-pad | `ABS_HAT0X/Y` | D-pad |
| AYANEO button | GPIO `KEY_A` | Guide |
| Home button | GPIO `KEY_EQUAL` | Quick Access |

## Test environment

- Device: AYANEO Pocket S Mini
- Platform: Qualcomm SM8550 / Snapdragon 8 Gen 2
- OS: ROCKNIX
- Architecture: native ARM64
- InputPlumber base: `0.78.1` (`23f84b78521a4e12f2ff7b16fa9e0dc03ccb1846`)

## Validation

- both YAML files validate against the current upstream schemas
- the device-tree compatible string and internal XInput physical path match captured retail-device data
- the equivalent event mappings were verified on a retail Pocket S Mini in both ROCKNIX and Steam
- A/B/X/Y matched the on-screen prompts
- AYANEO and Home buttons worked as Guide and Quick Access
- `git diff --check` passes

## Known limitation

LC and RC remain unmapped because their source events have not been verified.

## Related downstream work

- ROCKNIX/distribution#3177

## AI disclosure

I used OpenAI Codex (GPT-5) to compare the hardware-validated ROCKNIX configuration with current InputPlumber conventions, prepare the initial YAML changes, and run validation. I reviewed the complete final diff against the captured device data and the merged downstream configuration.
