### PR TITLE
feat(Hardware Support): Add AYANEO Pocket DS

### DIFF
--- a/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type10.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type10.yaml
@@ -1,0 +1,122 @@
+version: 2
+kind: CapabilityMap
+name: AYANEO Type 10
+id: aya10
+
+mapping:
+  - name: LC
+    source_events:
+      - evdev:
+            event_type: KEY
+            event_code: BTN3
+            value_type: button
+    target_event:
+      gamepad:
+        button: LeftPaddle1
+
+  - name: RC
+    source_events:
+      - evdev:
+            event_type: KEY
+            event_code: BTN4
+            value_type: button
+    target_event:
+      gamepad:
+        button: RightPaddle1
+
+  - name: Start Button to Guide
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_START
+          value_type: button
+    target_event:
+      gamepad:
+        button: Guide
+
+  - name: Share looking icon to LeftPaddle2
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN2
+          value_type: button
+    target_event:
+      gamepad:
+        button: LeftPaddle2
+
+  - name: 3 dots to RightPaddle2
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_MODE
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightPaddle2
+
+  - name: Evil secondary start to QAM2
+    source_events:
+      - evdev:
+            event_type: KEY
+            event_code: BTN7
+            value_type: button
+    target_event:
+      gamepad:
+        button: QuickAccess2
+
+  - name: AYANEO to QAM
+    source_events:
+      - evdev:
+            event_type: KEY
+            event_code: BTN5
+            value_type: button
+    target_event:
+      gamepad:
+        button: QuickAccess
+
+  - name: Slanted lines to Start
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN6
+          value_type: button
+    target_event:
+      gamepad:
+        button: Start
+
+  - name: Right Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_GAS
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: RightTrigger
+
+  - name: Left Trigger
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_BRAKE
+          value_type: trigger
+    target_event:
+      gamepad:
+        trigger:
+          name: LeftTrigger
+
+  - name: Right Stick
+    source_events:
+      - evdev:
+          event_type: ABS
+          event_code: ABS_Z
+          value_type: joystick_x
+      - evdev:
+          event_type: ABS
+          event_code: ABS_RZ
+          value_type: joystick_y
+    target_event:
+      gamepad:
+        axis:
+          name: RightStick

--- a/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type11.yaml
+++ b/rootfs/usr/share/inputplumber/capability_maps/ayaneo_type11.yaml
@@ -1,0 +1,25 @@
+version: 2
+kind: CapabilityMap
+name: AYANEO Type 11
+id: aya11
+
+mapping:
+  - name: Start Button to Guide
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_START
+          value_type: button
+    target_event:
+      gamepad:
+        button: Guide
+
+  - name: 3 dots to RightPaddle2
+    source_events:
+      - evdev:
+          event_type: KEY
+          event_code: BTN_MODE
+          value_type: button
+    target_event:
+      gamepad:
+        button: RightPaddle2

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_pocket_ds.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_pocket_ds.yaml
@@ -1,0 +1,49 @@
+version: 1
+kind: CompositeDevice
+name: AYANEO Pocket DS
+
+options:
+    auto_manage: true
+
+matches:
+    - udev:
+          sys_path: /sys/firmware/devicetree/base
+          attributes:
+              - name: compatible
+                value: ayaneo,pocketds
+
+source_devices:
+    # Ayaneo mode
+    - group: gamepad
+      capability_map_id: aya10
+      evdev:
+          name: AYANEO Controller
+          vendor_id: 4001
+          product_id: 0428
+          handler: event*
+    # Rumble
+    - group: gamepad
+      hidraw:
+          vendor_id: 0x4001
+          product_id: 0x0428
+          interface_num: 0
+    # Xinput mode
+    - group: gamepad
+      capability_map_id: aya11
+      evdev:
+          vendor_id: 045e
+          product_id: 028e
+          handler: event*
+    # Extra keys
+    - group: keyboard
+      capability_map_id: aya10
+      evdev:
+          name: AYANEO DEVICE
+          vendor_id: 1c4f
+          product_id: 0002
+          handler: event*
+
+target_devices:
+    - xbox-elite
+    - keyboard
+    - mouse


### PR DESCRIPTION
Based on #627 and #670 

Adds the AYANEO Pocket DS as a supported device, tested all buttons on the device in both Xbox and AYANEO/dinput mode. Needs 2 capability maps due to the remapping of guide/start so that we could use the rocker for extra paddle keys, also avoids dead keys on the controller.