### PR TITLE
fix(Hardware Support): Tune HIDRAW source driver poll rates

### DIFF
--- a/src/drivers/horipad_steam/driver.rs
+++ b/src/drivers/horipad_steam/driver.rs
@@ -11,24 +11,8 @@ use super::{
         JoystickInput, TriggerEvent, TriggerInput,
     },
     hid_report::PackedInputDataReport,
+    HID_TIMEOUT, PACKET_SIZE, PIDS, REPORT_ID, VID,
 };
-
-// Report ID
-pub const REPORT_ID: u8 = 0x07;
-
-// Input report size
-const PACKET_SIZE: usize = 287;
-
-// HID buffer read timeout
-const HID_TIMEOUT: i32 = 10;
-
-// Input report axis ranges
-pub const JOY_AXIS_MAX: f64 = 255.0;
-pub const JOY_AXIS_MIN: f64 = 0.0;
-pub const TRIGGER_AXIS_MAX: f64 = 255.0;
-
-pub const VID: u16 = 0x0F0D;
-pub const PIDS: [u16; 2] = [0x0196, 0x01AB];
 
 #[derive(Debug, Clone, Default)]
 struct DPadState {

--- a/src/drivers/horipad_steam/hid_report.rs
+++ b/src/drivers/horipad_steam/hid_report.rs
@@ -1,6 +1,6 @@
 use packed_struct::prelude::*;
 
-use super::driver::REPORT_ID;
+use super::REPORT_ID;
 
 #[derive(PrimitiveEnum_u8, Clone, Copy, PartialEq, Debug, Default)]
 pub enum Direction {

--- a/src/drivers/horipad_steam/mod.rs
+++ b/src/drivers/horipad_steam/mod.rs
@@ -4,3 +4,20 @@ pub mod hid_report;
 #[cfg(test)]
 pub mod hid_report_test;
 pub mod report_descriptor;
+
+// Report ID
+pub const REPORT_ID: u8 = 0x07;
+
+// Input report size
+pub const PACKET_SIZE: usize = 287;
+
+// HID buffer read timeout
+pub const HID_TIMEOUT: i32 = 4;
+
+// Input report axis ranges
+pub const JOY_AXIS_MAX: f64 = 255.0;
+pub const JOY_AXIS_MIN: f64 = 0.0;
+pub const TRIGGER_AXIS_MAX: f64 = 255.0;
+
+pub const VID: u16 = 0x0F0D;
+pub const PIDS: [u16; 2] = [0x0196, 0x01AB];

--- a/src/drivers/lego/go1_driver.rs
+++ b/src/drivers/lego/go1_driver.rs
@@ -13,7 +13,7 @@ use super::{
         TriggerEvent, TriggerInput,
     },
     hid_report::{GamepadMode, XInputDataReport},
-    GO1_PIDS, GP_IID, GP_TIMEOUT, VID, XINPUT_COMMAND_ID, XINPUT_DATA, XINPUT_PACKET_SIZE,
+    GAMEPAD_TIMEOUT, GO1_PIDS, GP_IID, VID, XINPUT_COMMAND_ID, XINPUT_DATA, XINPUT_PACKET_SIZE,
 };
 
 pub struct Driver {
@@ -59,7 +59,9 @@ impl Driver {
     pub fn poll(&mut self) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
         // Read data from the device into a buffer
         let mut buf = [0; XINPUT_PACKET_SIZE];
-        let bytes_read = self.hid_device.read_timeout(&mut buf[..], GP_TIMEOUT)?;
+        let bytes_read = self
+            .hid_device
+            .read_timeout(&mut buf[..], GAMEPAD_TIMEOUT)?;
 
         if bytes_read > XINPUT_PACKET_SIZE {
             return Err("Invalid packet size for X-Input Data.".into());

--- a/src/drivers/lego/go2_driver.rs
+++ b/src/drivers/lego/go2_driver.rs
@@ -14,7 +14,7 @@ use super::{
         MouseWheelInput, TriggerEvent, TriggerInput,
     },
     hid_report::{GamepadMode, XInputDataReport},
-    DEFAULT_EVENT_FILTER, GO2_PIDS, GP_IID, GP_TIMEOUT, VID, XINPUT_COMMAND_ID, XINPUT_DATA,
+    DEFAULT_EVENT_FILTER, GAMEPAD_TIMEOUT, GO2_PIDS, GP_IID, VID, XINPUT_COMMAND_ID, XINPUT_DATA,
     XINPUT_PACKET_SIZE,
 };
 
@@ -88,7 +88,9 @@ impl Driver {
     pub fn poll(&mut self) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
         // Read data from the device into a buffer
         let mut buf = [0; XINPUT_PACKET_SIZE];
-        let bytes_read = self.hid_device.read_timeout(&mut buf[..], GP_TIMEOUT)?;
+        let bytes_read = self
+            .hid_device
+            .read_timeout(&mut buf[..], GAMEPAD_TIMEOUT)?;
 
         if bytes_read > XINPUT_PACKET_SIZE {
             return Err("Invalid packet size for X-Input Data.".into());

--- a/src/drivers/lego/go_touchpad_driver.rs
+++ b/src/drivers/lego/go_touchpad_driver.rs
@@ -14,7 +14,7 @@ use super::{
     hid_report::TouchpadDataReport,
     DRAG_TIMEOUT_DINPUT, DRAG_TIMEOUT_XINPUT, GO_TOUCHPAD_D_PIDS, GO_TOUCHPAD_X_PIDS,
     PAD_FORCE_NORMAL, RELEASE_TIMEOUT_DINPUT, RELEASE_TIMEOUT_XINPUT, TAP_MAX_DISTANCE_SQ,
-    TOUCHPAD_DATA, TOUCHPAD_PACKET_SIZE, TP_IID, TP_TIMEOUT, VID,
+    TOUCHPAD_DATA, TOUCHPAD_PACKET_SIZE, TOUCHPAD_TIMEOUT, TP_IID, VID,
 };
 
 pub struct Driver {
@@ -83,7 +83,7 @@ impl Driver {
 
     pub fn poll(&mut self) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
         let mut buf = [0; TOUCHPAD_PACKET_SIZE];
-        let bytes_read = self.device.read_timeout(&mut buf[..], TP_TIMEOUT)?;
+        let bytes_read = self.device.read_timeout(&mut buf[..], TOUCHPAD_TIMEOUT)?;
 
         if bytes_read == 0 {
             // In XInput mode data only flows when the touchpad is touched.

--- a/src/drivers/lego/mod.rs
+++ b/src/drivers/lego/mod.rs
@@ -61,8 +61,8 @@ pub const XINPUT_DATA: u8 = 0x04;
 const TOUCHPAD_PACKET_SIZE: usize = 20;
 const XINPUT_PACKET_SIZE: usize = 60;
 
-const GP_TIMEOUT: i32 = 10;
-const TP_TIMEOUT: i32 = 5;
+const GAMEPAD_TIMEOUT: i32 = 8;
+const TOUCHPAD_TIMEOUT: i32 = 4;
 
 // HID Command ID's
 const XINPUT_COMMAND_ID: u8 = 0x74;

--- a/src/drivers/legos/imu_driver.rs
+++ b/src/drivers/legos/imu_driver.rs
@@ -6,7 +6,7 @@ use packed_struct::{types::SizedInteger, PackedStruct};
 use super::{
     event::{Event, InertialEvent, InertialInput},
     hid_report::{InertialDataReport, InputReportType},
-    GYRO_SCALE, HID_TIMEOUT, IMU_IID, INERTIAL_PACKET_SIZE, PIDS, VID,
+    GYRO_SCALE, IMU_IID, IMU_TIMEOUT, INERTIAL_PACKET_SIZE, PIDS, VID,
 };
 
 pub struct IMUDriver {
@@ -43,7 +43,7 @@ impl IMUDriver {
     pub fn poll(&mut self) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
         // Read data from the device into a buffer
         let mut buf = [0; INERTIAL_PACKET_SIZE];
-        let bytes_read = self.device.read_timeout(&mut buf[..], HID_TIMEOUT)?;
+        let bytes_read = self.device.read_timeout(&mut buf[..], IMU_TIMEOUT)?;
 
         if bytes_read != INERTIAL_PACKET_SIZE {
             return Ok(vec![]);

--- a/src/drivers/legos/mod.rs
+++ b/src/drivers/legos/mod.rs
@@ -34,4 +34,6 @@ pub const TRIGG_MAX: f64 = 255.0;
 const TOUCH_REPORT_ID: u8 = 0x31;
 
 // Timeouts
-const HID_TIMEOUT: i32 = 10;
+const IMU_TIMEOUT: i32 = 5;
+const GAMEPAD_TIMEOUT: i32 = 8;
+const TOUCHPAD_TIMEOUT: i32 = 16;

--- a/src/drivers/legos/touchpad_driver.rs
+++ b/src/drivers/legos/touchpad_driver.rs
@@ -8,7 +8,7 @@ use super::{
         AxisEvent, BinaryInput, ButtonEvent, Event, TouchAxisInput, TriggerEvent, TriggerInput,
     },
     hid_report::TouchpadDataReport,
-    HID_TIMEOUT, PAD_FORCE_NORMAL, PIDS, TOUCH_PACKET_SIZE, TOUCH_REPORT_ID, TP_IID, VID,
+    PAD_FORCE_NORMAL, PIDS, TOUCHPAD_TIMEOUT, TOUCH_PACKET_SIZE, TOUCH_REPORT_ID, TP_IID, VID,
 };
 
 pub struct TouchpadDriver {
@@ -43,7 +43,7 @@ impl TouchpadDriver {
         // Read data from the device into a buffer
         let mut events = vec![];
         let mut buf = [0; TOUCH_PACKET_SIZE];
-        let bytes_read = self.device.read_timeout(&mut buf[..], HID_TIMEOUT)?;
+        let bytes_read = self.device.read_timeout(&mut buf[..], TOUCHPAD_TIMEOUT)?;
         let report_id = buf[0];
 
         if bytes_read == TOUCH_PACKET_SIZE && report_id == TOUCH_REPORT_ID {

--- a/src/drivers/legos/xinput_driver.rs
+++ b/src/drivers/legos/xinput_driver.rs
@@ -6,7 +6,7 @@ use packed_struct::PackedStruct;
 use super::{
     event::{AxisEvent, BinaryInput, ButtonEvent, Event, JoyAxisInput, TriggerEvent, TriggerInput},
     hid_report::{RumbleOutputDataReport, XInputDataReport},
-    GP_IID, HID_TIMEOUT, PIDS, VID, XINPUT_PACKET_SIZE,
+    GAMEPAD_TIMEOUT, GP_IID, PIDS, VID, XINPUT_PACKET_SIZE,
 };
 
 pub struct XInputDriver {
@@ -40,7 +40,7 @@ impl XInputDriver {
     pub fn poll(&mut self) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
         // Read data from the device into a buffer
         let mut buf = [0; XINPUT_PACKET_SIZE];
-        let bytes_read = self.device.read_timeout(&mut buf[..], HID_TIMEOUT)?;
+        let bytes_read = self.device.read_timeout(&mut buf[..], GAMEPAD_TIMEOUT)?;
 
         if bytes_read != XINPUT_PACKET_SIZE {
             return Ok(vec![]);

--- a/src/drivers/msi_claw/driver.rs
+++ b/src/drivers/msi_claw/driver.rs
@@ -6,7 +6,7 @@ use packed_struct::PackedStruct;
 use super::{
     event::{AxisEvent, BinaryInput, ButtonEvent, Event, JoyAxisInput, TriggerEvent, TriggerInput},
     hid_report::{InputDataReport, RumbleOutputDataReport},
-    HID_TIMEOUT, INPUT_PACKET_SIZE, PID, VID,
+    GAMEPAD_TIMEOUT, INPUT_PACKET_SIZE, PID, VID,
 };
 
 pub struct Driver {
@@ -37,7 +37,7 @@ impl Driver {
     pub fn poll(&mut self) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
         // Read data from the device into a buffer
         let mut buf = [0; INPUT_PACKET_SIZE];
-        let bytes_read = self.device.read_timeout(&mut buf[..], HID_TIMEOUT)?;
+        let bytes_read = self.device.read_timeout(&mut buf[..], GAMEPAD_TIMEOUT)?;
 
         if bytes_read != INPUT_PACKET_SIZE {
             return Ok(vec![]);

--- a/src/drivers/msi_claw/mod.rs
+++ b/src/drivers/msi_claw/mod.rs
@@ -13,4 +13,4 @@ const INPUT_PACKET_SIZE: usize = 64;
 pub const AXIS_MAX: f64 = 255.0;
 
 // Timeouts
-const HID_TIMEOUT: i32 = 10;
+const GAMEPAD_TIMEOUT: i32 = 8;

--- a/src/drivers/opineo/driver.rs
+++ b/src/drivers/opineo/driver.rs
@@ -15,30 +15,8 @@ use crate::{
 use super::{
     event::{BinaryInput, Event, TouchAxisEvent, TouchButtonEvent},
     hid_report::TouchpadDataReport,
+    CLICK_DELAY, PAD_FORCE_NORMAL, PID, TOUCHPAD_PACKET_SIZE, TOUCHPAD_TIMEOUT, TOUCH_DATA, VID,
 };
-
-// Hardware ID's
-pub const VID: u16 = 0x0911;
-pub const PID: u16 = 0x5288;
-pub const LPAD_NAMES: [&str; 2] = ["OPI0001:00", "SYNA3602:00"];
-pub const RPAD_NAMES: [&str; 2] = ["OPI0002:00", "SYNA3602:01"];
-
-// Report ID
-pub const TOUCH_DATA: u8 = 0x04;
-
-// Input report size
-const TOUCHPAD_PACKET_SIZE: usize = 10;
-
-// HID buffer read timeout
-const HID_TIMEOUT: i32 = 10;
-
-// Input report axis ranges
-pub const PAD_X_MAX: f64 = 512.0;
-pub const PAD_Y_MAX: f64 = 512.0;
-pub const PAD_FORCE_MAX: f64 = 127.0;
-pub const PAD_FORCE_NORMAL: u8 = 32; /* Simulated average */
-
-const CLICK_DELAY: Duration = Duration::from_millis(75);
 
 pub struct Driver {
     /// HIDRAW device instance
@@ -83,7 +61,7 @@ impl Driver {
     pub fn poll(&mut self) -> Result<Vec<Event>, Box<dyn Error + Send + Sync>> {
         // Read data from the device into a buffer
         let mut buf = [0; TOUCHPAD_PACKET_SIZE];
-        let bytes_read = self.device.read_timeout(&mut buf[..], HID_TIMEOUT)?;
+        let bytes_read = self.device.read_timeout(&mut buf[..], TOUCHPAD_TIMEOUT)?;
 
         let report_id = buf[0];
         let slice = &buf[..bytes_read];

--- a/src/drivers/opineo/mod.rs
+++ b/src/drivers/opineo/mod.rs
@@ -1,5 +1,30 @@
+use std::time::Duration;
+
 pub mod driver;
 pub mod event;
 pub mod hid_report;
 #[cfg(test)]
 pub mod hid_report_test;
+
+// Hardware IDs
+pub const VID: u16 = 0x0911;
+pub const PID: u16 = 0x5288;
+pub const LPAD_NAMES: [&str; 2] = ["OPI0001:00", "SYNA3602:00"];
+pub const RPAD_NAMES: [&str; 2] = ["OPI0002:00", "SYNA3602:01"];
+
+// Report ID
+pub const TOUCH_DATA: u8 = 0x04;
+
+// Input report size
+const TOUCHPAD_PACKET_SIZE: usize = 10;
+
+// HID buffer read timeout
+const TOUCHPAD_TIMEOUT: i32 = 8;
+
+// Input report axis ranges
+pub const PAD_X_MAX: f64 = 512.0;
+pub const PAD_Y_MAX: f64 = 512.0;
+pub const PAD_FORCE_MAX: f64 = 127.0;
+pub const PAD_FORCE_NORMAL: u8 = 32; /* Simulated average */
+
+const CLICK_DELAY: Duration = Duration::from_millis(75);

--- a/src/input/source/hidraw.rs
+++ b/src/input/source/hidraw.rs
@@ -13,7 +13,7 @@ pub mod legos_imu;
 pub mod legos_touchpad;
 pub mod legos_xinput;
 pub mod msi_claw;
-pub mod opineo;
+pub mod opineo_touchpad;
 pub mod oxp_hid;
 pub mod rog_ally;
 pub mod steam_deck;
@@ -42,8 +42,8 @@ use self::{
     legion_go::LegionGoController, legion_go2::LegionGo2Controller, legion_go_tp::LegionGoTouchpad,
     legos_imu::LegionSImuController, legos_touchpad::LegionSTouchpadController,
     legos_xinput::LegionSXInputController, msi_claw::MsiClawController,
-    opineo::OrangePiNeoTouchpad, oxp_hid::OxpHid, rog_ally::RogAlly, steam_deck::DeckController,
-    ultimate_2::Ultimate2, xpad_uhid::XpadUhid, zotac_zone::ZotacZone,
+    opineo_touchpad::OrangePiNeoTouchpad, oxp_hid::OxpHid, rog_ally::RogAlly,
+    steam_deck::DeckController, ultimate_2::Ultimate2, xpad_uhid::XpadUhid, zotac_zone::ZotacZone,
 };
 use super::{InputError, OutputError, SourceDeviceCompatible, SourceDriver, SourceDriverOptions};
 
@@ -63,7 +63,7 @@ enum DriverType {
     LegionGoSXInput,
     LegionGoTouchpad,
     MsiClaw,
-    OrangePiNeo,
+    OrangePiNeoTouchpad,
     OxpHid,
     RogAlly,
     SteamDeck,
@@ -381,20 +381,38 @@ impl HidRawDevice {
                 Ok(Self::SteamDeck(source_device))
             }
             DriverType::LegionGo => {
+                let options = SourceDriverOptions {
+                    poll_rate: Duration::from_millis(8),
+                    buffer_size: 2048,
+                };
                 let device = LegionGoController::new(device_info.clone())?;
-                let source_device =
-                    SourceDriver::new(composite_device, device, device_info.into(), conf);
+                let source_device = SourceDriver::new_with_options(
+                    composite_device,
+                    device,
+                    device_info.into(),
+                    options,
+                    conf,
+                );
                 Ok(Self::LegionGo(source_device))
             }
             DriverType::LegionGo2 => {
+                let options = SourceDriverOptions {
+                    poll_rate: Duration::from_millis(8),
+                    buffer_size: 2048,
+                };
                 let device = LegionGo2Controller::new(device_info.clone())?;
-                let source_device =
-                    SourceDriver::new(composite_device, device, device_info.into(), conf);
+                let source_device = SourceDriver::new_with_options(
+                    composite_device,
+                    device,
+                    device_info.into(),
+                    options,
+                    conf,
+                );
                 Ok(Self::LegionGo2(source_device))
             }
             DriverType::LegionGoSImu => {
                 let options = SourceDriverOptions {
-                    poll_rate: Duration::from_millis(4),
+                    poll_rate: Duration::from_millis(5),
                     buffer_size: 2048,
                 };
                 let device = LegionSImuController::new(device_info.clone())?;
@@ -409,7 +427,7 @@ impl HidRawDevice {
             }
             DriverType::LegionGoSTouchpad => {
                 let options = SourceDriverOptions {
-                    poll_rate: Duration::from_millis(8),
+                    poll_rate: Duration::from_millis(16),
                     buffer_size: 2048,
                 };
                 let device = LegionSTouchpadController::new(device_info.clone())?;
@@ -424,7 +442,7 @@ impl HidRawDevice {
             }
             DriverType::LegionGoSXInput => {
                 let options = SourceDriverOptions {
-                    poll_rate: Duration::from_millis(4),
+                    poll_rate: Duration::from_millis(8),
                     buffer_size: 2048,
                 };
                 let device = LegionSXInputController::new(device_info.clone())?;
@@ -439,7 +457,7 @@ impl HidRawDevice {
             }
             DriverType::LegionGoTouchpad => {
                 let options = SourceDriverOptions {
-                    poll_rate: Duration::from_millis(2),
+                    poll_rate: Duration::from_millis(4),
                     buffer_size: 2048,
                 };
                 let device = LegionGoTouchpad::new(device_info.clone())?;
@@ -453,15 +471,33 @@ impl HidRawDevice {
                 Ok(Self::LegionGoTouchpad(source_device))
             }
             DriverType::MsiClaw => {
+                let options = SourceDriverOptions {
+                    poll_rate: Duration::from_millis(8),
+                    buffer_size: 2048,
+                };
                 let device = MsiClawController::new(device_info.clone())?;
-                let source_device =
-                    SourceDriver::new(composite_device, device, device_info.into(), conf);
+                let source_device = SourceDriver::new_with_options(
+                    composite_device,
+                    device,
+                    device_info.into(),
+                    options,
+                    conf,
+                );
                 Ok(Self::MsiClawController(source_device))
             }
-            DriverType::OrangePiNeo => {
+            DriverType::OrangePiNeoTouchpad => {
+                let options = SourceDriverOptions {
+                    poll_rate: Duration::from_millis(8),
+                    buffer_size: 2048,
+                };
                 let device = OrangePiNeoTouchpad::new(device_info.clone())?;
-                let source_device =
-                    SourceDriver::new(composite_device, device, device_info.into(), conf);
+                let source_device = SourceDriver::new_with_options(
+                    composite_device,
+                    device,
+                    device_info.into(),
+                    options,
+                    conf,
+                );
                 Ok(Self::OrangePiNeo(source_device))
             }
             DriverType::Fts3528Touchscreen => {
@@ -492,9 +528,18 @@ impl HidRawDevice {
                 Ok(Self::RogAlly(source_device))
             }
             DriverType::HoripadSteam => {
+                let options = SourceDriverOptions {
+                    poll_rate: Duration::from_millis(4),
+                    buffer_size: 2048,
+                };
                 let device = HoripadSteam::new(device_info.clone())?;
-                let source_device =
-                    SourceDriver::new(composite_device, device, device_info.into(), conf);
+                let source_device = SourceDriver::new_with_options(
+                    composite_device,
+                    device,
+                    device_info.into(),
+                    options,
+                    conf,
+                );
                 Ok(Self::HoripadSteam(source_device))
             }
             DriverType::Vader4Pro => {
@@ -647,11 +692,11 @@ impl HidRawDevice {
             return DriverType::MsiClaw;
         }
 
-        // OrangePi NEO
-        if vid == drivers::opineo::driver::VID && pid == drivers::opineo::driver::PID {
-            log::info!("Detected OrangePi NEO");
+        // OrangePi NEO Touchpad
+        if vid == drivers::opineo::VID && pid == drivers::opineo::PID {
+            log::info!("Detected OrangePi NEO Touchpad");
 
-            return DriverType::OrangePiNeo;
+            return DriverType::OrangePiNeoTouchpad;
         }
 
         // FTS3528 Touchscreen
@@ -677,9 +722,7 @@ impl HidRawDevice {
         }
 
         // Horipad Steam Controller
-        if vid == drivers::horipad_steam::driver::VID
-            && drivers::horipad_steam::driver::PIDS.contains(&pid)
-        {
+        if vid == drivers::horipad_steam::VID && drivers::horipad_steam::PIDS.contains(&pid) {
             log::info!("Detected Horipad Steam Controller");
             return DriverType::HoripadSteam;
         }

--- a/src/input/source/hidraw/horipad_steam.rs
+++ b/src/input/source/hidraw/horipad_steam.rs
@@ -1,16 +1,12 @@
 use std::{error::Error, fmt::Debug};
 
 use crate::{
-    drivers::horipad_steam::{
-        driver::{Driver, JOY_AXIS_MAX, JOY_AXIS_MIN, TRIGGER_AXIS_MAX},
-        event,
-    },
+    drivers::horipad_steam::{driver::Driver, event, JOY_AXIS_MAX, JOY_AXIS_MIN, TRIGGER_AXIS_MAX},
     input::{
         capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger},
         event::{
             native::NativeEvent,
-            value::InputValue,
-            value::{normalize_signed_value, normalize_unsigned_value},
+            value::{normalize_signed_value, normalize_unsigned_value, InputValue},
         },
         source::{InputError, SourceInputDevice, SourceOutputDevice},
     },

--- a/src/input/source/hidraw/opineo_touchpad.rs
+++ b/src/input/source/hidraw/opineo_touchpad.rs
@@ -2,12 +2,14 @@ use std::{error::Error, fmt::Debug};
 
 use crate::{
     drivers::opineo::{
-        driver::{self, Driver, LPAD_NAMES, PAD_FORCE_MAX, RPAD_NAMES},
-        event,
+        driver::Driver, event, LPAD_NAMES, PAD_FORCE_MAX, PAD_X_MAX, PAD_Y_MAX, RPAD_NAMES,
     },
     input::{
         capability::{Capability, Gamepad, GamepadTrigger, Touch, TouchButton, Touchpad},
-        event::{native::NativeEvent, value::normalize_unsigned_value, value::InputValue},
+        event::{
+            native::NativeEvent,
+            value::{normalize_unsigned_value, InputValue},
+        },
         output_capability::OutputCapability,
         source::{InputError, OutputError, SourceInputDevice, SourceOutputDevice},
     },
@@ -91,10 +93,10 @@ fn normalize_axis_value(event: event::TouchAxisEvent) -> InputValue {
     let x = event.x;
     let y = event.y;
     log::trace!("Got axis to normalize: {x}, {y}");
-    let max = driver::PAD_X_MAX;
+    let max = PAD_X_MAX;
     let x = normalize_unsigned_value(x as f64, max);
 
-    let max = driver::PAD_Y_MAX;
+    let max = PAD_Y_MAX;
     let y = normalize_unsigned_value(y as f64, max);
 
     // If this is an UP event, don't override the position of X/Y

--- a/src/input/source/mod.rs
+++ b/src/input/source/mod.rs
@@ -457,14 +457,13 @@ impl<T: SourceInputDevice + SourceOutputDevice + Send + 'static> SourceDriver<T>
                         break;
                     }
 
+                    let poll_time = poll_time_start.elapsed();
                     // Sleep up to the configured duration after polling timeout
-                    if let Some(remaining) = self
-                        .options
-                        .poll_rate
-                        .checked_sub(poll_time_start.elapsed())
-                    {
-                        log::trace!("Remaining sleep time: {remaining:?}");
+                    if let Some(remaining) = self.options.poll_rate.checked_sub(poll_time) {
+                        log::trace!("{:?}: Sleep time remaining: {remaining:?}", device_id);
                         thread::sleep(remaining);
+                    } else {
+                        log::trace!("{:?}: Total poll time: {poll_time:?} ", device_id);
                     }
                 }
 

--- a/src/input/target/horipad_steam.rs
+++ b/src/input/target/horipad_steam.rs
@@ -6,9 +6,9 @@ use uhid_virt::{Bus, CreateParams, StreamError, UHIDDevice};
 
 use crate::{
     drivers::horipad_steam::{
-        driver::{JOY_AXIS_MAX, JOY_AXIS_MIN, PIDS, TRIGGER_AXIS_MAX, VID},
         hid_report::{Direction, PackedInputDataReport},
         report_descriptor::REPORT_DESCRIPTOR,
+        JOY_AXIS_MAX, JOY_AXIS_MIN, PIDS, TRIGGER_AXIS_MAX, VID,
     },
     input::{
         capability::{Capability, Gamepad, GamepadAxis, GamepadButton, GamepadTrigger},


### PR DESCRIPTION
Previously the poll rates and read timeouts were less than ideal, leading to micro-stuttering in the reading of various devices. Using the new sleep time remaining and total poll time timeout trace debug I identified the ideal poll rate for each HIDRAW source device.

The correct poll rates were identified by setting the HID_TIMEOUT to 100ms, the poll rate to 1ms, and reading the total poll rate value. After setting the poll rate and HID_TIMEOUT to the average of the set value a single poll takes 50-500us and the device sleeps for the remainder of its natural interrupt heartbeat.