### PR TITLE
feat(input): add KONKR Pocket FIT Elite support

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/konkr_type3.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/konkr_type3.yaml
@@ -1,0 +1,52 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v2.json
+version: 2
+kind: CapabilityMap
+name: KONKR Type 3
+id: konkr3
+
+mapping:
+    - name: Right-side Menu Button
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN_TRIGGER_HAPPY5
+                value_type: button
+      target_event:
+          gamepad:
+              button: QuickAccess
+    - name: Equals Button
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN_TRIGGER_HAPPY2
+                value_type: button
+      target_event:
+          gamepad:
+              button: Keyboard
+    - name: K Button
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN_TRIGGER_HAPPY1
+                value_type: button
+      target_event:
+          gamepad:
+              button: QuickAccess2
+    - name: LC
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN_TRIGGER_HAPPY3
+                value_type: button
+      target_event:
+          gamepad:
+              button: LeftPaddle1
+    - name: RC
+      source_events:
+          - evdev:
+                event_type: KEY
+                event_code: BTN_TRIGGER_HAPPY4
+                value_type: button
+      target_event:
+          gamepad:
+              button: RightPaddle1

--- a/rootfs/usr/share/inputplumber/devices/50-konkr_pocket_fit_elite.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-konkr_pocket_fit_elite.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: KONKR Pocket FIT Elite
+
+maximum_sources: 0
+options:
+    auto_manage: true
+
+matches:
+    - udev:
+          sys_path: /sys/firmware/devicetree/base
+          attributes:
+              - name: compatible
+                value: konkr,pocket-fit-elite
+
+source_devices:
+    - group: gamepad
+      evdev:
+          name: AYANEO MCU Gamepad
+          handler: event*
+    - group: keyboard
+      capability_map_id: konkr3
+      evdev:
+          name: KONKR System Buttons
+          handler: event*
+
+target_devices:
+    - xbox-elite
+    - keyboard
+    - mouse


### PR DESCRIPTION
## Summary

I have a KONKR Pocket FIT Elite running native ARM64 Linux on the Qualcomm SM8750 platform. Its main controller already reports a standard evdev gamepad, while five dedicated controls are exposed through a separate `KONKR System Buttons` input device.

This PR adds:

- a device profile matched through `konkr,pocket-fit-elite`
- a dedicated capability map for the five system buttons
- the Xbox Elite target used by the existing KONKR Pocket FIT profile
- standard KONKR/AYANEO physical control names consistent with #670

I intentionally left the standard main-gamepad events out of the capability map because InputPlumber's built-in evdev translation already handles them correctly.

## Button mapping

| Physical control | Source event | InputPlumber output |
| --- | --- | --- |
| A / B / X / Y | `BTN_SOUTH` / `BTN_EAST` / `BTN_NORTH` / `BTN_WEST` | South / East / North / West |
| Start / Select | `BTN_START` / `BTN_SELECT` | Start / Select |
| L1 / R1 | `BTN_TL` / `BTN_TR` | Left / Right bumper |
| L2 / R2 | `ABS_Z` / `ABS_RZ` | Left / Right trigger |
| Left and right sticks | `ABS_X/Y` / `ABS_RX/RY` | Left and right sticks |
| L3 / R3 | `BTN_THUMBL` / `BTN_THUMBR` | Left and right stick click |
| D-pad | `ABS_HAT0X/Y` | D-pad |
| Navigation / Steam / Xbox Guide button | `BTN_MODE` | Guide |
| Right-side Menu Button | `BTN_TRIGGER_HAPPY5` | QuickAccess |
| Equals Button | `BTN_TRIGGER_HAPPY2` | Keyboard |
| K Button | `BTN_TRIGGER_HAPPY1` | QuickAccess2 |
| LC | `BTN_TRIGGER_HAPPY3` | LeftPaddle1 |
| RC | `BTN_TRIGGER_HAPPY4` | RightPaddle1 |

The default profile converts `Keyboard` to Guide + North and `QuickAccess2` to Screenshot, matching the naming and behavior established during review of #670.

## LC1 / RC1 limitation

I intentionally did not add LC1 and RC1 as independent paddles. The vendor Android configuration only exposes target values `0` through `24` for these two controls, and those values duplicate existing controller functions. For example, assigning LC1 to A and RC1 to B only makes them emit the same A/B events.

I also tested values `25` and `26`. The MCU accepted and read back both values, but pressing LC1/RC1 produced no evdev event and no changing SPI state during 5,306 high-rate samples. Independent LC1/RC1 support therefore needs a vendor firmware/protocol output that Linux can observe; mapping a duplicate standard button here would not provide real additional controls.

## Test environment

- Device: KONKR Pocket FIT Elite
- Platform: Qualcomm SM8750 / Snapdragon 8 Elite
- Architecture: native ARM64
- Device-tree compatible: `konkr,pocket-fit-elite`
- Main input: `AYANEO MCU Gamepad`
- Auxiliary input: `KONKR System Buttons`
- InputPlumber base: `0.78.1` (`23f84b78521a4e12f2ff7b16fa9e0dc03ccb1846`)

## Validation

- all controls listed in the mapping table were verified on the physical device
- `git diff --check` passed
- `cargo clippy --all -- -D warnings` passed in the project's Docker build environment
- InputPlumber unit tests: 10 passed, 0 failed
- InputPlumber documentation tests: 4 passed, 0 failed
- autostart configuration validation: 0 errors

## Related work

- #670

## AI disclosure

I used OpenAI Codex (GPT-5) to prepare the YAML configuration and run validation. I reviewed the generated configuration and validated the supported controls on the physical device.
