### PR TITLE
fix(Hardware Support): Fix SuiPlay 0X1 system buttons

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_2s.yaml
@@ -24,9 +24,6 @@ matches:
   - dmi_data:
       product_name: AYANEO GEEK 1S
       sys_vendor: AYANEO
-  - dmi_data:
-      product_name: SuiPlay0X1
-      sys_vendor: Mysten Labs, Inc.
 
 # One or more source devices to combine into a single virtual device. The events
 # from these devices will be watched and translated according to the key map.

--- a/rootfs/usr/share/inputplumber/devices/50-suiplay_0x1.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-suiplay_0x1.yaml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: SuiPlay 0X1
+single_source: false
+
+matches:
+  - dmi_data:
+      product_name: SuiPlay0X1
+      sys_vendor: Mysten Labs, Inc.
+
+source_devices:
+  - group: gamepad
+    evdev:
+      name: Nintendo Co., Ltd. Pro Controller
+      phys_path: usb-0000:c4:00.3-4/input0
+      handler: event*
+  - group: gamepad
+    evdev:
+      name: Microsoft X-Box 360 pad
+      phys_path: usb-0000:c4:00.3-4/input0
+      handler: event*
+  - group: keyboard
+    evdev:
+      name: AT Translated Set 2 keyboard
+      phys_path: isa0060/serio0/input0
+      handler: event*
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyF21
+        - Keyboard:KeyF22
+        - Keyboard:KeyF23
+        - Keyboard:KeyF24
+        - Keyboard:KeyVolumeDown
+        - Keyboard:KeyVolumeUp
+  - group: imu
+    iio:
+      name: "{i2c-BMI0160:00,bmi260}"
+      mount_matrix:
+        x: [0, -1, 0]
+        y: [-1, 0, 0]
+        z: [0, 0, -1]
+  - group: led
+    udev: # Legacy
+      sys_name: multicolor:chassis
+      subsystem: leds
+  - group: led
+    udev: # Updated
+      sys_name: ayaneo:rgb:joystick_rings
+      subsystem: leds
+
+options:
+  auto_manage: true
+
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+
+# SuiPlay uses the same unmodified F21-F24 buttons as AYANEO Type 7.
+capability_map_id: aya7


### PR DESCRIPTION
## Problem

On a SuiPlay 0X1 running Bazzite 44 with `inputplumber-0.78.0-5.fc44.x86_64`, the two system buttons and LC/RC do not work with the stock configuration.

The SuiPlay match added in #617 selects `AYANEO 2S`, whose keyboard allowlist and `aya4` capability map expect F15-F18 and modifier chords. The tested device instead emits unmodified F21-F24 from `AT Translated Set 2 keyboard`:

| Physical button | evtest key | Scan code | Capability |
| --- | --- | --- | --- |
| Large system button | `KEY_F23` (193) | `6e` | `Guide` |
| Small system button | `KEY_F24` (194) | `76` | `QuickAccess` |
| LC | `KEY_F21` (191) | `6c` | `LeftTop` |
| RC | `KEY_F22` (192) | `6d` | `RightTop` |

All four produced press and release events without Ctrl/Meta modifiers. These events are currently excluded by the AYANEO 2S allowlist.

## Change

- Give `SuiPlay0X1` / `Mysten Labs, Inc.` its own `SuiPlay 0X1` composite configuration and remove its match from the AYANEO 2S configuration.
- Allow F21-F24 and preserve the volume keys.
- Reuse the existing `aya7` capability map, which already provides exactly these four mappings; no duplicate map is needed.
- Preserve the inherited source-device definitions, automatic management, and `xbox-elite`, `mouse`, and `keyboard` targets. The existing SuiPlay autostart hwdb entry remains valid. Other AYANEO configurations are unchanged.

## Testing

Hardware checks were performed using local `/etc/inputplumber` overrides on the device above:

- Captured the key codes with InputPlumber stopped and `evtest` running.
- After restarting InputPlumber, the composite is `SuiPlay 0X1` with the Xbox 360 pad and AT keyboard as sources.
- The large button opens Steam's main menu; the small button opens Quick Access.
- Steam's controller test reports LC/RC as P1/P2. It reports Quick Access as Guide+A, as expected for the Xbox Elite target.

The hardware-tested override used a separate capability-map ID. Local structural checks confirm that this PR's device configuration is identical after substituting `aya7`, and that `aya7` has the same source/target mappings as the tested map (ignoring display names and entry order).

Additional local checks passed: JSON Schema validation of both device configurations and the reused capability map; unchanged AYANEO settings apart from removing the SuiPlay match; unique exact SuiPlay DMI entry; existing autostart rule; default paddle mappings; `git diff --check`.

`cargo fmt` was run; unrelated Rust formatting changes were excluded from this YAML-only PR. The full Linux build/test suite was not run locally. IMU, RGB, the alternate Nintendo controller mode, and reboot behavior were not hardware-tested as part of this fix.

## AI disclosure

OpenAI Codex assisted with source inspection, preparing the two YAML changes, local validation, and drafting the commit and PR. The task was to upstream a working SuiPlay button fix from Bazzite, using the owner's on-device event captures and test results and following the repository's contribution rules. The change was checked against the existing profiles and the hardware-tested overrides; no runtime driver code was generated.
