### PR TITLE
Correct thor ayn button phys path

### DIFF
--- a/rootfs/usr/share/inputplumber/devices/50-ayn_thor.yaml
+++ b/rootfs/usr/share/inputplumber/devices/50-ayn_thor.yaml
@@ -27,7 +27,7 @@ source_devices:
     capability_map_id: ayn2
     evdev:
       name: gpio-keys-ayn
-      phys_path: gpio-keys-ayn/input0
+      phys_path: gpio-keys/input0
       handler: event*
 
 target_devices:


### PR DESCRIPTION
The `phys_path` for the AYN thor is incorrectly defined using it's `name` instead of the `phys_path`. This PR adds a quick correction.

Tested on Thor and validated fixes the Ayn button