### PR TITLE
fix(Target): Allow missed events under 1 frame

### DIFF
--- a/src/input/event/native.rs
+++ b/src/input/event/native.rs
@@ -186,6 +186,7 @@ impl ScheduledNativeEvent {
 
     /// Create a new scheduled event with the given timestamp and wait time before
     /// being emitted
+    #[allow(unused)]
     pub fn new_with_time(event: NativeEvent, timestamp: Instant, wait_time: Duration) -> Self {
         Self {
             event,
@@ -200,6 +201,7 @@ impl ScheduledNativeEvent {
     }
 
     /// Returns the capability that the scheduled event implements
+    #[allow(unused)]
     pub fn as_capability(&self) -> Capability {
         self.event.capability.clone()
     }

--- a/src/input/target/dualsense.rs
+++ b/src/input/target/dualsense.rs
@@ -114,6 +114,10 @@ impl Default for DualSenseHardware {
     }
 }
 
+// The minimum interval between button events must wait between
+// each other for chords.
+const MIN_CHORD_TIME: Duration = Duration::from_millis(80);
+
 /// The [DualSenseDevice] is a target input device implementation that emulates
 /// a Playstation DualSense controller using uhid.
 pub struct DualSenseDevice {
@@ -199,7 +203,7 @@ impl DualSenseDevice {
 
     /// Write the current device state to the device
     fn write_state(&mut self) -> Result<(), Box<dyn Error>> {
-        // No consumer so don't bother emitting. 
+        // No consumer so don't bother emitting.
         if !self.is_open {
             return Ok(());
         }
@@ -930,8 +934,9 @@ impl DualSenseDevice {
 impl TargetInputDevice for DualSenseDevice {
     fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
         log::trace!("Received event: {event:?}");
-        // Check for QuickAccess, create chord for event.
         let cap = event.as_capability();
+        // Check for QuickAccess, create chord for event.
+        // TODO: Remove this once we add target device profiles
         if cap == Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)) {
             let pressed = event.pressed();
             let guide = NativeEvent::new(
@@ -945,11 +950,11 @@ impl TargetInputDevice for DualSenseDevice {
 
             let (guide, south) = if pressed {
                 let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
+                let south = ScheduledNativeEvent::new(south, MIN_CHORD_TIME);
                 (guide, south)
             } else {
-                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(240));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
+                let guide = ScheduledNativeEvent::new(guide, MIN_CHORD_TIME * 3);
+                let south = ScheduledNativeEvent::new(south, MIN_CHORD_TIME * 2);
                 (guide, south)
             };
 

--- a/src/input/target/horipad_steam.rs
+++ b/src/input/target/horipad_steam.rs
@@ -25,6 +25,10 @@ use crate::{
 
 use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
 
+// The minimum interval between button events must wait between
+// each other for chords.
+const MIN_CHORD_TIME: Duration = Duration::from_millis(80);
+
 /// The [HoripadSteamDevice] is a target input device implementation that emulates
 /// a Horipad Steam Controller using uhid.
 pub struct HoripadSteamDevice {
@@ -128,10 +132,13 @@ impl HoripadSteamDevice {
                             InputValue::Float(trigger_value),
                         );
 
-                        let (guide, trigger) = {
+                        let (guide, trigger) = if pressed {
                             let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
-                            let trigger =
-                                ScheduledNativeEvent::new(trigger, Duration::from_millis(8));
+                            let trigger = ScheduledNativeEvent::new(trigger, MIN_CHORD_TIME);
+                            (guide, trigger)
+                        } else {
+                            let guide = ScheduledNativeEvent::new(guide, MIN_CHORD_TIME * 3);
+                            let trigger = ScheduledNativeEvent::new(trigger, MIN_CHORD_TIME * 2);
                             (guide, trigger)
                         };
 

--- a/src/input/target/steam_deck.rs
+++ b/src/input/target/steam_deck.rs
@@ -4,11 +4,10 @@ use packed_struct::{
 };
 use std::{
     cmp::Ordering,
-    collections::HashMap,
     error::Error,
     fmt::Debug,
     sync::mpsc::{channel, Receiver, TryRecvError},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use virtual_usb::{
@@ -67,9 +66,9 @@ impl Default for SteamDeckConfig {
     }
 }
 
-// The minimum amount of time that button up events must wait after
-// a button down event.
-const MIN_FRAME_TIME: Duration = Duration::from_millis(8);
+// The minimum interval between button events must wait between
+// each other for chords.
+const MIN_CHORD_TIME: Duration = Duration::from_millis(80);
 
 pub struct SteamDeckDevice {
     chip_id: [u8; 15],
@@ -81,7 +80,6 @@ pub struct SteamDeckDevice {
     device: Option<VirtualUSBDevice>,
     lizard_mode_enabled: bool,
     output_event: Option<OutputEvent>,
-    pressed_events: HashMap<Capability, Instant>,
     queued_events: Vec<ScheduledNativeEvent>,
     serial_number: String,
     state: PackedInputDataReport,
@@ -108,7 +106,6 @@ impl SteamDeckDevice {
             device: None,
             lizard_mode_enabled: false,
             output_event: None,
-            pressed_events: HashMap::new(),
             queued_events: vec![],
             serial_number: "1NPU7PLUMB3R".to_string(),
             state: PackedInputDataReport::default(),
@@ -547,6 +544,7 @@ impl SteamDeckDevice {
                     GamepadButton::RightStickTouch => self.state.r_stick_touch = event.pressed(),
                     // TODO: Remove this once we add target device profiles
                     GamepadButton::Screenshot => {
+                        let pressed = event.pressed();
                         let guide = NativeEvent::new(
                             Capability::Gamepad(Gamepad::Button(GamepadButton::Guide)),
                             event.get_value(),
@@ -556,10 +554,13 @@ impl SteamDeckDevice {
                             event.get_value(),
                         );
 
-                        let (guide, bumper) = {
+                        let (guide, bumper) = if pressed {
                             let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
-                            let bumper =
-                                ScheduledNativeEvent::new(bumper, Duration::from_millis(1));
+                            let bumper = ScheduledNativeEvent::new(bumper, MIN_CHORD_TIME);
+                            (guide, bumper)
+                        } else {
+                            let guide = ScheduledNativeEvent::new(guide, MIN_CHORD_TIME * 3);
+                            let bumper = ScheduledNativeEvent::new(bumper, MIN_CHORD_TIME * 2);
                             (guide, bumper)
                         };
 
@@ -821,53 +822,9 @@ impl TargetInputDevice for SteamDeckDevice {
         Ok(())
     }
 
+    /// Update device state with input events
     fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
         log::trace!("Received event: {event:?}");
-
-        // Check to see if this is a button event
-        // In some cases, a button down and button up event can happen within
-        // the same "frame", which would result in no net state change. This
-        // allows us to process up events at a later time.
-        let cap = event.as_capability();
-        if let Capability::Gamepad(Gamepad::Button(_)) = cap {
-            if event.pressed() {
-                log::trace!("Button down: {cap:?}");
-                // Keep track of button down events
-                self.pressed_events.insert(cap.clone(), Instant::now());
-                // Clear any stale up events for this capability
-                self.queued_events.retain(|scheduled| {
-                    let found = scheduled.as_capability() == cap;
-                    if found {
-                        log::trace!("Found stale queued release for {cap:?}, Clearing.");
-                    }
-                    !found
-                });
-            } else {
-                log::trace!("Button up: {cap:?}");
-                // If the event is a button up event, check to
-                // see if we received a down event in the same
-                // frame.
-                if let Some(last_pressed) = self.pressed_events.get(&cap) {
-                    log::trace!("Button was pressed {:?} ago", last_pressed.elapsed());
-                    if last_pressed.elapsed() < MIN_FRAME_TIME {
-                        log::trace!("Button up & down event received in the same frame. Queueing event for the next frame.");
-                        let scheduled_event = ScheduledNativeEvent::new_with_time(
-                            event,
-                            *last_pressed,
-                            MIN_FRAME_TIME,
-                        );
-                        self.queued_events.push(scheduled_event);
-                        return Ok(());
-                    } else {
-                        log::trace!("Removing button from pressed");
-                        // Button up event should be processed now
-                        self.pressed_events.remove(&cap);
-                    }
-                }
-            }
-        }
-
-        // Update device state with input events
         self.update_state(event);
 
         Ok(())
@@ -1048,7 +1005,6 @@ impl Debug for SteamDeckDevice {
             .field("lizard_mode_enabled", &self.lizard_mode_enabled)
             .field("serial_number", &self.serial_number)
             .field("queued_events", &self.queued_events)
-            .field("pressed_events", &self.pressed_events)
             .finish()
     }
 }

--- a/src/input/target/steam_deck_uhid.rs
+++ b/src/input/target/steam_deck_uhid.rs
@@ -1,11 +1,10 @@
 use std::{
     cmp::Ordering,
-    collections::HashMap,
     error::Error,
     fmt::Debug,
     fs::File,
     sync::mpsc::{channel, Receiver, TryRecvError},
-    time::{Duration, Instant},
+    time::Duration,
 };
 
 use packed_struct::{
@@ -45,9 +44,9 @@ use super::{
     InputError, OutputError, TargetInputDevice, TargetOutputDevice,
 };
 
-// The minimum amount of time that button up events must wait after
-// a button down event.
-const MIN_FRAME_TIME: Duration = Duration::from_millis(8);
+// The minimum interval between button events must wait between
+// each other for chords.
+const MIN_CHORD_TIME: Duration = Duration::from_millis(80);
 
 pub struct SteamDeckUhidDevice {
     chip_id: [u8; 15],
@@ -58,7 +57,6 @@ pub struct SteamDeckUhidDevice {
     current_report: ReportType,
     device: Option<UHIDDevice<File>>,
     lizard_mode_enabled: bool,
-    pressed_events: HashMap<Capability, Instant>,
     queued_events: Vec<ScheduledNativeEvent>,
     serial_number: String,
     state: PackedInputDataReport,
@@ -78,7 +76,6 @@ impl SteamDeckUhidDevice {
             current_report: ReportType::InputData,
             device: None,
             lizard_mode_enabled: false,
-            pressed_events: HashMap::new(),
             queued_events: vec![],
             serial_number: "1NPU7PLUMB3R".to_string(),
             state: PackedInputDataReport::default(),
@@ -152,6 +149,7 @@ impl SteamDeckUhidDevice {
                     GamepadButton::RightStickTouch => self.state.r_stick_touch = event.pressed(),
                     // TODO: Remove this once we add target device profiles
                     GamepadButton::Screenshot => {
+                        let pressed = event.pressed();
                         let guide = NativeEvent::new(
                             Capability::Gamepad(Gamepad::Button(GamepadButton::Guide)),
                             event.get_value(),
@@ -161,10 +159,13 @@ impl SteamDeckUhidDevice {
                             event.get_value(),
                         );
 
-                        let (guide, bumper) = {
+                        let (guide, bumper) = if pressed {
                             let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
-                            let bumper =
-                                ScheduledNativeEvent::new(bumper, Duration::from_millis(8));
+                            let bumper = ScheduledNativeEvent::new(bumper, MIN_CHORD_TIME);
+                            (guide, bumper)
+                        } else {
+                            let guide = ScheduledNativeEvent::new(guide, MIN_CHORD_TIME * 3);
+                            let bumper = ScheduledNativeEvent::new(bumper, MIN_CHORD_TIME * 2);
                             (guide, bumper)
                         };
 
@@ -720,53 +721,10 @@ impl TargetInputDevice for SteamDeckUhidDevice {
         Ok(())
     }
 
+    /// Update device state with input events
+    /// Update device state with input events
     fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
         log::trace!("Received event: {event:?}");
-
-        // Check to see if this is a button event
-        // In some cases, a button down and button up event can happen within
-        // the same "frame", which would result in no net state change. This
-        // allows us to process up events at a later time.
-        let cap = event.as_capability();
-        if let Capability::Gamepad(Gamepad::Button(_)) = cap {
-            if event.pressed() {
-                log::trace!("Button down: {cap:?}");
-                // Keep track of button down events
-                self.pressed_events.insert(cap.clone(), Instant::now());
-                // Clear any stale up events for this capability
-                self.queued_events.retain(|scheduled| {
-                    let found = scheduled.as_capability() == cap;
-                    if found {
-                        log::trace!("Found stale queued release for {cap:?}, Clearing.");
-                    }
-                    !found
-                });
-            } else {
-                log::trace!("Button up: {cap:?}");
-                // If the event is a button up event, check to
-                // see if we received a down event in the same
-                // frame.
-                if let Some(last_pressed) = self.pressed_events.get(&cap) {
-                    log::trace!("Button was pressed {:?} ago", last_pressed.elapsed());
-                    if last_pressed.elapsed() < MIN_FRAME_TIME {
-                        log::trace!("Button up & down event received in the same frame. Queueing event for the next frame.");
-                        let scheduled_event = ScheduledNativeEvent::new_with_time(
-                            event,
-                            *last_pressed,
-                            MIN_FRAME_TIME,
-                        );
-                        self.queued_events.push(scheduled_event);
-                        return Ok(());
-                    } else {
-                        log::trace!("Removing button from pressed");
-                        // Button up event should be processed now
-                        self.pressed_events.remove(&cap);
-                    }
-                }
-            }
-        }
-
-        // Update device state with input events
         self.update_state(event);
 
         Ok(())
@@ -998,7 +956,6 @@ impl Debug for SteamDeckUhidDevice {
             .field("lizard_mode_enabled", &self.lizard_mode_enabled)
             .field("serial_number", &self.serial_number)
             .field("queued_events", &self.queued_events)
-            .field("pressed_events", &self.pressed_events)
             .finish()
     }
 }

--- a/src/input/target/ulitmate_2.rs
+++ b/src/input/target/ulitmate_2.rs
@@ -33,6 +33,10 @@ use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
 
 const GRAVITY: f64 = 9.80665;
 
+// The minimum interval between button events must wait between
+// each other for chords.
+const MIN_CHORD_TIME: Duration = Duration::from_millis(80);
+
 pub struct Ultimate2WirelessDevice {
     device: UHIDDevice<File>,
     state: PackedInputDataReport,
@@ -274,11 +278,11 @@ impl TargetInputDevice for Ultimate2WirelessDevice {
     fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
         log::trace!("Received event: {event:?}");
 
-        // QuickAccess maps to Guide+South combo (press: Guide@0ms South@160ms,
-        // release: South@160ms Guide@240ms), same timing as xpad target.
-        if event.as_capability() == Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess))
-        {
-            let pressed = event.pressed();
+        let cap = event.as_capability();
+        let pressed = event.pressed();
+
+        // TODO: Remove once we implement target device profiles
+        if cap == Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)) {
             let guide = NativeEvent::new(
                 Capability::Gamepad(Gamepad::Button(GamepadButton::Guide)),
                 event.get_value(),
@@ -287,17 +291,17 @@ impl TargetInputDevice for Ultimate2WirelessDevice {
                 Capability::Gamepad(Gamepad::Button(GamepadButton::South)),
                 event.get_value(),
             );
+
             let (guide, south) = if pressed {
-                (
-                    ScheduledNativeEvent::new(guide, Duration::from_millis(0)),
-                    ScheduledNativeEvent::new(south, Duration::from_millis(160)),
-                )
+                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
+                let south = ScheduledNativeEvent::new(south, MIN_CHORD_TIME);
+                (guide, south)
             } else {
-                (
-                    ScheduledNativeEvent::new(guide, Duration::from_millis(240)),
-                    ScheduledNativeEvent::new(south, Duration::from_millis(160)),
-                )
+                let guide = ScheduledNativeEvent::new(guide, MIN_CHORD_TIME * 3);
+                let south = ScheduledNativeEvent::new(south, MIN_CHORD_TIME * 2);
+                (guide, south)
             };
+
             self.queued_events.push(guide);
             self.queued_events.push(south);
             return Ok(());
@@ -315,12 +319,17 @@ impl TargetInputDevice for Ultimate2WirelessDevice {
                 Capability::Gamepad(Gamepad::Trigger(GamepadTrigger::RightTrigger)),
                 InputValue::Float(trigger_value),
             );
-            let (guide, trigger) = {
-                (
-                    ScheduledNativeEvent::new(guide, Duration::from_millis(0)),
-                    ScheduledNativeEvent::new(trigger, Duration::from_millis(1)),
-                )
+
+            let (guide, trigger) = if pressed {
+                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
+                let trigger = ScheduledNativeEvent::new(trigger, MIN_CHORD_TIME);
+                (guide, trigger)
+            } else {
+                let guide = ScheduledNativeEvent::new(guide, MIN_CHORD_TIME * 3);
+                let trigger = ScheduledNativeEvent::new(trigger, MIN_CHORD_TIME * 2);
+                (guide, trigger)
             };
+
             self.queued_events.push(guide);
             self.queued_events.push(trigger);
             return Ok(());

--- a/src/input/target/xpad.rs
+++ b/src/input/target/xpad.rs
@@ -1,6 +1,4 @@
-use std::os::fd::AsFd;
-use std::time::Duration;
-use std::{collections::HashMap, error::Error};
+use std::{collections::HashMap, error::Error, os::fd::AsFd, time::Duration};
 
 use evdev::{
     uinput::{VirtualDevice, VirtualDeviceBuilder},
@@ -21,6 +19,10 @@ use crate::input::output_capability::OutputCapability;
 use crate::input::output_event::{OutputEvent, UinputOutputEvent};
 
 use super::{InputError, OutputError, TargetInputDevice, TargetOutputDevice};
+
+// The minimum interval between button events must wait between
+// each other for chords.
+const MIN_CHORD_TIME: Duration = Duration::from_millis(80);
 
 #[derive(Debug)]
 pub struct XBoxController {
@@ -235,9 +237,10 @@ impl TargetInputDevice for XBoxController {
     fn write_event(&mut self, event: NativeEvent) -> Result<(), InputError> {
         log::trace!("Received event: {event:?}");
 
+        let cap = event.as_capability();
+
         //TODO: Remove these once we add target device profiles
         // Check for QuickAccess
-        let cap = event.as_capability();
         if cap == Capability::Gamepad(Gamepad::Button(GamepadButton::QuickAccess)) {
             let pressed = event.pressed();
             let guide = NativeEvent::new(
@@ -251,11 +254,11 @@ impl TargetInputDevice for XBoxController {
 
             let (guide, south) = if pressed {
                 let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(0));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
+                let south = ScheduledNativeEvent::new(south, MIN_CHORD_TIME);
                 (guide, south)
             } else {
-                let guide = ScheduledNativeEvent::new(guide, Duration::from_millis(240));
-                let south = ScheduledNativeEvent::new(south, Duration::from_millis(160));
+                let guide = ScheduledNativeEvent::new(guide, MIN_CHORD_TIME * 3);
+                let south = ScheduledNativeEvent::new(south, MIN_CHORD_TIME * 2);
                 (guide, south)
             };
 


### PR DESCRIPTION
Currently the vhci and uhid deck targets attempt to ensure that no events that have an up and down event in under 1 frame are missed. It does this by rescheduling events for the next frame. If another down event happens before that scheduled event fires the up event is canceled to prevent the button from turning off. Not doing so causes lost input, and was added in #650 to address that issue. Unfortunately this delay is too short for 'on-release' events to trigger gamepad macros that userspace (i.e. Steam) can see, so QuickAccess and Screenshot type events are currently broken as reported in #657. Adding back the appropriate delay causes the up events to get canceled and the virtual button to be held until the matching physical button is pressed and released.

To resolve this issue, permit the rare 1 frame event drops and return the delays back to the working values.

Closes #657
Replaces #661