### PR TITLE
Fix AYANEO NEXT 2 input device grouping and gyro

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_next2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_next2.yaml
@@ -26,6 +26,19 @@ source_devices:
       name: AYANEO COMPOSITE DEVICE
       phys_path: usb-0000:c6:00.0-1/input1
       handler: event*
+      events:
+        exclude:
+          - "*"
+        include:
+          - Keyboard:KeyF16
+          - Keyboard:KeyF17
+          - Keyboard:KeyF18
+          - Keyboard:KeyF19
+          - Keyboard:KeyF20
+          - Keyboard:KeyF21
+          - Keyboard:KeyF22
+          - Keyboard:KeyF23
+          - Keyboard:KeyLeftMeta
 
   # IMU
   - group: imu
@@ -46,7 +59,7 @@ options:
   auto_manage: true
 
 target_devices:
-  - ds5-edge
+  - xbox-elite
   - mouse
   - keyboard
 

--- a/rootfs/usr/share/inputplumber/devices/50-ayaneo_next2.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayaneo_next2.yaml
@@ -11,42 +11,29 @@ matches:
       sys_vendor: AYA
 
 source_devices:
-  # Xinput mode
+  # XInput mode
   - group: gamepad
+    unique: false
     evdev:
       name: Microsoft X-Box 360 pad
       phys_path: usb-0000:c6:00.0-4/input0
       handler: event*
-  # Dinput mode
-  - group: gamepad
-    evdev:
-      name: Microsoft X-Box 360 pad
-      phys_path: usb-0000:c6:00.0-4/input0
-      handler: event*
-    capability_map_id: dinput_generic
-  - group: gamepad
+
+  # AYANEO special/back buttons
+  - group: keyboard
+    unique: false
     evdev:
       name: AYANEO COMPOSITE DEVICE
+      phys_path: usb-0000:c6:00.0-1/input1
       handler: event*
-    events:
-      exclude:
-        - "*"
-      include:
-        - Keyboard:KeyF16
-        - Keyboard:KeyF17
-        - Keyboard:KeyF18
-        - Keyboard:KeyF19
-        - Keyboard:KeyF20
-        - Keyboard:KeyF21
-        - Keyboard:KeyF22
-        - Keyboard:KeyF23
-        - Keyboard:KeyLeftMeta
+
+  # IMU
   - group: imu
     iio:
       name: bmi323-imu
       mount_matrix:
-        x: [-1, 0, 0]
-        y: [0, -1, 0]
+        x: [0, 1, 0]
+        y: [-1, 0, 0]
         z: [0, 0, 1]
 
   # RGB
@@ -59,7 +46,7 @@ options:
   auto_manage: true
 
 target_devices:
-  - xbox-elite
+  - ds5-edge
   - mouse
   - keyboard
 


### PR DESCRIPTION
Tested on the AYANEO NEXT 2 (AB09).

Changes:
- Fix duplicate composite devices by using `unique: false`.
- Match the AYANEO keyboard/special-button interface specifically via `input1`, leaving the native mouse interface untouched.
- Keep DInput/AYANEO desktop mode unmanaged so the firmware's native mouse/keyboard behavior continues to work.
- Fix the BMI323 mount matrix orientation.
- Use the DualSense Edge target so the BMI323 gyro is exposed correctly to Steam.

Tested in XInput mode:
- One composite device
- Gamepad controls working
- Back/special buttons working
- Native mouse/touchpad working
- Gyro working in InputPlumber and Steam

The RGB section from the existing profile was retained but has not yet been tested.