### PR TITLE
feat(Hardware Support): Add AYANEO NEXT 2 device and capability map config

### DIFF
--- a/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
+++ b/rootfs/usr/lib/udev/hwdb.d/60-inputplumber-autostart.hwdb
@@ -51,6 +51,8 @@ dmi:*svnAYANEO:pnNEXT:*
 dmi:*svnAYANEO:pnNEXTAdvance:*
 dmi:*svnAYANEO:pnNEXTLite:*
 dmi:*svnAYANEO:pnNEXTPro:*
+# AYANEO Next 2
+dmi:*svnAYA:pnAB09:*
 # AYANEO Slide
 dmi:*svnAYANEO:pnSLIDE:*
 # AYN Loki

--- a/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type10.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type10.yaml
@@ -1,0 +1,60 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/capability_map_v1.json
+version: 1
+kind: CapabilityMap
+name: AYANEO Type 10
+id: aya10
+
+mapping:
+  # This device has 4 paddles and a dedicated QAM 2 button,
+  # so LC/RC events will get swallowed if we use the normal
+  # LeftTop/RightTop.
+  - name: LC
+    source_events:
+      - keyboard: KeyF21
+    target_event:
+      gamepad:
+        button: LeftStickTouch
+  - name: RC
+    source_events:
+      - keyboard: KeyF22
+    target_event:
+      gamepad:
+        button: RightStickTouch
+  - name: LC1
+    source_events:
+      - keyboard: KeyF19
+    target_event:
+      gamepad:
+        button: LeftPaddle1
+  - name: LC2
+    source_events:
+      - keyboard: KeyF17
+    target_event:
+      gamepad:
+        button: LeftPaddle2
+  - name: RC1
+    source_events:
+      - keyboard: KeyF20
+    target_event:
+      gamepad:
+        button: RightPaddle1
+  - name: RC2
+    source_events:
+      - keyboard: KeyF18
+    target_event:
+      gamepad:
+        button: RightPaddle2
+  - name: Ayaneo Button
+    source_events:
+      - keyboard: KeyF23
+    target_event:
+      gamepad:
+        button: QuickAccess
+  - name: T Button
+    source_events:
+      - keyboard: KeyF16
+    target_event:
+      gamepad:
+        button: QuickAccess2
+
+filtered_events: []

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_next2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_next2.yaml
@@ -1,0 +1,66 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/ShadowBlip/InputPlumber/main/rootfs/usr/share/inputplumber/schema/composite_device_v1.json
+version: 1
+kind: CompositeDevice
+name: AYANEO NEXT 2
+
+single_source: false
+
+matches:
+  - dmi_data:
+      product_name: AB09
+      sys_vendor: AYA
+
+source_devices:
+  # XInput mode
+  - group: gamepad
+    unique: false
+    evdev:
+      name: Microsoft X-Box 360 pad
+      phys_path: usb-0000:c6:00.0-4/input0
+      handler: event*
+
+  # AYANEO special/back buttons
+  - group: keyboard
+    unique: false
+    evdev:
+      name: AYANEO COMPOSITE DEVICE
+      phys_path: usb-0000:c6:00.0-1/input1
+      handler: event*
+    events:
+      exclude:
+        - "*"
+      include:
+        - Keyboard:KeyF16
+        - Keyboard:KeyF17
+        - Keyboard:KeyF18
+        - Keyboard:KeyF19
+        - Keyboard:KeyF20
+        - Keyboard:KeyF21
+        - Keyboard:KeyF22
+        - Keyboard:KeyF23
+        - Keyboard:KeyLeftMeta
+
+  # IMU
+  - group: imu
+    iio:
+      name: bmi323-imu
+      mount_matrix:
+        x: [0, 1, 0]
+        y: [-1, 0, 0]
+        z: [0, 0, 1]
+
+  # RGB
+  - group: led
+    udev:
+      sys_name: "*:rgb:joystick_rings"
+      subsystem: leds
+
+options:
+  auto_manage: true
+
+target_devices:
+  - xbox-elite
+  - mouse
+  - keyboard
+
+capability_map_id: aya10


### PR DESCRIPTION
Original Author: Gregory Moore <greg@sysadmin.network>
(cherry picked from commit a414f15dcdef9378ab205cff67299f6f499572a1)

Modifications from original:
- Add dinput mode support
- Add IMU mount matrix
- Use Left/RightStickTouch for LC/RC so events are unique with default profile
- Add Next 2 to autostart rules
Signed-off-by: Derek J. Clark <derekjohn.clark@gmail.com>

Replaces #658 
Closes #654 