### PR TITLE
fix(Hardware Support): Prevent Legion Go 2 from dropping CompositeDevice on suspend

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-legion_go_2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-legion_go_2.yaml
@@ -114,6 +114,15 @@ source_devices:
       product_id: 0x61ee
       interface_num: 2
 
+  # IMU
+  - group: imu
+    blocked: true
+    iio:
+      name: gyro_3d
+  - group: imu
+    blocked: true
+    iio:
+      name: accel_3d
 # Optional configuration for the composite device
 options:
   # If true, InputPlumber will automatically try to manage the input device. If


### PR DESCRIPTION
The controller device is re-enumerated on resume, dropping all source devices and detaching the CompositeDevice. Many games stop responding to input if the controller is detached. The accel_gyro_3d device remains after resume but produces events that coflict with the built-in controller's gyro.

Add the gyro_3d and accel_3d sources back in a blocked state so they don't produce events but keep the ComposteDevice alive during resume.